### PR TITLE
fix: graph never renders when loading a shared factory

### DIFF
--- a/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
@@ -491,6 +491,8 @@ const ProductionGraphTab = () => {
       if (active) {
         setPluginsReady(true);
       }
+    }).catch((err) => {
+      console.error('[graph] ensureGraphPluginsReady failed:', err);
     });
 
     return () => {

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -76,6 +76,9 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
   const debouncedSolveRef = useRef<ReturnType<typeof debounce> | null>(null);
   // Set to true in triggerInitialize effect so the state-change effect runs the solve after dispatch applies.
   const forceCalculateRef = useRef(false);
+  // Monotonically-increasing ID for each solve request. Used to discard stale results from the worker,
+  // since worker and main-thread performance.now() have different origins and can't be compared.
+  const solveIdRef = useRef(0);
 
   useEffect(() => {
     const worker = new Worker(
@@ -85,14 +88,11 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
 
     worker.onmessage = (event: MessageEvent<WorkerOutput>) => {
       const data = event.data;
+      if (data.solveId < solveIdRef.current) {
+        return;
+      }
       if (data.ok) {
-        setSolverResults((prevState) => {
-          if (!prevState || prevState.timestamp < data.results.timestamp) {
-            console.log(`Computed in: ${data.results.computeTime}ms`);
-            return data.results;
-          }
-          return prevState;
-        });
+        setSolverResults(data.results);
       } else {
         setSolverResults({
           productionGraph: null,
@@ -117,8 +117,9 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
     };
 
     const debouncedSolve = debounce((state: FactoryOptions, gameData: GameData) => {
+      const solveId = ++solveIdRef.current;
       _setCalculating(true, setCalculating);
-      worker.postMessage({ state, gameData });
+      worker.postMessage({ state, gameData, solveId });
     }, 300, { leading: true, trailing: true });
 
     debouncedSolveRef.current = debouncedSolve;

--- a/client/src/utilities/production-solver/solver.worker.ts
+++ b/client/src/utilities/production-solver/solver.worker.ts
@@ -8,22 +8,23 @@ import type { SolverResults } from './models';
 export type WorkerInput = {
   state: FactoryOptions;
   gameData: GameData;
+  solveId: number;
 };
 
 export type WorkerOutput =
-  | { ok: true; results: SolverResults }
-  | { ok: false; message: string; helpText?: string };
+  | { ok: true; results: SolverResults; solveId: number }
+  | { ok: false; message: string; helpText?: string; solveId: number };
 
 addEventListener('message', async (event: MessageEvent<WorkerInput>) => {
-  const { state, gameData } = event.data;
+  const { state, gameData, solveId } = event.data;
   try {
     const solver = new ProductionSolver(state, gameData);
     // solver.exec runs the GLPK MILP computation off the main thread
     const results = await solver['exec']();
-    postMessage({ ok: true, results } satisfies WorkerOutput);
+    postMessage({ ok: true, results, solveId } satisfies WorkerOutput);
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : String(e);
     const helpText = (e as { helpText?: string })?.helpText;
-    postMessage({ ok: false, message, helpText } satisfies WorkerOutput);
+    postMessage({ ok: false, message, helpText, solveId } satisfies WorkerOutput);
   }
 });


### PR DESCRIPTION
## Summary

- **Root cause:** `performance.now()` in a Web Worker starts from 0 at worker creation time, while the main thread's value is already tens of seconds ahead (the worker isn't created until `ProductionProvider` mounts, after the game data API call completes). The stale-result guard `prevState.timestamp < data.results.timestamp` always evaluated to `false` (e.g. `33408 < 276`), so the error result from the initial empty-state solve permanently blocked the success result from the loaded factory solve.
- **Fix:** Replace the timestamp comparison with a monotonically-increasing `solveId` counter. Each `debouncedSolve` call increments `solveIdRef` and passes the ID to the worker; the worker echoes it back in both success and error responses. Any result where `data.solveId < solveIdRef.current` is discarded as stale.
- **Cleanup:** Surface `ensureGraphPluginsReady` rejections to the console.

## Test plan

- [ ] Navigate to `/?factory=<key>` for a valid shared factory — production graph renders correctly on first load
- [ ] Navigate to `/?factory=<key>` with auto-calculate off — clicking Calculate renders the graph
- [ ] Normal factory editing (add/remove items) still triggers re-solves and updates the graph
- [ ] Stale solve results (rapid edits triggering debounce) are discarded correctly — only the latest solve result is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)