### PR TITLE
Repository review improvements: observability, perf, validation, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  build-and-test:
+    name: Build & Test (.NET)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Restore
+        run: dotnet restore api.sln
+
+      - name: Build
+        run: dotnet build api.sln --no-restore --configuration Release
+
+      - name: Test
+        run: >
+          dotnet test api.Tests/api.Tests.csproj
+          --no-build
+          --configuration Release
+          --logger trx
+          --results-directory TestResults
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults
+
+  build-frontend:
+    name: Build (Frontend)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: client
+        run: npm ci
+
+      - name: Build
+        working-directory: client
+        run: npm run build

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ playwright-report/
 # Environment
 .env.local
 .env.development.local
+
+# Git worktrees
+.worktrees/

--- a/YetAnotherFactoryPlanner.AppHost/AppHost.cs
+++ b/YetAnotherFactoryPlanner.AppHost/AppHost.cs
@@ -1,3 +1,6 @@
+using Azure.Provisioning.AppContainers;
+using Azure.Provisioning.CosmosDB;
+
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureContainerAppEnvironment("env");
@@ -19,6 +22,15 @@ var cosmosDb = builder.AddAzureCosmosDB("cosmos-db")
     });
 var db = cosmosDb.AddCosmosDatabase("shared-factory");
 var container = db.AddContainer("factories", "/gameVersion");
+cosmosDb.ConfigureInfrastructure(infra =>
+{
+    // Set 7-day TTL on the factories container so stale shared plans are auto-expired.
+    // cosmosDb is the account-level AzureProvisioningResource; its infra contains all child resources.
+    foreach (var sqlContainer in infra.GetProvisionableResources().OfType<CosmosDBSqlContainer>())
+    {
+        sqlContainer.Resource.DefaultTtl = 604800;
+    }
+});
 #pragma warning restore ASPIRECOSMOSDB001
 
 // Add ASP.NET Core Web API project
@@ -27,6 +39,12 @@ var api = builder.AddProject<Projects.api_web>("api")
     .WithExternalHttpEndpoints()
     .WithReference(cosmosDb)
     .WaitFor(cosmosDb);
+
+api.PublishAsAzureContainerApp((infra, containerApp) =>
+{
+    containerApp.Template.Scale.MinReplicas = 0; // scale to zero when idle
+    containerApp.Template.Scale.MaxReplicas = 3;
+});
 
 if (string.Equals(builder.Environment.EnvironmentName, "Development", StringComparison.OrdinalIgnoreCase)
     || string.Equals(builder.Environment.EnvironmentName, "Testing", StringComparison.OrdinalIgnoreCase))

--- a/YetAnotherFactoryPlanner.AppHost/YetAnotherFactoryPlanner.AppHost.csproj
+++ b/YetAnotherFactoryPlanner.AppHost/YetAnotherFactoryPlanner.AppHost.csproj
@@ -11,7 +11,6 @@
   <ItemGroup>
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" Version="13.2.4" />
     <PackageReference Include="Aspire.Hosting.Azure.CosmosDB" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.NodeJs" Version="9.5.2" />
     <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.2.4" />
   </ItemGroup>
 

--- a/YetAnotherFactoryPlanner.IntegrationTests/BrowserFixture.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/BrowserFixture.cs
@@ -21,6 +21,7 @@ public sealed class BrowserFixture : IAsyncLifetime
 		_browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
 		{
 			Headless = true,
+			Args = ["--no-sandbox", "--disable-dev-shm-usage"],
 		});
 	}
 

--- a/YetAnotherFactoryPlanner.IntegrationTests/ControlPanelPlaywrightTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/ControlPanelPlaywrightTests.cs
@@ -57,12 +57,10 @@ public sealed class ControlPanelPlaywrightTests(AppHostFixture appHost, BrowserF
 		var tooltip = page.GetByText("Link copied!", new PageGetByTextOptions { Exact = true });
 		await Expect(tooltip).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
 
-		// Act — wait 4 seconds (tooltip should have auto-dismissed after 2–3 s)
-		await Task.Delay(TimeSpan.FromSeconds(4));
-
 		// Assert
-		// BUG 4: tooltip never dismisses — this assertion will fail until auto-dismiss is implemented
-		await Expect(tooltip).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 1_000 });
+		// BUG 4: tooltip never dismisses — this assertion will fail until auto-dismiss is implemented.
+		// Allow up to 5 s for the tooltip to disappear (it should auto-dismiss after 2–3 s).
+		await Expect(tooltip).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 5_000 });
 	}
 
 	/// <summary>

--- a/YetAnotherFactoryPlanner.IntegrationTests/GraphPlaywrightTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/GraphPlaywrightTests.cs
@@ -77,8 +77,9 @@ public sealed class GraphPlaywrightTests(AppHostFixture appHost, BrowserFixture 
 		// Close the drawer; we're still on the Production Graph tab
 		await CloseDrawerAsync(page);
 
-		// Allow React to flush the recalculation and any resulting DOM mutations
-		await Task.Delay(500);
+		// Wait for React to flush the recalculation and any resulting DOM mutations.
+		// Poll until the canvas element reference stabilises (i.e. a canvas is present in the DOM).
+		await page.WaitForFunctionAsync("() => document.querySelector('canvas') !== null");
 
 		// Assert — the canvas element must be the same DOM node (no remount occurred)
 		var isSameCanvas = await page.EvaluateAsync<bool>(

--- a/YetAnotherFactoryPlanner.IntegrationTests/InitializeEndpointTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/InitializeEndpointTests.cs
@@ -1,19 +1,19 @@
 namespace YetAnotherFactoryPlanner.IntegrationTests;
 
 /// <summary>
-/// Integration tests covering Bug 1:
-///   API returns 400 Bad Request instead of 404 Not Found for a missing factory key.
+/// Integration tests covering Bug 1 (fixed):
+///   API was returning 400 Bad Request instead of 404 Not Found for a missing factory key.
 ///   The request is well-formed; the resource simply does not exist.
-///   These tests are written TDD-style: they fail against the current implementation and
-///   will pass once the bug is fixed.
+///   Bug is fixed in api.web — these tests now pass against the current implementation.
 /// </summary>
 [Collection(AppHostCollection.Name)]
 public sealed class InitializeEndpointTests(AppHostFixture fixture)
 {
 	/// <summary>
-	/// Bug 1 — reproducer.
+	/// Bug 1 (fixed) — verifier.
 	/// A factory key that matches the expected format (16 hex/alphanumeric chars) but has
 	/// never been saved should return 404 Not Found, not 400 Bad Request.
+	/// api.web now correctly returns 404 for this case.
 	/// </summary>
 	[Fact]
 	public async Task GetInitialize_WithValidFormatNonExistentFactoryKey_ReturnsNotFound()
@@ -28,8 +28,8 @@ public sealed class InitializeEndpointTests(AppHostFixture fixture)
 		var response = await client.GetAsync($"/initialize?factoryKey={nonExistentKey}");
 
 		// Assert
-		// BUG: currently returns 400 BadRequest with {"message":"Invalid factory id"}
-		// EXPECTED: 404 NotFound — the key is syntactically valid, the resource just doesn't exist
+		// FIXED: api.web now correctly returns 404 NotFound for a valid-format key that doesn't exist.
+		// Previously returned 400 BadRequest with {"message":"Invalid factory id"}.
 		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
 	}
 

--- a/YetAnotherFactoryPlanner.IntegrationTests/ShareFactoryEndpointTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/ShareFactoryEndpointTests.cs
@@ -4,12 +4,11 @@ using System.Text.Json;
 namespace YetAnotherFactoryPlanner.IntegrationTests;
 
 /// <summary>
-/// Integration tests covering Bug 6:
-///   "Save &amp; Share" creates a new CosmosDB entry on every click with no deduplication.
+/// Integration tests covering Bug 6 (fixed):
+///   "Save &amp; Share" was creating a new CosmosDB entry on every click with no deduplication.
 ///   A second POST with an identical factory configuration should return the same key as
 ///   the first, not a brand-new one.
-///   These tests are written TDD-style: they fail against the current implementation and
-///   will pass once the bug is fixed.
+///   Bug is fixed in api.web via content-hashed IDs (FindOrSaveAsync) — these tests now pass.
 /// </summary>
 [Collection(AppHostCollection.Name)]
 public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
@@ -20,8 +19,9 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 	};
 
 	/// <summary>
-	/// Bug 6 — reproducer.
+	/// Bug 6 (fixed) — verifier.
 	/// Posting the same factory configuration twice must return the same share key.
+	/// api.web uses content-hashed IDs via FindOrSaveAsync so duplicates are deduplicated.
 	/// </summary>
 	[Fact]
 	public async Task PostShareFactory_SameConfigPostedTwice_ReturnsSameKey()
@@ -42,7 +42,8 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 		var firstKey = await ExtractKeyAsync(firstResponse);
 		var secondKey = await ExtractKeyAsync(secondResponse);
 
-		// BUG: currently returns two different GUIDs; they should be identical
+		// FIXED: api.web returns the same content-hashed key for identical configurations.
+		// Previously returned two different GUIDs.
 		Assert.Equal(firstKey, secondKey);
 	}
 

--- a/YetAnotherFactoryPlanner.IntegrationTests/YetAnotherFactoryPlanner.IntegrationTests.csproj
+++ b/YetAnotherFactoryPlanner.IntegrationTests/YetAnotherFactoryPlanner.IntegrationTests.csproj
@@ -32,4 +32,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <Target Name="InstallPlaywright" AfterTargets="Build">
+    <Exec Command="pwsh $(OutputPath)playwright.ps1 install chromium" />
+  </Target>
+
 </Project>

--- a/YetAnotherFactoryPlanner.ServiceDefaults/Extensions.cs
+++ b/YetAnotherFactoryPlanner.ServiceDefaults/Extensions.cs
@@ -1,3 +1,4 @@
+using Azure.Monitor.OpenTelemetry.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
@@ -87,12 +88,11 @@ public static class Extensions
             builder.Services.AddOpenTelemetry().UseOtlpExporter();
         }
 
-        // Uncomment the following lines to enable the Azure Monitor exporter (requires the Azure.Monitor.OpenTelemetry.AspNetCore package)
-        //if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
-        //{
-        //    builder.Services.AddOpenTelemetry()
-        //       .UseAzureMonitor();
-        //}
+        if (!string.IsNullOrEmpty(builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]))
+        {
+            builder.Services.AddOpenTelemetry()
+               .UseAzureMonitor();
+        }
 
         return builder;
     }

--- a/YetAnotherFactoryPlanner.ServiceDefaults/Extensions.cs
+++ b/YetAnotherFactoryPlanner.ServiceDefaults/Extensions.cs
@@ -108,19 +108,15 @@ public static class Extensions
 
     public static WebApplication MapDefaultEndpoints(this WebApplication app)
     {
-        // Adding health checks endpoints to applications in non-development environments has security implications.
-        // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks(HealthEndpointPath);
+        // Health check endpoints are mapped in all environments to support ACA liveness and readiness probes.
+        // All health checks must pass for app to be considered ready to accept traffic after starting
+        app.MapHealthChecks(HealthEndpointPath);
 
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
-            {
-                Predicate = r => r.Tags.Contains("live")
-            });
-        }
+        // Only health checks tagged with the "live" tag must pass for app to be considered alive
+        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("live")
+        });
 
         return app;
     }

--- a/YetAnotherFactoryPlanner.ServiceDefaults/YetAnotherFactoryPlanner.ServiceDefaults.csproj
+++ b/YetAnotherFactoryPlanner.ServiceDefaults/YetAnotherFactoryPlanner.ServiceDefaults.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
 
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.1.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />

--- a/api.Tests/Validation/FactoryConfigSchemaValidatorTests.cs
+++ b/api.Tests/Validation/FactoryConfigSchemaValidatorTests.cs
@@ -5,164 +5,266 @@ using Xunit;
 
 namespace api.Tests.Validation;
 
-public class FactoryConfigSchemaValidatorTests {
-	private readonly FactoryConfigSchemaValidator _validator = new();
+public class FactoryConfigSchemaValidatorTests
+{
+    private readonly FactoryConfigSchemaValidator _validator = new();
 
-	private static FactoryConfigSchema CreateValidConfig() => new() {
-		GameVersion = "V1_1",
-		ProductionItems = new[] {
-			new ProductionItems("Desc_IronPlate_C", "per-minute", 10)
-		},
-		InputItems = Array.Empty<Input>(),
-		InputResources = new[] {
-			new Input("Desc_OreIron_C", 70380, 1, false)
-		},
-		AllowHandGatheredItems = false,
-		WeightingOptions = new WeightingOptions(1000, 1, 0, 0),
-		AllowedRecipes = new[] { "Recipe_IronIngot_C", "Recipe_IronPlate_C" },
-		NodesPositions = Array.Empty<NodePosition>(),
-	};
+    private static FactoryConfigSchema CreateValidConfig() => new()
+    {
+        GameVersion = "V1_1",
+        ProductionItems =
+        [
+            new ProductionItems("Desc_IronPlate_C", "per-minute", 10)
+        ],
+        InputItems = [],
+        InputResources =
+        [
+            new Input("Desc_OreIron_C", 70380, 1, false)
+        ],
+        AllowHandGatheredItems = false,
+        WeightingOptions = new WeightingOptions(1000, 1, 0, 0),
+        AllowedRecipes = ["Recipe_IronIngot_C", "Recipe_IronPlate_C"],
+        NodesPositions = [],
+    };
 
-	[Fact]
-	public void ValidConfig_ShouldPass() {
-		var config = CreateValidConfig();
-		var result = _validator.TestValidate(config);
-		result.ShouldNotHaveAnyValidationErrors();
-	}
+    [Fact]
+    public void ValidConfig_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
 
-	// GameVersion validation
-	[Theory]
-	[InlineData("V1_1")]
-	public void ValidGameVersions_ShouldPass(string version) {
-		var config = CreateValidConfig() with { GameVersion = version };
-		var result = _validator.TestValidate(config);
-		result.ShouldNotHaveValidationErrorFor(x => x.GameVersion);
-	}
+    // GameVersion validation
+    [Theory]
+    [InlineData("V1_1")]
+    [InlineData("1.1")]
+    public void ValidConfig_ValidGameVersions_ShouldPass(string version)
+    {
+        var config = CreateValidConfig();
+        config.GameVersion = version;
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor(x => x.GameVersion);
+    }
 
-	[Theory]
-	[InlineData("")]
-	[InlineData("U8")]
-	[InlineData("invalid")]
-	public void InvalidGameVersion_ShouldFail(string version) {
-		var config = CreateValidConfig() with { GameVersion = version };
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor(x => x.GameVersion);
-	}
+    [Theory]
+    [InlineData("")]
+    [InlineData("U8")]
+    [InlineData("invalid")]
+    public void ValidConfig_InvalidGameVersion_ShouldFail(string version)
+    {
+        var config = CreateValidConfig();
+        config.GameVersion = version;
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.GameVersion);
+    }
 
-	// ProductionItems validation
-	[Fact]
-	public void EmptyProductionItems_ShouldFail() {
-		var config = CreateValidConfig() with { ProductionItems = Array.Empty<ProductionItems>() };
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor(x => x.ProductionItems);
-	}
+    // ProductionItems validation
+    [Fact]
+    public void ValidConfig_EmptyProductionItems_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.ProductionItems = [];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.ProductionItems);
+    }
 
-	[Fact]
-	public void ProductionItem_EmptyItemKey_ShouldFail() {
-		var config = CreateValidConfig() with {
-			ProductionItems = new[] { new ProductionItems("", "per-minute", 10) }
-		};
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor("ProductionItems[0].ItemKey");
-	}
+    [Fact]
+    public void ValidConfig_ProductionItemsExceedingLimit_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.ProductionItems = Enumerable.Range(0, 501)
+            .Select(i => new ProductionItems($"Item_{i}", "per-minute", 1))
+            .ToList();
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.ProductionItems);
+    }
 
-	[Fact]
-	public void ProductionItem_EmptyMode_ShouldFail() {
-		var config = CreateValidConfig() with {
-			ProductionItems = new[] { new ProductionItems("Desc_IronPlate_C", "", 10) }
-		};
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor("ProductionItems[0].Mode");
-	}
+    [Fact]
+    public void ValidConfig_ProductionItem_EmptyItemKey_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.ProductionItems = [new ProductionItems("", "per-minute", 10)];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor("ProductionItems[0].ItemKey");
+    }
 
-	// InputResources validation
-	[Fact]
-	public void EmptyInputResources_ShouldFail() {
-		var config = CreateValidConfig() with { InputResources = Array.Empty<Input>() };
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor(x => x.InputResources);
-	}
+    [Fact]
+    public void ValidConfig_ProductionItem_EmptyMode_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.ProductionItems = [new ProductionItems("Desc_IronPlate_C", "", 10)];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor("ProductionItems[0].Mode");
+    }
 
-	[Fact]
-	public void InputResource_EmptyItemKey_ShouldFail() {
-		var config = CreateValidConfig() with {
-			InputResources = new[] { new Input("", 100, 1, false) }
-		};
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor("InputResources[0].ItemKey");
-	}
+    // ProductionItems.Mode validation
+    [Theory]
+    [InlineData("per-minute")]
+    [InlineData("maximize")]
+    [InlineData("rate")]
+    public void ValidConfig_ProductionItem_ValidMode_ShouldPass(string mode)
+    {
+        var config = CreateValidConfig();
+        config.ProductionItems = [new ProductionItems("Desc_IronPlate_C", mode, 10)];
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor("ProductionItems[0].Mode");
+    }
 
-	// InputItems validation
-	[Fact]
-	public void InputItem_EmptyItemKey_ShouldFail() {
-		var config = CreateValidConfig() with {
-			InputItems = new[] { new Input("", 100, 1, false) }
-		};
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor("InputItems[0].ItemKey");
-	}
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("per_minute")]
+    [InlineData("MAXIMIZE")]
+    [InlineData("Rate")]
+    public void ValidConfig_ProductionItem_InvalidMode_ShouldFail(string mode)
+    {
+        var config = CreateValidConfig();
+        config.ProductionItems = [new ProductionItems("Desc_IronPlate_C", mode, 10)];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor("ProductionItems[0].Mode");
+    }
 
-	[Fact]
-	public void ValidInputItems_ShouldPass() {
-		var config = CreateValidConfig() with {
-			InputItems = new[] { new Input("Desc_IronIngot_C", 50, 0, false) }
-		};
-		var result = _validator.TestValidate(config);
-		result.ShouldNotHaveValidationErrorFor(x => x.InputItems);
-	}
+    // InputResources validation
+    [Fact]
+    public void ValidConfig_EmptyInputResources_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.InputResources = [];
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor(x => x.InputResources);
+    }
 
-	// AllowedRecipes validation
-	[Fact]
-	public void EmptyAllowedRecipes_ShouldFail() {
-		var config = CreateValidConfig() with { AllowedRecipes = Array.Empty<string>() };
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor(x => x.AllowedRecipes);
-	}
+    [Fact]
+    public void ValidConfig_InputResourcesExceedingLimit_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.InputResources = Enumerable.Range(0, 501)
+            .Select(i => new Input($"Desc_Ore_{i}", 100, 1, false))
+            .ToList();
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.InputResources);
+    }
 
-	[Fact]
-	public void AllowedRecipes_WithEmptyString_ShouldFail() {
-		var config = CreateValidConfig() with { AllowedRecipes = new[] { "" } };
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor("AllowedRecipes[0]");
-	}
+    [Fact]
+    public void ValidConfig_InputResource_EmptyItemKey_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.InputResources = [new Input("", 100, 1, false)];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor("InputResources[0].ItemKey");
+    }
 
-	// NodesPositions validation
-	[Fact]
-	public void ValidNodesPositions_ShouldPass() {
-		var config = CreateValidConfig() with {
-			NodesPositions = new[] { new NodePosition("node1", 10.5m, 20.3m) }
-		};
-		var result = _validator.TestValidate(config);
-		result.ShouldNotHaveAnyValidationErrors();
-	}
+    // InputItems validation
+    [Fact]
+    public void ValidConfig_InputItem_EmptyItemKey_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.InputItems = [new Input("", 100, 1, false)];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor("InputItems[0].ItemKey");
+    }
 
-	[Fact]
-	public void NodePosition_EmptyKey_ShouldFail() {
-		var config = CreateValidConfig() with {
-			NodesPositions = new[] { new NodePosition("", 10.5m, 20.3m) }
-		};
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor("NodesPositions[0].Key");
-	}
+    [Fact]
+    public void ValidConfig_ValidInputItems_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.InputItems = [new Input("Desc_IronIngot_C", 50, 0, false)];
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor(x => x.InputItems);
+    }
 
-	// WeightingOptions validation
-	[Fact]
-	public void NullWeightingOptions_ShouldFail() {
-		var config = CreateValidConfig() with { WeightingOptions = null! };
-		var result = _validator.TestValidate(config);
-		result.ShouldHaveValidationErrorFor(x => x.WeightingOptions);
-	}
+    [Fact]
+    public void ValidConfig_InputItemsExceedingLimit_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.InputItems = Enumerable.Range(0, 501)
+            .Select(i => new Input($"Item_{i}", 50, 1, false))
+            .ToList();
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.InputItems);
+    }
 
-	// Multiple production items
-	[Fact]
-	public void MultipleValidProductionItems_ShouldPass() {
-		var config = CreateValidConfig() with {
-			ProductionItems = new[] {
-				new ProductionItems("Desc_IronPlate_C", "per-minute", 10),
-				new ProductionItems("Desc_IronIngot_C", "maximize", 5),
-			}
-		};
-		var result = _validator.TestValidate(config);
-		result.ShouldNotHaveAnyValidationErrors();
-	}
+    // AllowedRecipes validation
+    [Fact]
+    public void ValidConfig_EmptyAllowedRecipes_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.AllowedRecipes = [];
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor(x => x.AllowedRecipes);
+    }
+
+    [Fact]
+    public void ValidConfig_AllowedRecipesExceedingLimit_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.AllowedRecipes = Enumerable.Range(0, 501)
+            .Select(i => $"Recipe_{i}")
+            .ToList();
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.AllowedRecipes);
+    }
+
+    [Fact]
+    public void ValidConfig_AllowedRecipes_WithEmptyString_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.AllowedRecipes = [""];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor("AllowedRecipes[0]");
+    }
+
+    // NodesPositions validation
+    [Fact]
+    public void ValidConfig_ValidNodesPositions_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.NodesPositions = [new NodePosition("node1", 10.5m, 20.3m)];
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void ValidConfig_NodePosition_EmptyKey_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.NodesPositions = [new NodePosition("", 10.5m, 20.3m)];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor("NodesPositions[0].Key");
+    }
+
+    [Fact]
+    public void ValidConfig_NodesPositionsExceedingLimit_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.NodesPositions = Enumerable.Range(0, 1001)
+            .Select(i => new NodePosition($"node_{i}", i, i))
+            .ToList();
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.NodesPositions);
+    }
+
+    // WeightingOptions validation
+    [Fact]
+    public void ValidConfig_NullWeightingOptions_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.WeightingOptions = null!;
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.WeightingOptions);
+    }
+
+    // Multiple production items
+    [Fact]
+    public void ValidConfig_MultipleValidProductionItems_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.ProductionItems =
+        [
+            new ProductionItems("Desc_IronPlate_C", "per-minute", 10),
+            new ProductionItems("Desc_IronIngot_C", "maximize", 5),
+        ];
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
 }

--- a/api.Tests/api.Tests.csproj
+++ b/api.Tests/api.Tests.csproj
@@ -15,6 +15,6 @@
 		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\api\api.csproj" />
+		<ProjectReference Include="..\api.web\api.web.csproj" />
 	</ItemGroup>
 </Project>

--- a/api.sln
+++ b/api.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "api", "api\api.csproj", "{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ParseDocs", "ParseDocs\ParseDocs.csproj", "{EF4FD81B-BE21-431A-B6ED-B814BC3C815D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "api.Tests", "api.Tests\api.Tests.csproj", "{94327E0F-EAF0-4B29-B39E-252CAEE28C9A}"
@@ -29,18 +27,6 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Debug|x64.Build.0 = Debug|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Debug|x86.Build.0 = Debug|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Release|x64.ActiveCfg = Release|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Release|x64.Build.0 = Release|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Release|x86.ActiveCfg = Release|Any CPU
-		{E8BAD8F3-3DBA-4C2A-AF20-876A87A13C78}.Release|x86.Build.0 = Release|Any CPU
 		{EF4FD81B-BE21-431A-B6ED-B814BC3C815D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EF4FD81B-BE21-431A-B6ED-B814BC3C815D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF4FD81B-BE21-431A-B6ED-B814BC3C815D}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/api.web/Program.cs
+++ b/api.web/Program.cs
@@ -7,6 +7,8 @@ using api.web.Resources;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddServiceDefaults();
+
 // CORS: allow specific origins when configured, otherwise allow all.
 // In production, set "AllowedOrigins" in config/env to restrict to known client URLs.
 // Without that setting (dev / integration-test environments) wildcard is intentional.
@@ -30,6 +32,8 @@ builder.AddCosmosDbContext<FactoryDbContext>("cosmos-db", "shared-factory");
 builder.Services.AddScoped<FactoryClient>();
 
 var app = builder.Build();
+
+app.MapDefaultEndpoints();
 
 app.UseCors("CorsPolicy");
 

--- a/api.web/Program.cs
+++ b/api.web/Program.cs
@@ -112,7 +112,7 @@ app.MapPost("/share-factory", async (
     try
     {
         var config = request.FactoryConfig;
-        var validationResult = await validator.ValidateAsync(config);
+        var validationResult = await validator.ValidateAsync(config, cancellationToken);
 
         if (!validationResult.IsValid)
             return Results.BadRequest(new { message = string.Join(".", validationResult.Errors.Select(x => x.ErrorMessage)) });

--- a/api.web/Services/FactoryClient.cs
+++ b/api.web/Services/FactoryClient.cs
@@ -68,7 +68,7 @@ public sealed class FactoryClient(FactoryDbContext dbContext, ILogger<FactoryCli
         }
         catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
-            logger.LogWarning(ex, "Factory {FactoryKey} not found in Cosmos", factoryKey);
+            logger.LogWarning(ex, "Factory {FactoryKey} not found in Cosmos", factoryKey.ReplaceLineEndings(string.Empty));
             return new None();
         }
     }

--- a/api.web/Services/FactoryClient.cs
+++ b/api.web/Services/FactoryClient.cs
@@ -10,13 +10,13 @@ namespace api.web.Services;
 
 public sealed class FactoryClient(FactoryDbContext dbContext, ILogger<FactoryClient> logger)
 {
-    internal async Task SaveFactoryAsync(FactoryConfigSchema factoryConfig)
+    internal async Task SaveFactoryAsync(FactoryConfigSchema factoryConfig, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrEmpty(factoryConfig.Id))
             factoryConfig.Id = Guid.NewGuid().ToString("N");
 
         dbContext.Factories.Add(factoryConfig);
-        await dbContext.SaveChangesAsync();
+        await dbContext.SaveChangesAsync(cancellationToken);
     }
 
     /// <summary>

--- a/api.web/Services/FactoryClient.cs
+++ b/api.web/Services/FactoryClient.cs
@@ -1,8 +1,10 @@
+using System.Net;
 using api.Models;
+using api.web.Data;
+using Microsoft.Azure.Cosmos;
+using Microsoft.EntityFrameworkCore;
 using OneOf;
 using OneOf.Types;
-using api.web.Data;
-using Microsoft.EntityFrameworkCore;
 
 namespace api.web.Services;
 
@@ -34,8 +36,21 @@ public sealed class FactoryClient(FactoryDbContext dbContext, ILogger<FactoryCli
 
         config.GameVersion = normalizedVersion;
         dbContext.Factories.Add(config);
-        await dbContext.SaveChangesAsync(cancellationToken);
-        return config.Id!;
+
+        try
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+            return config.Id!;
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is CosmosException { StatusCode: HttpStatusCode.Conflict })
+        {
+            // Another concurrent request inserted the same entity; re-query and return its Id.
+            var conflict = await dbContext.Factories
+                .Where(f => f.Id == config.Id && f.GameVersion == normalizedVersion)
+                .FirstOrDefaultAsync(cancellationToken);
+
+            return conflict!.Id!;
+        }
     }
 
     internal async Task<GetFactoryResult> GetFactory(string factoryKey, string gameVersion,
@@ -51,9 +66,9 @@ public sealed class FactoryClient(FactoryDbContext dbContext, ILogger<FactoryCli
 
             return factory is not null ? (GetFactoryResult)factory : new None();
         }
-        catch (Exception ex)
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
-            logger.LogError(ex, "Failed to retrieve factory {FactoryKey}", factoryKey);
+            logger.LogWarning(ex, "Factory {FactoryKey} not found in Cosmos", factoryKey);
             return new None();
         }
     }

--- a/api.web/Validation/FactoryConfigSchemaValidator.cs
+++ b/api.web/Validation/FactoryConfigSchemaValidator.cs
@@ -12,18 +12,29 @@ public class FactoryConfigSchemaValidator : AbstractValidator<FactoryConfigSchem
         "1.1",
     ];
 
+    private static readonly HashSet<string> ValidModes = ["per-minute", "maximize", "rate"];
+
     public FactoryConfigSchemaValidator()
     {
         RuleFor(x => x.GameVersion).Must(v => ValidGameVersions.Contains(v))
             .WithMessage("'{PropertyValue}' is not a valid game version.");
-        RuleFor(x => x.ProductionItems).NotEmpty();
+        RuleFor(x => x.ProductionItems).NotEmpty()
+            .Must(x => x.Count <= 500).WithMessage("ProductionItems must not exceed 500 items.");
         RuleForEach(x => x.ProductionItems).SetValidator(new ProductionItemsValidator());
+        RuleFor(x => x.InputItems)
+            .Must(x => x.Count <= 500).WithMessage("InputItems must not exceed 500 items.");
         RuleForEach(x => x.InputItems).SetValidator(new InputValidator());
         // InputResources may be empty (no constraints means unlimited resources)
+        RuleFor(x => x.InputResources)
+            .Must(x => x.Count <= 500).WithMessage("InputResources must not exceed 500 items.");
         RuleForEach(x => x.InputResources).SetValidator(new InputValidator());
         RuleFor(x => x.WeightingOptions).NotNull().SetValidator(new WeightingOptionsValidator());
         // AllowedRecipes may be empty (means all recipes are allowed)
+        RuleFor(x => x.AllowedRecipes)
+            .Must(x => x.Count <= 500).WithMessage("AllowedRecipes must not exceed 500 items.");
         RuleForEach(x => x.AllowedRecipes).NotEmpty();
+        RuleFor(x => x.NodesPositions)
+            .Must(x => x.Count <= 1000).WithMessage("NodesPositions must not exceed 1000 items.");
         RuleForEach(x => x.NodesPositions).SetValidator(new NodePositionValidator());
     }
 
@@ -32,7 +43,9 @@ public class FactoryConfigSchemaValidator : AbstractValidator<FactoryConfigSchem
         public ProductionItemsValidator()
         {
             RuleFor(x => x.ItemKey).NotEmpty();
-            RuleFor(x => x.Mode).NotEmpty();
+            RuleFor(x => x.Mode).NotEmpty()
+                .Must(m => ValidModes.Contains(m))
+                .WithMessage($"Mode must be one of: {string.Join(", ", ValidModes)}.");
             RuleFor(x => x.Value).NotNull();
         }
     }

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -8,30 +8,12 @@ var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
     .ConfigureServices((context, services) => {
         var configuration = context.Configuration;
-        
-        // Print all environment variables for debugging
-        var envVars = Environment.GetEnvironmentVariables();
-        foreach (var key in envVars.Keys)
-        {
-            var keyStr = key as string;
-            if (keyStr is null)
-            {
-                continue;
-            }
 
-            if (keyStr.Contains("cosmos", StringComparison.OrdinalIgnoreCase) || 
-                keyStr.Contains("Aspire", StringComparison.OrdinalIgnoreCase))
-            {
-                Console.WriteLine($"{keyStr}={envVars[key]}");
-            }
-        }
-        
-        // Get the Cosmos connection string from Aspire - try all possible keys
-        var connectionString = 
+        var connectionString =
             configuration["Aspire__Microsoft__Azure__Cosmos__cosmos-db__ConnectionString"]
             ?? configuration["Aspire:Microsoft:Azure:Cosmos:cosmos-db:ConnectionString"]
             ?? configuration["ConnectionStrings:cosmos-db"];
-            
+
         if (string.IsNullOrEmpty(connectionString))
         {
             throw new InvalidOperationException(
@@ -40,10 +22,8 @@ var host = new HostBuilder()
                 "Aspire:Microsoft:Azure:Cosmos:cosmos-db:ConnectionString, " +
                 "ConnectionStrings:cosmos-db");
         }
-        
-        Console.WriteLine($"Using connection string: {connectionString}");
-        
-        // Test that we can create a CosmosClient
+
+        // Create a CosmosClient
         var cosmosClient = new CosmosClient(connectionString, new CosmosClientOptions
         {
             ConnectionMode = ConnectionMode.Gateway,

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,12 +1,16 @@
+# NOTE: This Dockerfile is preserved for reference only.
+# It is NOT the active deployment path. The canonical dev and deployment path is
+# the .NET Aspire AppHost (YetAnotherFactoryPlanner.AppHost).
+
 FROM node:20-alpine3.17 as build
 WORKDIR /home/node/app
 COPY client/package.json client/package-lock.json ./
 RUN npm install --legacy-peer-deps
 RUN npx update-browserslist-db@latest
 COPY client/. .
-RUN echo 'REACT_APP_API_BASE_URL="http://localhost:8080/"' > .env
+RUN echo 'VITE_API_BASE_URL="http://localhost:8080/"' > .env
 RUN echo 'PUBLIC_URL="http://localhost"' >> .env
 RUN npm run build
 
-FROM nginx:latest as host
-COPY --from=build /home/node/app/build /usr/share/nginx/html
+FROM nginx:1.27-alpine as host
+COPY --from=build /home/node/app/dist /usr/share/nginx/html

--- a/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
@@ -2,12 +2,10 @@ import React, { useMemo, useRef, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { nanoid } from 'nanoid';
 import Cytoscape, { Stylesheet } from 'cytoscape';
-import klay from 'cytoscape-klay';
 import GraphVisualizer from 'react-cytoscapejs';
-import popper from 'cytoscape-popper';
-import { Text, Container, Center, Group, Loader, Button, ButtonProps } from '@mantine/core';
+import { Text, Container, Center, Group, Stack, Loader, Button, ButtonProps } from '@mantine/core';
 import { AlertCircle } from 'react-feather';
-import { GraphNode, GraphEdge, NODE_TYPE } from '../../../../utilities/production-solver';
+import { GraphNode, GraphEdge, NODE_TYPE } from '../../../../utilities/production-solver/models';
 import { graphColors } from '../../../../theme';
 import GraphTooltip from '../../../../components/GraphTooltip';
 import { truncateFloat } from '../../../../utilities/number';
@@ -15,8 +13,26 @@ import { useProductionContext } from '../../../../contexts/production';
 import { GameData } from '../../../../contexts/gameData/types';
 import { NodeInfo } from '../../../../contexts/production/types';
 
-Cytoscape.use(popper);
-Cytoscape.use(klay);
+let graphPluginsReadyPromise: Promise<void> | null = null;
+
+async function ensureGraphPluginsReady() {
+  if (!graphPluginsReadyPromise) {
+    graphPluginsReadyPromise = Promise.all([
+      import('cytoscape-klay'),
+      import('cytoscape-popper'),
+      import('@popperjs/core'),
+    ]).then(([klayModule, cytoscapePopperModule, popperModule]) => {
+      const klay = klayModule.default;
+      const cytoscapePopper = cytoscapePopperModule.default;
+      const createPopper = popperModule.createPopper;
+
+      Cytoscape.use(cytoscapePopper(createPopper));
+      Cytoscape.use(klay);
+    });
+  }
+
+  await graphPluginsReadyPromise;
+}
 
 if (process.env.NODE_ENV !== 'development') {
   Cytoscape.warnings(false);
@@ -237,7 +253,7 @@ const GraphButtonGroup = styled(Group)`
 `;
 
 //Extend the mantine/core button component to add a custom style
-const GraphButton = styled(Button)<ButtonProps<'button'>>`
+const GraphButton = styled(Button)<ButtonProps & React.ComponentPropsWithoutRef<'button'>>`
   opacity: 0.1;
   border: 1px solid rgba(255,255,255,0.1);
   border-radius: 5px;
@@ -317,8 +333,12 @@ export interface EdgeData extends GraphEdge {
 
 const ProductionGraphTab = () => {
   const [doFirstRender, setDoFirstRender] = useState(false);
+  const [pluginsReady, setPluginsReady] = useState(false);
   const graphRef = useRef<HTMLDivElement | null>(null);
   const cyRef = useRef<Cytoscape.Core | null>(null);
+  // Stable key so GraphVisualizer is never unmounted/remounted on recalculation.
+  // Using a ref ensures the value is created once per component mount.
+  const graphKey = useRef(nanoid()).current;
   const popupRef = useRef<HTMLDivElement | null>(null);
   const popperRef = useRef<PopperRef | null>(null);
   const [popupNode, setPopupNode] = useState<any | null>(null);
@@ -433,6 +453,10 @@ const ProductionGraphTab = () => {
       content: () => popupRef.current || undefined,
       popper: {
         placement: 'top',
+        strategy: 'fixed',
+        modifiers: [
+          { name: 'offset', options: { offset: [0, 45] } },
+        ],
       }
     });
     popperRef.current = { popper, nodeId: node.id() };
@@ -451,6 +475,27 @@ const ProductionGraphTab = () => {
     setPopupNode(null);
   }
 
+  // Re-position tooltip after React renders the content so Popper measures the correct width
+  useEffect(() => {
+    if (popupNode && popperRef.current) {
+      popperRef.current.popper.update();
+    }
+  }, [popupNode]);
+
+  useEffect(() => {
+    let active = true;
+
+    ensureGraphPluginsReady().then(() => {
+      if (active) {
+        setPluginsReady(true);
+      }
+    });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   useEffect(() => {
     function resizeListener() {
       _resizeListener(graphRef);
@@ -466,7 +511,6 @@ const ProductionGraphTab = () => {
       return null;
     }
 
-    const key = nanoid();
     const elements: any[] = [];
 
     Object.entries(resultsGraph.nodes).forEach(([key, node]) => {
@@ -492,7 +536,7 @@ const ProductionGraphTab = () => {
       });
     });
 
-    return { key, elements };
+    return { key: graphKey, elements };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resultsGraph]);
 
@@ -504,14 +548,14 @@ const ProductionGraphTab = () => {
           <GraphButton onClick={() => { resetNodePositions(); }}>Reset positions</GraphButton>
         </GraphButtonGroup>
         {
-          isLoading && (
+          (isLoading || !pluginsReady) && (
             <Center style={{ position: 'absolute', height: '100%', width: '100%' }}>
               <Loader size={50} />
             </Center>
           )
         }
         {
-          doFirstRender && !isLoading && (
+          doFirstRender && !isLoading && pluginsReady && (
             graphProps != null
               ? (
                 <GraphVisualizer
@@ -530,8 +574,8 @@ const ProductionGraphTab = () => {
               : (
                 <Center style={{ position: 'absolute', height: '100%', width: '100%' }}>
                   <Group>
-                    <AlertCircle color="#eee" size={85} style={{ position: 'relative', top: '3px' }} />
-                    <Group direction='column' style={{ gap: '0px' }}>
+                    <AlertCircle size={85} style={{ position: 'relative', top: '3px' }} />
+                    <Stack style={{ gap: '0px' }}>
                       <Text style={{ fontSize: '28px' }}>
                         Could not build graph
                       </Text>
@@ -543,7 +587,7 @@ const ProductionGraphTab = () => {
                           </Text>
                         )
                         : null}
-                    </Group>
+                    </Stack>
                   </Group>
                 </Center>
               )
@@ -561,7 +605,7 @@ const GraphContainer = styled(Container)`
   position: relative;
   min-height: 600px;
   min-width: 800px;
-  border: 1px solid #fff;
+  border: 1px solid var(--yafp-graph-border);
   border-top-width: 0px;
   margin: 0px;
   padding: 0px;

--- a/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
@@ -2,10 +2,12 @@ import React, { useMemo, useRef, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { nanoid } from 'nanoid';
 import Cytoscape, { Stylesheet } from 'cytoscape';
+import klay from 'cytoscape-klay';
 import GraphVisualizer from 'react-cytoscapejs';
-import { Text, Container, Center, Group, Stack, Loader, Button, ButtonProps } from '@mantine/core';
+import popper from 'cytoscape-popper';
+import { Text, Container, Center, Group, Loader, Button, ButtonProps } from '@mantine/core';
 import { AlertCircle } from 'react-feather';
-import { GraphNode, GraphEdge, NODE_TYPE } from '../../../../utilities/production-solver/models';
+import { GraphNode, GraphEdge, NODE_TYPE } from '../../../../utilities/production-solver';
 import { graphColors } from '../../../../theme';
 import GraphTooltip from '../../../../components/GraphTooltip';
 import { truncateFloat } from '../../../../utilities/number';
@@ -13,26 +15,8 @@ import { useProductionContext } from '../../../../contexts/production';
 import { GameData } from '../../../../contexts/gameData/types';
 import { NodeInfo } from '../../../../contexts/production/types';
 
-let graphPluginsReadyPromise: Promise<void> | null = null;
-
-async function ensureGraphPluginsReady() {
-  if (!graphPluginsReadyPromise) {
-    graphPluginsReadyPromise = Promise.all([
-      import('cytoscape-klay'),
-      import('cytoscape-popper'),
-      import('@popperjs/core'),
-    ]).then(([klayModule, cytoscapePopperModule, popperModule]) => {
-      const klay = klayModule.default;
-      const cytoscapePopper = cytoscapePopperModule.default;
-      const createPopper = popperModule.createPopper;
-
-      Cytoscape.use(cytoscapePopper(createPopper));
-      Cytoscape.use(klay);
-    });
-  }
-
-  await graphPluginsReadyPromise;
-}
+Cytoscape.use(popper);
+Cytoscape.use(klay);
 
 if (process.env.NODE_ENV !== 'development') {
   Cytoscape.warnings(false);
@@ -253,7 +237,7 @@ const GraphButtonGroup = styled(Group)`
 `;
 
 //Extend the mantine/core button component to add a custom style
-const GraphButton = styled(Button)<ButtonProps & React.ComponentPropsWithoutRef<'button'>>`
+const GraphButton = styled(Button)<ButtonProps<'button'>>`
   opacity: 0.1;
   border: 1px solid rgba(255,255,255,0.1);
   border-radius: 5px;
@@ -333,12 +317,8 @@ export interface EdgeData extends GraphEdge {
 
 const ProductionGraphTab = () => {
   const [doFirstRender, setDoFirstRender] = useState(false);
-  const [pluginsReady, setPluginsReady] = useState(false);
   const graphRef = useRef<HTMLDivElement | null>(null);
   const cyRef = useRef<Cytoscape.Core | null>(null);
-  // Stable key so GraphVisualizer is never unmounted/remounted on recalculation.
-  // Using a ref ensures the value is created once per component mount.
-  const graphKey = useRef(nanoid()).current;
   const popupRef = useRef<HTMLDivElement | null>(null);
   const popperRef = useRef<PopperRef | null>(null);
   const [popupNode, setPopupNode] = useState<any | null>(null);
@@ -453,10 +433,6 @@ const ProductionGraphTab = () => {
       content: () => popupRef.current || undefined,
       popper: {
         placement: 'top',
-        strategy: 'fixed',
-        modifiers: [
-          { name: 'offset', options: { offset: [0, 45] } },
-        ],
       }
     });
     popperRef.current = { popper, nodeId: node.id() };
@@ -475,27 +451,6 @@ const ProductionGraphTab = () => {
     setPopupNode(null);
   }
 
-  // Re-position tooltip after React renders the content so Popper measures the correct width
-  useEffect(() => {
-    if (popupNode && popperRef.current) {
-      popperRef.current.popper.update();
-    }
-  }, [popupNode]);
-
-  useEffect(() => {
-    let active = true;
-
-    ensureGraphPluginsReady().then(() => {
-      if (active) {
-        setPluginsReady(true);
-      }
-    });
-
-    return () => {
-      active = false;
-    };
-  }, []);
-
   useEffect(() => {
     function resizeListener() {
       _resizeListener(graphRef);
@@ -511,6 +466,7 @@ const ProductionGraphTab = () => {
       return null;
     }
 
+    const key = nanoid();
     const elements: any[] = [];
 
     Object.entries(resultsGraph.nodes).forEach(([key, node]) => {
@@ -536,7 +492,7 @@ const ProductionGraphTab = () => {
       });
     });
 
-    return { key: graphKey, elements };
+    return { key, elements };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resultsGraph]);
 
@@ -548,14 +504,14 @@ const ProductionGraphTab = () => {
           <GraphButton onClick={() => { resetNodePositions(); }}>Reset positions</GraphButton>
         </GraphButtonGroup>
         {
-          (isLoading || !pluginsReady) && (
+          isLoading && (
             <Center style={{ position: 'absolute', height: '100%', width: '100%' }}>
               <Loader size={50} />
             </Center>
           )
         }
         {
-          doFirstRender && !isLoading && pluginsReady && (
+          doFirstRender && !isLoading && (
             graphProps != null
               ? (
                 <GraphVisualizer
@@ -574,8 +530,8 @@ const ProductionGraphTab = () => {
               : (
                 <Center style={{ position: 'absolute', height: '100%', width: '100%' }}>
                   <Group>
-                    <AlertCircle size={85} style={{ position: 'relative', top: '3px' }} />
-                    <Stack style={{ gap: '0px' }}>
+                    <AlertCircle color="#eee" size={85} style={{ position: 'relative', top: '3px' }} />
+                    <Group direction='column' style={{ gap: '0px' }}>
                       <Text style={{ fontSize: '28px' }}>
                         Could not build graph
                       </Text>
@@ -587,7 +543,7 @@ const ProductionGraphTab = () => {
                           </Text>
                         )
                         : null}
-                    </Stack>
+                    </Group>
                   </Group>
                 </Center>
               )
@@ -605,7 +561,7 @@ const GraphContainer = styled(Container)`
   position: relative;
   min-height: 600px;
   min-width: 800px;
-  border: 1px solid var(--yafp-graph-border);
+  border: 1px solid #fff;
   border-top-width: 0px;
   margin: 0px;
   padding: 0px;

--- a/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
@@ -432,8 +432,7 @@ const ProductionGraphTab = () => {
   }
 
   function areNodesSame(node1: NodeInfo, node2: NodeInfo): boolean {
-    console.log(node1 === node2);
-    return false;
+    return node1.key === node2.key && node1.x === node2.x && node1.y === node2.y;
   }
   function updateStateNodePosition(key: string, x: number, y: number) {
     let existingNode = nodesPositions?.find(node => node.key === key);

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useReducer, useState, useEffect, useM
 import _ from 'lodash';
 import { usePrevious } from '../../hooks/usePrevious';
 import { useSessionStorage } from '../../hooks/useSessionStorage';
-import { ProductionSolver, SolverResults } from '../../utilities/production-solver';
 import { GraphError } from '../../utilities/error/GraphError';
 import { usePostSharedFactory } from '../../api/modules/shared-factories/usePostSharedFactory';
 import { reducer, FactoryAction, getInitialState } from './reducer';
@@ -11,6 +10,7 @@ import { FactoryInitializer } from '../gameData';
 import { GameData } from '../gameData/types';
 import { SHARE_QUERY_PARAM } from '../gameData/consts';
 import { useGlobalContext } from '../global';
+import { SolverResults } from '../../utilities/production-solver/models';
 
 
 export type ShareLinkProps = { link: string, copyToClipboard: boolean, loading: boolean };
@@ -57,6 +57,7 @@ const _handleCalculateFactory = _.debounce(async (
 ) => {
   _setCalculating(true, setCalculating);
   try {
+    const { ProductionSolver } = await import('../../utilities/production-solver');
     const solver = new ProductionSolver(state, gameData);
     const results = await solver.exec();
     setSolverResults((prevState) => {

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useReducer, useState, useEffect, useM
 import _ from 'lodash';
 import { usePrevious } from '../../hooks/usePrevious';
 import { useSessionStorage } from '../../hooks/useSessionStorage';
+import { ProductionSolver, SolverResults } from '../../utilities/production-solver';
 import { GraphError } from '../../utilities/error/GraphError';
 import { usePostSharedFactory } from '../../api/modules/shared-factories/usePostSharedFactory';
 import { reducer, FactoryAction, getInitialState } from './reducer';
@@ -10,7 +11,6 @@ import { FactoryInitializer } from '../gameData';
 import { GameData } from '../gameData/types';
 import { SHARE_QUERY_PARAM } from '../gameData/consts';
 import { useGlobalContext } from '../global';
-import { SolverResults } from '../../utilities/production-solver/models';
 
 
 export type ShareLinkProps = { link: string, copyToClipboard: boolean, loading: boolean };
@@ -57,7 +57,6 @@ const _handleCalculateFactory = _.debounce(async (
 ) => {
   _setCalculating(true, setCalculating);
   try {
-    const { ProductionSolver } = await import('../../utilities/production-solver');
     const solver = new ProductionSolver(state, gameData);
     const results = await solver.exec();
     setSolverResults((prevState) => {

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useReducer, useState, useEffect, useMemo, useCallback } from 'react';
+import React, { createContext, useContext, useReducer, useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import debounce from 'lodash/debounce';
 import { usePrevious } from '../../hooks/usePrevious';
 import { useSessionStorage } from '../../hooks/useSessionStorage';
@@ -11,6 +11,7 @@ import { GameData } from '../gameData/types';
 import { SHARE_QUERY_PARAM } from '../gameData/consts';
 import { useGlobalContext } from '../global';
 import { SolverResults } from '../../utilities/production-solver/models';
+import type { WorkerOutput } from '../../utilities/production-solver/solver.worker';
 
 
 export type ShareLinkProps = { link: string, copyToClipboard: boolean, loading: boolean };
@@ -49,37 +50,6 @@ const _setCalculating = debounce((value: boolean, setCalculating: React.Dispatch
   setCalculating(value);
 }, 300, { leading: false, trailing: true });
 
-const _handleCalculateFactory = debounce(async (
-  state: FactoryOptions,
-  gameData: GameData,
-  setSolverResults: React.Dispatch<React.SetStateAction<SolverResults | null>>,
-  setCalculating: React.Dispatch<React.SetStateAction<boolean>>,
-) => {
-  _setCalculating(true, setCalculating);
-  try {
-    const { ProductionSolver } = await import('../../utilities/production-solver');
-    const solver = new ProductionSolver(state, gameData);
-    const results = await solver.exec();
-    setSolverResults((prevState) => {
-      if (!prevState || prevState.timestamp < results.timestamp) {
-        console.log(`Computed in: ${results.computeTime}ms`);
-        return results;
-      }
-      return prevState;
-    });
-  } catch (e: unknown) {
-    setSolverResults({
-      productionGraph: null,
-      report: null,
-      timestamp: performance.now(),
-      computeTime: 0,
-      error: e as GraphError,
-    });
-  } finally {
-    _setCalculating(false, setCalculating);
-  }
-}, 300, { leading: true, trailing: true });
-
 
 // PROVIDER
 type PropTypes = {
@@ -102,9 +72,66 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
 
   const postSharedFactory = usePostSharedFactory();
 
+  // Debounced post ref: 300ms leading+trailing, matching the previous module-level debounce.
+  const debouncedSolveRef = useRef<ReturnType<typeof debounce> | null>(null);
+
+  useEffect(() => {
+    const worker = new Worker(
+      new URL('../../utilities/production-solver/solver.worker.ts', import.meta.url),
+      { type: 'module' },
+    );
+
+    worker.onmessage = (event: MessageEvent<WorkerOutput>) => {
+      const data = event.data;
+      if (data.ok) {
+        setSolverResults((prevState) => {
+          if (!prevState || prevState.timestamp < data.results.timestamp) {
+            console.log(`Computed in: ${data.results.computeTime}ms`);
+            return data.results;
+          }
+          return prevState;
+        });
+      } else {
+        setSolverResults({
+          productionGraph: null,
+          report: null,
+          timestamp: performance.now(),
+          computeTime: 0,
+          error: new GraphError(data.message, data.helpText),
+        });
+      }
+      _setCalculating(false, setCalculating);
+    };
+
+    worker.onerror = (e) => {
+      setSolverResults({
+        productionGraph: null,
+        report: null,
+        timestamp: performance.now(),
+        computeTime: 0,
+        error: new GraphError(e.message ?? 'Worker error'),
+      });
+      _setCalculating(false, setCalculating);
+    };
+
+    const debouncedSolve = debounce((state: FactoryOptions, gameData: GameData) => {
+      _setCalculating(true, setCalculating);
+      worker.postMessage({ state, gameData });
+    }, 300, { leading: true, trailing: true });
+
+    debouncedSolveRef.current = debouncedSolve;
+
+    return () => {
+      debouncedSolve.cancel();
+      worker.terminate();
+      debouncedSolveRef.current = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const handleCalculateFactory = useCallback(() => {
     ctx.refreshTip();
-    _handleCalculateFactory(state, gameData, setSolverResults, setCalculating)
+    debouncedSolveRef.current?.(state, gameData);
   }, [ctx, gameData, state]);
 
   const handleSetAutoCalculate = (checked: boolean) => {

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useReducer, useState, useEffect, useMemo, useCallback } from 'react';
-import _ from 'lodash';
+import debounce from 'lodash/debounce';
 import { usePrevious } from '../../hooks/usePrevious';
 import { useSessionStorage } from '../../hooks/useSessionStorage';
 import { GraphError } from '../../utilities/error/GraphError';
@@ -45,11 +45,11 @@ export function useProductionContext() {
 }
 
 
-const _setCalculating = _.debounce((value: boolean, setCalculating: React.Dispatch<React.SetStateAction<boolean>>) => {
+const _setCalculating = debounce((value: boolean, setCalculating: React.Dispatch<React.SetStateAction<boolean>>) => {
   setCalculating(value);
 }, 300, { leading: false, trailing: true });
 
-const _handleCalculateFactory = _.debounce(async (
+const _handleCalculateFactory = debounce(async (
   state: FactoryOptions,
   gameData: GameData,
   setSolverResults: React.Dispatch<React.SetStateAction<SolverResults | null>>,

--- a/client/src/utilities/production-solver/index.ts
+++ b/client/src/utilities/production-solver/index.ts
@@ -73,6 +73,14 @@ type ItemMap = {
   [key: string]: boolean;
 }
 
+let _glpkInstance: Awaited<ReturnType<typeof loadGLPK>> | null = null;
+async function getGLPK() {
+  if (!_glpkInstance) {
+    _glpkInstance = await loadGLPK();
+  }
+  return _glpkInstance;
+}
+
 export class ProductionSolver {
   private gameData: GameData;
   private globalWeights: GlobalWeights;
@@ -284,7 +292,7 @@ export class ProductionSolver {
   public async exec(): Promise<SolverResults> {
     const timestamp = performance.now();
     try {
-      const glpk = await loadGLPK();
+      const glpk = await getGLPK();
       const productionSolution = await this.productionSolverPass(RATE_TARGET_KEY, this.inputs, glpk);
       let productionGraph = this.generateProductionGraph(productionSolution);
 
@@ -357,6 +365,7 @@ export class ProductionSolver {
 
     const doPoints = (targetKey === RATE_TARGET_KEY && this.rateTargets[POINTS_ITEM_KEY]) || targetKey === POINTS_ITEM_KEY;
     const pointsVars: Var[] = [];
+    const objectiveVarMap = new Map<string, Var>();
 
     for (const [recipeKey, recipeInfo] of Object.entries(this.gameData.recipes)) {
       if (!this.allowedRecipes[recipeKey]) continue;
@@ -373,10 +382,12 @@ export class ProductionSolver {
       }
 
 
-      model.objective.vars.push({
+      const recipeObjVar: Var = {
         name: recipeKey,
         coef: powerScore + resourceScore + buildingsScore,
-      });
+      };
+      model.objective.vars.push(recipeObjVar);
+      objectiveVarMap.set(recipeKey, recipeObjVar);
 
 
       if (targetKey === RATE_TARGET_KEY) {
@@ -426,14 +437,13 @@ export class ProductionSolver {
         });
       } else if (targetKey === POINTS_ITEM_KEY) {
         pointsVars.forEach((v) => {
-          const existingVar = model.objective.vars.find((ov) => ov.name === v.name);
+          const existingVar = objectiveVarMap.get(v.name);
           if (existingVar) {
             existingVar.coef += v.coef * MAXIMIZE_WEIGHT;
           } else {
-            model.objective.vars.push({
-              name: v.name,
-              coef: v.coef * MAXIMIZE_WEIGHT,
-            });
+            const newVar: Var = { name: v.name, coef: v.coef * MAXIMIZE_WEIGHT };
+            model.objective.vars.push(newVar);
+            objectiveVarMap.set(v.name, newVar);
           }
         });
       }
@@ -443,6 +453,7 @@ export class ProductionSolver {
     for (const [itemKey, itemInfo] of Object.entries(this.gameData.items)) {
       if (!this.allowedItems[itemKey]) continue;
       const vars: Var[] = [];
+      const varsMap = new Map<string, Var>();
 
       const binKey = `${itemKey}_BIN`;
       const binVars: Var[] = [];
@@ -451,7 +462,9 @@ export class ProductionSolver {
         if (!this.allowedRecipes[recipeKey]) continue;
         const recipeInfo = this.gameData.recipes[recipeKey];
         const target = recipeInfo.ingredients.find((i) => i.itemClass === itemKey)!;
-        vars.push({ name: recipeKey, coef: target.perMinute });
+        const v: Var = { name: recipeKey, coef: target.perMinute };
+        vars.push(v);
+        varsMap.set(recipeKey, v);
 
         if (!this.gameData.handGatheredItems[itemKey]) {
           binVars.push({ name: recipeKey, coef: -1 });
@@ -463,11 +476,13 @@ export class ProductionSolver {
         const recipeInfo = this.gameData.recipes[recipeKey];
         const target = recipeInfo.products.find((p) => p.itemClass === itemKey)!;
 
-        const existingVar = vars.find((v) => v.name === recipeKey);
+        const existingVar = varsMap.get(recipeKey);
         if (existingVar) {
           existingVar.coef -= target.perMinute;
         } else {
-          vars.push({ name: recipeKey, coef: -target.perMinute });
+          const v: Var = { name: recipeKey, coef: -target.perMinute };
+          vars.push(v);
+          varsMap.set(recipeKey, v);
         }
       }
 
@@ -516,14 +531,13 @@ export class ProductionSolver {
         });
 
         vars.forEach((v) => {
-          const existingVar = model.objective.vars.find((ov) => ov.name === v.name);
+          const existingVar = objectiveVarMap.get(v.name);
           if (existingVar) {
             existingVar.coef += v.coef * MAXIMIZE_WEIGHT;
           } else {
-            model.objective.vars.push({
-              name: v.name,
-              coef: v.coef * MAXIMIZE_WEIGHT,
-            });
+            const newVar: Var = { name: v.name, coef: v.coef * MAXIMIZE_WEIGHT };
+            model.objective.vars.push(newVar);
+            objectiveVarMap.set(v.name, newVar);
           }
         });
       }
@@ -932,6 +946,12 @@ export class ProductionSolver {
   }
 
   private hasLoop(productionGraph: ProductionGraph): boolean {
+    const adjacency = new Map<string, string[]>();
+    for (const edge of productionGraph.edges) {
+      if (!adjacency.has(edge.from)) adjacency.set(edge.from, []);
+      adjacency.get(edge.from)!.push(edge.to);
+    }
+
     const visited = new Set<string>();
     const stack = new Set<string>();
 
@@ -939,7 +959,7 @@ export class ProductionSolver {
       visited.add(node);
       stack.add(node);
 
-      for (const edge of productionGraph.edges.filter(e => e.from === node).map((e) => e.to)) {
+      for (const edge of (adjacency.get(node) ?? [])) {
         if ( stack.has(edge) ) {
           return true;
         } else if (!visited.has(edge)) {

--- a/client/src/utilities/production-solver/solver.worker.ts
+++ b/client/src/utilities/production-solver/solver.worker.ts
@@ -1,0 +1,29 @@
+/// <reference lib="webworker" />
+
+import { ProductionSolver } from '.';
+import type { FactoryOptions } from '../../contexts/production/types';
+import type { GameData } from '../../contexts/gameData/types';
+import type { SolverResults } from './models';
+
+export type WorkerInput = {
+  state: FactoryOptions;
+  gameData: GameData;
+};
+
+export type WorkerOutput =
+  | { ok: true; results: SolverResults }
+  | { ok: false; message: string; helpText?: string };
+
+addEventListener('message', async (event: MessageEvent<WorkerInput>) => {
+  const { state, gameData } = event.data;
+  try {
+    const solver = new ProductionSolver(state, gameData);
+    // solver.exec runs the GLPK MILP computation off the main thread
+    const results = await solver['exec']();
+    postMessage({ ok: true, results } satisfies WorkerOutput);
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    const helpText = (e as { helpText?: string })?.helpText;
+    postMessage({ ok: false, message, helpText } satisfies WorkerOutput);
+  }
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# NOTE: This docker-compose.yml is preserved for reference only.
+# It is NOT the active deployment path. The canonical dev and deployment path is
+# the .NET Aspire AppHost (YetAnotherFactoryPlanner.AppHost).
+
 networks:
   default:
     external: false


### PR DESCRIPTION
## Summary

Full repository review pass implementing 23 backlog items across backend, frontend, infrastructure, and CI/CD.

### Backend (api.web)
- Wire up `AddServiceDefaults()` and `MapDefaultEndpoints()` so health probes (`/health`, `/alive`) respond in all environments — required for ACA liveness/readiness checks
- Enable Application Insights via `UseAzureMonitor()` with `Azure.Monitor.OpenTelemetry.AspNetCore`
- Fix `FactoryClient.GetFactory` swallowing all Cosmos exceptions as 404 — only catches `HttpStatusCode.NotFound` now; 429/503 propagate correctly
- Fix `FindOrSaveAsync` TOCTOU race: catch `DbUpdateException` on conflict and return the existing record instead of throwing
- Pass `CancellationToken` through `ValidateAsync` and `SaveChangesAsync`
- Add array length limits to `FactoryConfigSchemaValidator` (ProductionItems/InputItems/InputResources/AllowedRecipes ≤ 500, NodesPositions ≤ 1000) and validate `Mode` against allowed values

### Frontend (client/)
- Fix `areNodesSame()` stub that always returned `false`, causing spurious re-solves on every node drag
- Replace `import _ from 'lodash'` with `import debounce from 'lodash/debounce'` (tree-shaking)
- Cache the GLPK WASM module instance across solver calls (was reloading on every calculation)
- Replace O(N²) `.find()` scans in LP model-building with `Map` lookups (`objectiveVarMap`, `varsMap`, `adjacencyMap`)
- **Move GLPK solver to a Web Worker** (`solver.worker.ts`) so the main thread stays responsive during calculation — worker bundle emits as a separate chunk

### Infrastructure (AppHost)
- Remove redundant `Aspire.Hosting.NodeJs` package (covered by `Aspire.Hosting.JavaScript`)
- Add `cosmosDb.ConfigureInfrastructure`: set `DefaultTtl = 604800` (7 days) on the factories container
- Add `api.PublishAsAzureContainerApp`: `MinReplicas = 0` (scale to zero), `MaxReplicas = 3`

### Housekeeping
- Remove dead `api/` Azure Functions project from `api.sln` (replaced by `api.web/`)
- Remove credential-logging debug block from `api/Program.cs`
- Fix `client/Dockerfile`: copy path `build/` → `dist/`, env var prefix `REACT_APP_` → `VITE_`, `nginx:latest` → `nginx:1.27-alpine`; add reference-only comments to Dockerfile and `docker-compose.yml`
- Update integration test comments from `// BUG:` → `// FIXED:` for Bugs 1 and 6

### Tests & CI
- Retarget `api.Tests` to `api.web`; fix test data; add 7 new coverage tests for Mode validation and all five array-limit boundaries — **31/31 passing**
- Fix `BrowserFixture` Chromium launch to include `--no-sandbox --disable-dev-shm-usage` for Linux CI runners
- Add MSBuild target to auto-install Playwright browsers after build
- Replace `Task.Delay` timing hacks in Playwright tests with deterministic Playwright waits
- Add `.github/workflows/ci.yml`: two jobs on push/PR to main/master
  - `build-and-test`: restore → build → `dotnet test api.Tests` with TRX upload
  - `build-frontend`: `npm ci` → `npm run build`

## Test plan

- [x] `dotnet test api.Tests` — 31/31 passed
- [x] `dotnet test YetAnotherFactoryPlanner.IntegrationTests` — 11/11 passed (full Aspire stack with Cosmos emulator)
- [x] `cd client && npm run build` — clean Vite build, worker chunk emitted as `solver.worker-*.js`
- [x] `dotnet build api.sln` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)