### PR TITLE
fix(ci): drop invalid skip_api_build input from SWA deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,4 +191,3 @@ jobs:
           action: upload
           app_location: client/dist
           skip_app_build: true
-          skip_api_build: true


### PR DESCRIPTION
The Deploy to Azure job logged an annotation on every run:

> Unexpected input(s) 'skip_api_build', valid inputs are ['entryPoint', 'args', 'action', 'app_location', 'azure_static_web_apps_api_token', 'api_build_command', 'api_location', 'app_artifact_location', 'output_location', 'app_build_command', 'repo_token', 'routes_location', 'skip_app_build']

`Azure/static-web-apps-deploy@v1` accepts `skip_app_build` but not `skip_api_build`, so the input was silently ignored and warned. No `api_location` is configured, so no API is built/deployed regardless — removing the invalid input clears the warning with no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)