### PR TITLE
fix: solve with correct state after factory load

### DIFF
--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -74,6 +74,8 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
 
   // Debounced post ref: 300ms leading+trailing, matching the previous module-level debounce.
   const debouncedSolveRef = useRef<ReturnType<typeof debounce> | null>(null);
+  // Set to true in triggerInitialize effect so the state-change effect runs the solve after dispatch applies.
+  const forceCalculateRef = useRef(false);
 
   useEffect(() => {
     const worker = new Worker(
@@ -169,13 +171,16 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
       } else {
         dispatch({ type: 'RESET_FACTORY', gameData });
       }
-      handleCalculateFactory();
+      // Don't call handleCalculateFactory() here — state hasn't updated yet (dispatch is async).
+      // Set the flag so the state-change effect below runs the solve after the new state is applied.
+      forceCalculateRef.current = true;
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [triggerInitialize]);
 
   useEffect(() => {
-    if (autoCalculateBool && prevState !== state) {
+    if (prevState !== state && (autoCalculateBool || forceCalculateRef.current)) {
+      forceCalculateRef.current = false;
       handleCalculateFactory();
     }
   }, [autoCalculateBool, handleCalculateFactory, prevState, state]);


### PR DESCRIPTION
## Summary

- `triggerInitialize` effect was calling `handleCalculateFactory()` immediately after `dispatch()`, but React's `useReducer` dispatch is async — the state hadn't updated yet
- The debounce **leading call** always fired with `initialState` (empty factory), producing a "NO OUTPUTS SET" error
- The **trailing call** only corrected this if `auto-calculate` was enabled; with it disabled (or if `auto-calculate` was `false` in session storage from a prior session), the shared factory URL never rendered a graph

## Fix

Replaced the immediate `handleCalculateFactory()` call in the `triggerInitialize` effect with a `forceCalculateRef` flag. The existing state-change effect now also checks this flag, calling `handleCalculateFactory()` **after** the dispatch has applied and the new state is available — regardless of the `auto-calculate` setting.

## Test plan

- [ ] Load `/?factory=cd21f8300a09a5dd` in a browser where `auto-calculate` has been set to `false` in session storage — graph should now render
- [ ] Load any shared factory URL with `auto-calculate = true` — graph still renders (no regression)
- [ ] Manually building a factory with `auto-calculate = false` and clicking Calculate still works
- [ ] Enabling `auto-calculate` while a factory is loaded still triggers an immediate solve

🤖 Generated with [Claude Code](https://claude.com/claude-code)