### PR TITLE
fix(ci): skip Playwright chromium download during .NET build in CI

### DIFF
--- a/YetAnotherFactoryPlanner.IntegrationTests/YetAnotherFactoryPlanner.IntegrationTests.csproj
+++ b/YetAnotherFactoryPlanner.IntegrationTests/YetAnotherFactoryPlanner.IntegrationTests.csproj
@@ -32,7 +32,14 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
-  <Target Name="InstallPlaywright" AfterTargets="Build">
+  <!--
+    Install the Playwright browser after building so a local `dotnet test` of
+    this project has Chromium available. Skipped when CI=true (set by GitHub
+    Actions): CI builds the solution but never runs these integration tests, so
+    the download is wasted and made the .NET build flaky (transient ECONNRESET).
+    When these tests are added to CI, install browsers in a dedicated step.
+  -->
+  <Target Name="InstallPlaywright" AfterTargets="Build" Condition="'$(CI)' != 'true'">
     <Exec Command="pwsh $(OutputPath)playwright.ps1 install chromium" />
   </Target>
 


### PR DESCRIPTION
## Symptom
The **Build & Test (.NET)** job failed at the Build step:

```
error MSB3077: The command "pwsh bin/Release/net10.0/playwright.ps1 install chromium"
exited with return value 0, but errors were detected during execution.
EXEC : error : read ECONNRESET [YetAnotherFactoryPlanner.IntegrationTests.csproj]
```

## Cause
`YetAnotherFactoryPlanner.IntegrationTests` installs Chromium after every build (`<Target AfterTargets="Build">` → `playwright.ps1 install chromium`). CI's `dotnet build api.sln` triggers it, and a **transient `ECONNRESET`** during that download failed the whole .NET build. It's also wasted work: CI's test step runs `api.Tests` only (`--no-build`), so these integration tests never execute in CI.

## Fix
Gate the install target on `Condition="'$(CI)' != 'true'"` (GitHub Actions sets `CI=true`, which MSBuild reads as a property). Local `dotnet test` of the integration project still installs Chromium as before; CI stops downloading it entirely — removing both the flakiness and the wasted time. When these integration tests are wired into CI, browsers should be installed in a dedicated step.

## Verification
`CI=true dotnet build YetAnotherFactoryPlanner.IntegrationTests.csproj -c Release` → **Build succeeded, 0 errors**, with the `InstallPlaywright` target skipped (no `install chromium` Exec).

Note: the failing run's root cause was a transient network error unrelated to PR #101 (which only edits the SWA deploy input); this PR removes the underlying fragility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)