### PR TITLE
fix: prevent spurious solver call on first render when loading shared…

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -27,7 +27,7 @@
                 "nanoid": "^5.1.11",
                 "react": "^19.2.7",
                 "react-cytoscapejs": "^2.0.0",
-                "react-dom": "^19.2.4",
+                "react-dom": "^19.2.7",
                 "react-feather": "^2.0.10",
                 "seedrandom": "^3.0.5",
                 "styled-components": "^6.4.2",
@@ -4402,15 +4402,15 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.4"
+                "react": "^19.2.7"
             }
         },
         "node_modules/react-feather": {
@@ -8527,9 +8527,9 @@
             }
         },
         "react-dom": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+            "version": "19.2.7",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+            "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
             "requires": {
                 "scheduler": "^0.27.0"
             }

--- a/client/package.json
+++ b/client/package.json
@@ -60,7 +60,7 @@
         "nanoid": "^5.1.11",
         "react": "^19.2.7",
         "react-cytoscapejs": "^2.0.0",
-        "react-dom": "^19.2.4",
+        "react-dom": "^19.2.7",
         "react-feather": "^2.0.10",
         "seedrandom": "^3.0.5",
         "styled-components": "^6.4.2",

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -180,7 +180,7 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
   }, [triggerInitialize]);
 
   useEffect(() => {
-    if (prevState !== state && (autoCalculateBool || forceCalculateRef.current)) {
+    if (prevState !== undefined && prevState !== state && (autoCalculateBool || forceCalculateRef.current)) {
       forceCalculateRef.current = false;
       handleCalculateFactory();
     }


### PR DESCRIPTION
… factory

usePrevious returns undefined on the first render (ref not yet initialized), so prevState !== state was true even before any real state transition occurred. This caused the solver to fire with the empty initial state, producing "NO OUTPUTS SET" when loading a factory from a shared URL.

Adding prevState !== undefined ensures the state-change effect only triggers on genuine transitions, not on the initial mount.

Also bumps react-dom to 19.2.7 to match the react peer dependency.