### PR TITLE
fix(ci): launch Firefox/WebKit in container + clear frontend warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       options: --ipc=host
+    # GitHub sets HOME=/github/home for container jobs and that dir isn't owned
+    # by root, so Firefox/WebKit refuse to launch ("$HOME isn't owned by the
+    # current user"). Point HOME at the root-owned /root, as Playwright advises.
+    env:
+      HOME: /root
 
     steps:
       - uses: actions/checkout@v6

--- a/client/index.html
+++ b/client/index.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="A tool for planning factories in Satisfactory" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/public/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="/public/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="/public/favicon-16x16.png">
-    <link rel="manifest" href="/public/site.webmanifest">
-    <link rel="mask-icon" href="/public/safari-pinned-tab.svg" color="#333333">
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
+    <link rel="manifest" href="/site.webmanifest">
+    <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#333333">
     <meta name="msapplication-TileColor" content="#444444">
     <meta name="theme-color" content="#333333">
     <meta http-equiv='cache-control' content='no-cache'>

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -129,7 +129,6 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
       worker.terminate();
       debouncedSolveRef.current = null;
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleCalculateFactory = useCallback(() => {

--- a/client/src/contexts/production/reducer.tsx
+++ b/client/src/contexts/production/reducer.tsx
@@ -201,7 +201,6 @@ export function reducer(state: FactoryOptions, action: FactoryAction): FactoryOp
               } else if (newItem.mode === 'maximize') {
                 let nextPriority = MAX_PRIORITY;
                 while (nextPriority && nextPriority > 0) {
-                  // eslint-disable-next-line no-loop-func
                   const priorityTaken = !!state.productionItems.find((i) => i.mode === 'maximize' && i.value === String(nextPriority));
                   if (!priorityTaken) {
                     break;


### PR DESCRIPTION
Follow-up to #98. The first `build-frontend` run in the new CI image failed at the e2e step, plus the run had several warnings.

## Error — Firefox/WebKit fail to launch as root
GitHub sets `HOME=/github/home` for container jobs, and that directory isn't owned by root, so Firefox/WebKit refuse to start (`$HOME isn't owned by the current user`). Chromium tolerated it, so the first ~21 tests passed before the rest failed. Fix: set `HOME=/root` on the `build-frontend` job, the workaround Playwright's own error message prescribes.

## Warnings cleared
- **`index.html`** referenced icons as `/public/apple-touch-icon.png` etc. Vite serves `public/` at the root, so these 404'd in production and flooded the e2e dev-server log with `Files in the public directory are served at the root path` warnings. Changed to `/apple-touch-icon.png` etc.
- Removed two dead `eslint-disable` directives (`react-hooks/exhaustive-deps` in `production/index.tsx`, `no-loop-func` in `production/reducer.tsx`) that no longer suppress anything.

## Verification (CI image, GitHub `HOME` ownership reproduced + `HOME=/root`)
- lint clean (0 warnings)
- build ok
- **63/63 Playwright e2e pass across chromium/firefox/webkit**
- no `/public/` WebServer warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)