### PR TITLE
fix(ci): scope HOME to e2e step + silence expected-error test log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,11 +57,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
       options: --ipc=host
-    # GitHub sets HOME=/github/home for container jobs and that dir isn't owned
-    # by root, so Firefox/WebKit refuse to launch ("$HOME isn't owned by the
-    # current user"). Point HOME at the root-owned /root, as Playwright advises.
-    env:
-      HOME: /root
 
     steps:
       - uses: actions/checkout@v6
@@ -93,8 +88,15 @@ jobs:
       # Blocking gate: the scanned surfaces must report zero WCAG 2.0 A/AA
       # violations (axe-core via Playwright). The graph canvas is excluded as a
       # separate tracked follow-up; see client/tests/a11y.spec.ts.
+      # GitHub sets HOME=/github/home for container jobs and that dir isn't
+      # owned by root, so Firefox/WebKit refuse to launch ("$HOME isn't owned
+      # by the current user"). Point HOME at the root-owned /root, as Playwright
+      # advises. Scoped to this step only — a job-level HOME leaks to the host
+      # runner and breaks its docker config lookup (/root/.docker/config.json).
       - name: Accessibility e2e (axe)
         working-directory: client
+        env:
+          HOME: /root
         run: npm run test:e2e
 
       - name: Upload accessibility reports

--- a/client/src/contexts/production/reducer.test.ts
+++ b/client/src/contexts/production/reducer.test.ts
@@ -492,12 +492,18 @@ describe('reducer', () => {
     });
 
     it('returns initial state on error', () => {
+      // The reducer logs the caught error via console.error; silence it here
+      // (and assert it fired) so this expected-error path doesn't print a
+      // TypeError to the test output.
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       const result = reducer(createInitialState(), {
         type: 'LOAD_FROM_SHARED_FACTORY',
         config: null,
         gameData: mockGameData,
       });
       expect(result.productionItems).toEqual([]);
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
Cleans up two noisy outputs in the (passing) `build-frontend` run.

## `WARNING: Error loading config file: open /root/.docker/config.json: permission denied`
The job-level `env: HOME: /root` added in #99 (so Firefox/WebKit launch) leaks into the **host runner**. The runner then invokes `docker exec` for each step with `HOME=/root` and, running as the non-root `runner` user, can't read `/root/.docker/config.json` — so the warning prints on every step.

Fix: move `HOME: /root` to the **Playwright e2e step only**. It's the only step that needs it (Chromium/Lighthouse tolerate the default `HOME`), and step-level env is injected into the container step without changing the host runner's `HOME`.

## `TypeError: Cannot read properties of null (reading 'productionItems')` in unit tests
The `LOAD_FROM_SHARED_FACTORY > returns initial state on error` test passes `config: null` on purpose to exercise the reducer's catch path, which logs the caught error via `console.error`. The behavior is correct (the test passes); only the log is noise.

Fix: spy on `console.error` in that test (silence + assert it fired). Production logging is unchanged.

## Verification (CI image, GitHub `HOME` ownership reproduced)
- 80 unit tests pass, **no TypeError in output**
- Firefox launches with step-scoped `HOME=/root`

🤖 Generated with [Claude Code](https://claude.com/claude-code)