### PR TITLE
fix(client): resolve WCAG A/AA violations and make axe e2e scan blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,13 +80,12 @@ jobs:
         working-directory: client
         run: npx playwright install --with-deps chromium
 
-      # Report-only baseline: the app currently has known WCAG A/AA violations.
-      # This step surfaces them (artifact below) without failing the build.
-      # Promote to a blocking gate once the violations are resolved.
-      - name: Accessibility e2e (axe) — report-only baseline
+      # Blocking gate: the scanned surfaces must report zero WCAG 2.0 A/AA
+      # violations (axe-core via Playwright). The graph canvas is excluded as a
+      # separate tracked follow-up; see client/tests/a11y.spec.ts.
+      - name: Accessibility e2e (axe)
         working-directory: client
         run: npm run test:e2e
-        continue-on-error: true
 
       - name: Upload accessibility reports
         if: always()

--- a/client/lighthouserc.json
+++ b/client/lighthouserc.json
@@ -12,7 +12,7 @@
     },
     "assert": {
       "assertions": {
-        "categories:accessibility": ["error", { "minScore": 0.9 }]
+        "categories:accessibility": ["error", { "minScore": 0.95 }]
       }
     },
     "upload": {

--- a/client/src/components/ExternalLink/index.tsx
+++ b/client/src/components/ExternalLink/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Anchor, AnchorProps, ElementProps } from '@mantine/core';
 
 const ExternalLink = (props: AnchorProps & ElementProps<'a'>) => {
-  return <Anchor target='_blank' rel='noopener noreferrer' inherit {...props} />;
+  return <Anchor target='_blank' rel='noopener noreferrer' inherit underline='always' {...props} />;
 };
 
 export default ExternalLink;

--- a/client/src/components/SocialIcon/index.tsx
+++ b/client/src/components/SocialIcon/index.tsx
@@ -5,12 +5,13 @@ import { Anchor } from '@mantine/core';
 interface Props {
   href: string;
   icon: React.ReactNode;
+  label: string;
 }
 
 const SocialIcon = (props: Props) => {
-  const { href, icon } = props;
+  const { href, icon, label } = props;
   return (
-    <SAnchor href={href} target='_blank' rel='noopener noreferrer'>
+    <SAnchor href={href} target='_blank' rel='noopener noreferrer' aria-label={label} title={label}>
       {icon || null}
     </SAnchor>
   );

--- a/client/src/containers/Main/SiteHeader/index.tsx
+++ b/client/src/containers/Main/SiteHeader/index.tsx
@@ -52,7 +52,7 @@ const SiteHeader = () => {
         >
           {computedColorScheme === 'dark' ? <SunIcon /> : <MoonIcon />}
         </ActionIcon>
-        <SocialIcon href='https://github.com/greven145/yet-another-factory-planner' icon={<FontAwesomeIcon icon={faGithub} fontSize={32} />} />
+        <SocialIcon href='https://github.com/greven145/yet-another-factory-planner' label='View source on GitHub' icon={<FontAwesomeIcon icon={faGithub} fontSize={32} />} />
       </RightAlign>
     </HeaderContainer>
   );

--- a/client/src/containers/ProductionPlanner/PlannerOptions/InputsTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/InputsTab/index.tsx
@@ -38,6 +38,7 @@ const InputsTab = () => {
               style={{ flex: '1 1 0' }}
             />
             <TextInput
+              aria-label='Input item amount'
               placeholder='Amount'
               className='no-spinner'
               type='number'
@@ -84,6 +85,7 @@ const InputsTab = () => {
           <ResourceRow key={data.key}>
             <ResourceName>{ctx.gameData.items[data.itemKey].name}</ResourceName>
             <TextInput
+              aria-label={`${ctx.gameData.items[data.itemKey].name} amount`}
               className='no-spinner'
               type='number'
               min='0'
@@ -100,6 +102,7 @@ const InputsTab = () => {
             />
             <ResourceCheckboxCell>
               <Checkbox
+                aria-label={`${ctx.gameData.items[data.itemKey].name} unlimited`}
                 checked={data.unlimited}
                 onChange={(e) => {
                   ctx.dispatch({
@@ -110,6 +113,7 @@ const InputsTab = () => {
               />
             </ResourceCheckboxCell>
             <TextInput
+              aria-label={`${ctx.gameData.items[data.itemKey].name} weight`}
               className='no-spinner'
               type='number'
               min='0'
@@ -139,10 +143,10 @@ const InputsTab = () => {
       </CollapsibleSection>
       <CollapsibleSection title='Raw Resources' tooltip='Set how much of each raw resource is available and its weight. Weight is a relative cost the solver pays per unit consumed: raise it to make a resource "precious" so the solver avoids it and favours recipes that lean on cheaper resources; lower it (or set 0) to use it freely. Weights are relative to each other and only take effect when Resource Efficiency (under Weighting Options) is above 0.'>
         <Group style={{ marginBottom: '12px' }}>
-          <Button color='red' onClick={() => { ctx.dispatch({ type: 'SET_RESOURCES_TO_MAP_LIMITS', gameData: ctx.gameData }) }}>
+          <Button color='danger.8' onClick={() => { ctx.dispatch({ type: 'SET_RESOURCES_TO_MAP_LIMITS', gameData: ctx.gameData }) }}>
             Set All To Maximum
           </Button>
-          <Button color='red' onClick={() => { ctx.dispatch({ type: 'SET_RESOURCES_TO_0' }) }}>
+          <Button color='danger.8' onClick={() => { ctx.dispatch({ type: 'SET_RESOURCES_TO_0' }) }}>
             Set All To 0
           </Button>
         </Group>
@@ -188,7 +192,7 @@ const ResourceHeaderCell = styled.div`
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  opacity: 0.6;
+  opacity: 0.72;
   color: light-dark(#212529, #eee);
 `;
 

--- a/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
@@ -55,7 +55,7 @@ const PlannerOptions = () => {
         </Group>
         <Group style={{ marginBottom: '15px' }}>
           <Button
-            color='green'
+            color='positive.8'
             onClick={() => { ctx.generateShareLink(); }}
             loading={ctx.shareLink.loading}
             style={{ width: '125px' }}
@@ -67,6 +67,7 @@ const PlannerOptions = () => {
             onClose={() => setPopoverOpened(false)}
             position='right'
             withArrow
+            withRoles={false}
           >
             <Popover.Target>
               <TextInput
@@ -85,7 +86,7 @@ const PlannerOptions = () => {
         <Space />
         <Group style={{ marginBottom: '15px' }} justify='flex-end'>
           <Button
-            color='red'
+            color='danger.8'
             onClick={() => { setResetConfirmOpen(true); }}
           >
             Reset ALL Factory Options

--- a/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
@@ -254,17 +254,14 @@ const GraphButtonGroup = styled(Group)`
 `;
 
 //Extend the mantine/core button component to add a custom style
+// The button overlays the (transparent) graph, so any resting transparency
+// composites the label against an unknown backdrop and tanks contrast — a faded
+// rest state measured ~1:1 (and even 0.92 fell to 3.95:1). Keep it fully opaque
+// so the white label always meets WCAG AA against the solid button background.
 const GraphButton = styled(Button)<ButtonProps & React.ComponentPropsWithoutRef<'button'>>`
-  opacity: 0.25;
   border: 1px solid light-dark(rgba(0,0,0,0.15), rgba(255,255,255,0.1));
   border-radius: 5px;
   padding: 5px;
-  &:hover {
-    opacity: 0.8;
-  }
-  &:active {
-    opacity: 1;
-  }
 `;
 
 function getNodeLabel(node: GraphNode, gameData: GameData) {

--- a/client/src/containers/ProductionPlanner/PlannerResults/ReportTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ReportTab/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Title, Text, Container, Group } from '@mantine/core';
 import { AlertCircle } from 'react-feather';
 import { useProductionContext } from '../../../../contexts/production';
@@ -192,6 +192,14 @@ const StatCard = styled.div<{ $accent?: boolean }>`
   background: ${({ theme, $accent }) => $accent ? theme.colors.primary[8] : 'light-dark(#e9ecef, #3f434a)'};
   border-radius: 4px;
   padding: 12px 14px;
+
+  /* The accent card uses the dark primary[8] background, so its text must be
+     light to keep WCAG AA contrast (dark-on-brown failed at ~1-2.5:1). */
+  ${({ $accent }) => $accent && css`
+    ${StatLabel} { color: #fff; }
+    ${StatValue} { color: #fff; }
+    ${StatUnit} { opacity: 1; }
+  `}
 `;
 
 const StatLabel = styled.div`
@@ -229,7 +237,7 @@ const StepTitle = styled(Title)`
   font-size: 15px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  opacity: 0.6;
+  opacity: 0.72;
   margin-bottom: 6px;
 `;
 
@@ -262,7 +270,7 @@ const ItemCellRate = styled.div`
 `;
 
 const LoopWarning = styled.div`
-  background: ${({ theme }) => theme.colors.danger[6]};
+  background: ${({ theme }) => theme.colors.danger[8]};
   color: #fff;
   border-radius: 4px;
   padding: 8px 14px;

--- a/client/src/global-stylesheet.ts
+++ b/client/src/global-stylesheet.ts
@@ -100,7 +100,7 @@ const GlobalStylesheet = createGlobalStyle<any>`
     padding: 7px 18px !important;
     border: none !important;
     border-radius: 4px !important;
-    color: light-dark(#6b6459, #b0a89c) !important;
+    color: light-dark(#666058, #b0a89c) !important;
     background-color: transparent !important;
     transition: background-color 120ms ease, color 120ms ease;
   }
@@ -112,7 +112,7 @@ const GlobalStylesheet = createGlobalStyle<any>`
 
   :root .segmented-tabs button[role="tab"][data-active],
   :root .segmented-tabs button[role="tab"][data-active]:hover {
-    background-color: #ec7821 !important;
+    background-color: #b0581a !important;
     color: #ffffff !important;
   }
 
@@ -139,7 +139,7 @@ const GlobalStylesheet = createGlobalStyle<any>`
   :root .hud-segmented .mantine-SegmentedControl-indicator {
     border-radius: 4px !important;
     box-shadow: none !important;
-    background-color: #ec7821 !important;
+    background-color: #b0581a !important;
   }
 
   // Hide the divider Mantine draws between inactive segments.
@@ -153,7 +153,7 @@ const GlobalStylesheet = createGlobalStyle<any>`
     letter-spacing: 0.5px;
     font-weight: 600;
     padding: 5px 16px;
-    color: light-dark(#6b6459, #b0a89c) !important;
+    color: light-dark(#666058, #b0a89c) !important;
     transition: color 120ms ease;
   }
 

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -28,7 +28,7 @@ export const graphColors = {
 export const theme: MantineThemeOverride = {
   primaryColor: 'primary',
   colors: {
-    'primary': ["#fcebde", "#f9d8be", "#f7c59f", "#f4b17f", "#f19e60", "#ef8b40", "#ec7821", "#c4631c", "#94501e", "#673c1c"],
+    'primary': ["#fcebde", "#f9d8be", "#f7c59f", "#f4b17f", "#f19e60", "#ef8b40", "#b0581a", "#a4521a", "#94501e", "#673c1c"],
     'positive': ["#e9f3ea", "#d5e8d6", "#c1ddc2", "#acd2ae", "#98c69a", "#83bb86", "#6fb072", "#58965c", "#49744b", "#39543a"],
     'danger': ["#fdb5b5", "#fda3a3", "#fc9191", "#fc7e7e", "#fb6c6c", "#fa5959", "#fa4747", "#f12929", "#dc1818", "#b21b1b"],
     'background': ["#26282b", "#373b40", "#3f434a", "#50565e", "#6c7582", "#ffffff", "#ffffff", "#ffffff", "#b3b6ba", "#ffffff"],
@@ -60,7 +60,7 @@ export const theme: MantineThemeOverride = {
     AppShell: {
       styles: {
         root: { minHeight: '100vh' },
-        header: { background: '#ec7821', borderBottom: 'none', padding: '10px', overflow: 'hidden' },
+        header: { background: '#b0581a', borderBottom: 'none', padding: '10px', overflow: 'hidden' },
         main: { background: 'transparent', paddingTop: '80px', paddingBottom: '0px' },
       },
     },


### PR DESCRIPTION
## Summary
Fixes every WCAG 2.0 A/AA violation flagged by the axe-core Playwright scan across all 5 scanned surfaces (initial load, Production/Inputs/Recipes tabs, Factory Report), then promotes the e2e step from **report-only** to a **blocking** CI gate.

Locally, `npx playwright test a11y.spec.ts` now reports **0 violations** (was 5/5 surfaces failing).

## Violations fixed
- **link-name** — icon-only GitHub header link had no accessible name. `SocialIcon` now takes a required `label` → `aria-label`/`title`.
- **aria-allowed-attr** (critical) — the share-link `Popover.Target` injected `aria-expanded`/`aria-haspopup` onto a bare `<input>`. Set `withRoles={false}` (it is a transient "Link copied!" confirmation, not a disclosure widget).
- **label** (critical) — added `aria-label`s to the InputsTab amount/weight number fields and the resource "unlimited" checkboxes.
- **link-in-text-block** — footer credit links were colour-only. `ExternalLink` now underlines always.
- **color-contrast** — adjusted each failing pair to the nearest AA-compliant shade, preserving the brand look:
  - brand orange `#ec7821` → `#b0581a` for white-text surfaces (filled buttons, active tabs, segmented/HUD active, header); orange ramp kept monotonic (`primary[7]` → `#a4521a`).
  - Save & Share → `positive.8`; destructive/red buttons + LoopWarning → `danger.8`.
  - inactive segmented label `#6b6459` → `#666058`.
  - InputsTab column headers & Report step titles: `opacity` 0.6 → 0.72.
  - Report "Total Usage" accent card: light text on the dark `primary[8]` background.
  - graph HUD buttons (Fit Graph / Reset positions): dropped the resting `opacity: 0.25` — overlay transparency composited the white label to ~1:1 (and even 0.92 fell to 3.95:1), so the buttons are now fully opaque. **This removes their faint-until-hover look** — flagging as a visible design change.

## CI
- Removed `continue-on-error` from the axe e2e step → now blocking.
- Ratcheted the Lighthouse accessibility floor 0.90 → 0.95 (measured **1.0**, up from 0.91).
- The Cytoscape graph `canvas` remains excluded (separate tracked follow-up).

## Notes vs. the original task brief
- **`presentational-role`** does not actually fire on any surface — dropped.
- **color-contrast** was substantially larger than the brief implied (graph HUD, Report card, green/red buttons, step/column headings) — all addressed.

## Verification
- `playwright test a11y.spec.ts` → 0 violations on all 5 surfaces.
- `vitest run` → 78 passed; `eslint` clean (pre-existing warnings only); `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)