### PR TITLE
a11y: tooling hardening follow-ups (#93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: client
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium firefox webkit
 
       # Blocking gate: the scanned surfaces must report zero WCAG 2.0 A/AA
       # violations (axe-core via Playwright). The graph canvas is excluded as a

--- a/client/eslint.config.mjs
+++ b/client/eslint.config.mjs
@@ -33,8 +33,8 @@ export default [
       'react-hooks': reactHooks,
     },
     rules: {
-      // Primary purpose: jsx-a11y recommended accessibility rules.
-      ...jsxA11y.configs.recommended.rules,
+      // Primary purpose: jsx-a11y strict accessibility rules.
+      ...jsxA11y.configs.strict.rules,
 
       // Register react-hooks so the inline `// eslint-disable-next-line
       // react-hooks/exhaustive-deps` comments in src/ don't error as unknown

--- a/client/lighthouserc.json
+++ b/client/lighthouserc.json
@@ -12,7 +12,7 @@
     },
     "assert": {
       "assertions": {
-        "categories:accessibility": ["error", { "minScore": 0.95 }]
+        "categories:accessibility": ["error", { "minScore": 0.98 }]
       }
     },
     "upload": {

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -17,6 +17,14 @@ export default defineConfig({
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
   ],
 
   webServer: {

--- a/client/src/components/Card/index.a11y.test.tsx
+++ b/client/src/components/Card/index.a11y.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MantineProvider } from '@mantine/core';
+import { ThemeProvider } from 'styled-components';
+import Card from './index';
+import { theme } from '../../theme';
+
+// Minimal styled-components theme matching the shape Card's CSS expects
+// (Card reads theme.colors.primary[6] for its left border).
+const scTheme = {
+  colors: {
+    background: ['#26282b', '#373b40', '#3f434a', '#50565e', '#6c7582'],
+    primary: ['#fcebde', '#f9d8be', '#f7c59f', '#f4b17f', '#f19e60', '#ef8b40', '#ec7821'],
+  },
+};
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <MantineProvider theme={theme}>
+      <ThemeProvider theme={scTheme}>
+        {children}
+      </ThemeProvider>
+    </MantineProvider>
+  );
+}
+
+describe('Card component — accessibility', () => {
+  it('renders without axe violations', async () => {
+    const { container } = render(
+      <Wrapper>
+        <Card>
+          <h2>Card Title</h2>
+          <p>Card body content for accessibility testing.</p>
+        </Card>
+      </Wrapper>
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
+++ b/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MantineProvider } from '@mantine/core';
+import { ThemeProvider } from 'styled-components';
+import SiteHeader from './index';
+import { theme } from '../../../theme';
+import { GameDataContext, GameDataContextType } from '../../../contexts/gameData';
+import { DEFAULT_GAME_VERSION } from '../../../contexts/gameData/consts';
+
+// Minimal styled-components theme matching the shape SiteHeader's CSS expects
+// (HeaderContainer reads theme.other.pageLeftMargin).
+const scTheme = {
+  other: {
+    pageLeftMargin: '55px',
+  },
+};
+
+// Minimal GameDataContext value: SiteHeader only reads gameVersion, setGameVersion,
+// and loading. The rest of the contract is stubbed out.
+const gameDataValue = {
+  gameData: null,
+  initializer: null,
+  loading: false,
+  loadingError: false,
+  completedThisFrame: false,
+  gameVersion: DEFAULT_GAME_VERSION,
+  setGameVersion: () => {},
+} as GameDataContextType;
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <MantineProvider theme={theme}>
+      <ThemeProvider theme={scTheme}>
+        <GameDataContext.Provider value={gameDataValue}>
+          {children}
+        </GameDataContext.Provider>
+      </ThemeProvider>
+    </MantineProvider>
+  );
+}
+
+describe('SiteHeader component — accessibility', () => {
+  it('renders without axe violations', async () => {
+    const { container } = render(
+      <Wrapper>
+        <SiteHeader />
+      </Wrapper>
+    );
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
@@ -97,12 +97,22 @@ const PlannerOptions = () => {
         opened={resetConfirmOpen}
         onClose={() => setResetConfirmOpen(false)}
         title="Reset ALL Factory Options"
+        closeButtonProps={{ 'aria-label': 'Close' }}
       >
         <Text>Are you sure? This will clear all production goals, inputs, and recipe settings.</Text>
         <Group justify='flex-end' style={{ marginTop: '20px' }}>
-          <Button variant='default' onClick={() => setResetConfirmOpen(false)}>Cancel</Button>
           <Button
-            color='red'
+            variant='default'
+            onClick={() => setResetConfirmOpen(false)}
+            // The global Button theme forces white labels (for filled colored
+            // buttons); the default variant needs the readable theme text color
+            // so it isn't white-on-light. See WCAG contrast scan in a11y.spec.ts.
+            styles={{ root: { color: 'var(--mantine-color-text)' } }}
+          >
+            Cancel
+          </Button>
+          <Button
+            color='danger.8'
             onClick={() => {
               ctx.dispatch({ type: 'RESET_FACTORY', gameData: ctx.gameData });
               setResetConfirmOpen(false);

--- a/client/tests/a11y.spec.ts
+++ b/client/tests/a11y.spec.ts
@@ -1,9 +1,27 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
 const fixtureResponse = readFileSync(join(__dirname, 'fixtures/initialize-response.json'), 'utf-8');
+
+// Builds the standard WCAG 2.0 A/AA axe scan (canvas excluded — the graph is a
+// separate tracked follow-up). Headless WebKit's colour management diverges
+// from real sRGB and produces non-deterministic color-contrast results on
+// borderline brand colours that pass reliably on Chromium + Firefox (which are
+// authoritative for contrast here), so that single rule is dropped on WebKit
+// only — every other axe rule still runs cross-browser.
+function buildScan(page: Page) {
+  const builder = new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa'])
+    .exclude('canvas');
+
+  if (test.info().project.name === 'webkit') {
+    builder.disableRules(['color-contrast']);
+  }
+
+  return builder;
+}
 
 test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
   test.beforeEach(async ({ page }) => {
@@ -11,6 +29,17 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
     // The hook stores JSON-encoded strings: '"false"' deserialises to the string 'false'.
     await page.addInitScript(() => {
       sessionStorage.setItem('drawer-open', '"false"');
+    });
+
+    // Disable CSS transitions/animations so axe never samples an element mid-fade
+    // (e.g. a modal/popover transition), which produces non-deterministic
+    // composited colours — especially under headless WebKit.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.addInitScript(() => {
+      const style = document.createElement('style');
+      style.textContent =
+        '*,*::before,*::after{transition:none!important;animation:none!important;}';
+      document.documentElement.appendChild(style);
     });
 
     // Mock the /initialize API so tests run without the Aspire backend.
@@ -26,10 +55,7 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
   test('initial page load has no WCAG A/AA violations', async ({ page }) => {
     await page.goto('/');
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .exclude('canvas')
-      .analyze();
+    const results = await buildScan(page).analyze();
 
     expect(results.violations).toEqual([]);
   });
@@ -44,10 +70,7 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
     // Ensure the Production tab is active (it is the default, but be explicit)
     await page.getByRole('tab', { name: 'Production', exact: true }).click();
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .exclude('canvas')
-      .analyze();
+    const results = await buildScan(page).analyze();
 
     expect(results.violations).toEqual([]);
   });
@@ -62,10 +85,7 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
     // Switch to the Inputs tab
     await page.getByRole('tab', { name: 'Inputs', exact: true }).click();
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .exclude('canvas')
-      .analyze();
+    const results = await buildScan(page).analyze();
 
     expect(results.violations).toEqual([]);
   });
@@ -80,10 +100,47 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
     // Switch to the Recipes tab
     await page.getByRole('tab', { name: 'Recipes', exact: true }).click();
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .exclude('canvas')
-      .analyze();
+    const results = await buildScan(page).analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('Reset-confirmation modal has no WCAG A/AA violations', async ({ page }) => {
+    await page.goto('/');
+
+    // Open the control panel drawer
+    const openPanelBtn = page.getByRole('button', { name: 'Open Control Panel' });
+    await openPanelBtn.click();
+
+    // Open the reset-confirmation modal
+    await page.getByRole('button', { name: 'Reset ALL Factory Options' }).click();
+
+    // Wait for the modal dialog to be present before scanning
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    // Scope the scan to the dialog itself: the open Modal renders a translucent
+    // overlay that dims the (inert, aria-hidden) page behind it, which would
+    // otherwise lower the composited contrast of background elements. The
+    // transient surface under test is the dialog.
+    const results = await buildScan(page).include('[role="dialog"]').analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('Share-link "copied" popover has no WCAG A/AA violations', async ({ page }) => {
+    await page.goto('/');
+
+    // Open the control panel drawer
+    const openPanelBtn = page.getByRole('button', { name: 'Open Control Panel' });
+    await openPanelBtn.click();
+
+    // Clicking the share input opens the "Link copied!" popover directly,
+    // avoiding the backend round-trip the "Save & Share" button performs.
+    await page.getByPlaceholder('Save factory to generate a link').click();
+
+    await expect(page.getByText('Link copied!')).toBeVisible();
+
+    const results = await buildScan(page).analyze();
 
     expect(results.violations).toEqual([]);
   });
@@ -112,10 +169,7 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
     // Switch to the Factory Report tab
     await page.getByRole('tab', { name: 'Factory Report' }).click();
 
-    const results = await new AxeBuilder({ page })
-      .withTags(['wcag2a', 'wcag2aa'])
-      .exclude('canvas')
-      .analyze();
+    const results = await buildScan(page).analyze();
 
     expect(results.violations).toEqual([]);
   });


### PR DESCRIPTION
Implements the automatable follow-ups from the accessibility assessment tooling work. Closes #93.

## Changes

- **ESLint strict**: promote `jsx-a11y` from `recommended` to `strict` (`client/eslint.config.mjs`). Lint passes with no new errors.
- **More jest-axe component tests**: `Card` and `SiteHeader` (the latter mocks `GameDataContext`, exercising the game-version `Select` and icon-button form controls).
- **Transient-state axe scans** (`client/tests/a11y.spec.ts`): the reset-confirmation modal and the share-link "copied" popover.
- **Cross-browser e2e**: add Firefox + WebKit Playwright projects alongside Chromium; install all three in CI.
  - Scans disable CSS transitions/animations so axe never samples an element mid-fade.
  - `color-contrast` is dropped **on WebKit only** via a `buildScan` helper — headless WebKit's colour management diverges from real sRGB and flakes on borderline brand colours (~4.3 vs ~4.77:1) that pass reliably on Chromium + Firefox, which stay authoritative.
- **Lighthouse ratchet**: bump a11y `minScore` 0.95 → 0.98 (measured 1.0).

## Real bugs fixed

The new transient-state scans surfaced two genuine WCAG violations, fixed in `PlannerOptions`:
- The modal **close (X) button had no accessible name** → added `aria-label="Close"`.
- The modal **Cancel/Reset buttons failed colour contrast** (Cancel was white-on-light at 1.16:1; Reset used `color='red'` at 3.28:1) → Cancel now uses the readable theme text colour, Reset uses the app's accessible `danger.8`.

## Out of scope

- Manual keyboard-only + NVDA screen-reader walkthrough (issue checkbox #5 — cannot be automated).
- Graph `canvas` axe coverage remains excluded (separate tracked follow-up).

## Verification

- `npm run lint` — clean (0 errors).
- `npm run test` — 80 unit tests pass (incl. new Card + SiteHeader a11y tests).
- `npm run test:e2e` — all 21 scans (7 × 3 browsers) pass; stable across 3 consecutive runs.
- `npm run build && npm run a11y:lhci` — accessibility score 1.0, passes `minScore` 0.98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
