### PR TITLE
ci: auto-install Playwright browsers and pin CI image to locked version

### DIFF
--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -55,6 +55,10 @@ jobs:
           context: client
           file: client/Dockerfile.ci
           push: true
+          # Pin the Playwright base image to the locked @playwright/test version
+          # so the baked browsers always match the client (no manual tag bump).
+          build-args: |
+            PLAYWRIGHT_VERSION=${{ steps.pw.outputs.version }}
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:pw-${{ steps.pw.outputs.version }}

--- a/client/Dockerfile.ci
+++ b/client/Dockerfile.ci
@@ -3,10 +3,14 @@
 # client's npm dependencies so the GitHub Actions `build-frontend` job no longer
 # pays the per-run cost of `npm ci` + `playwright install --with-deps`.
 #
-# IMPORTANT: the base image tag is coupled to the @playwright/test version in
-# client/package-lock.json (currently 1.58.2). When Playwright is bumped, bump
-# this tag to match or the baked browsers won't match the installed client.
-FROM mcr.microsoft.com/playwright:v1.58.2-noble
+# The base image tag MUST match the @playwright/test version in
+# client/package-lock.json, or the baked browsers won't match the installed
+# client (the version/browser-build mismatch class of failure). To keep them in
+# lockstep automatically, build-ci-image.yml resolves the locked Playwright
+# version and passes it as the PLAYWRIGHT_VERSION build arg. The default below is
+# only a fallback for ad-hoc local `docker build` invocations without --build-arg.
+ARG PLAYWRIGHT_VERSION=1.58.2
+FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-noble
 
 # The Playwright image ships Node 24, but the rest of CI (and the deploy build)
 # standardizes on Node 20. Pin Node 20 here for parity so tests/build run under

--- a/client/package.json
+++ b/client/package.json
@@ -18,8 +18,12 @@
         "deploy": "az storage blob upload-batch --account-name yafp -s ./dist -d '$web' --auth-mode login --overwrite",
         "test": "vitest run",
         "test:watch": "vitest",
+        "playwright:install": "playwright install",
+        "pretest:e2e": "npm run playwright:install",
         "test:e2e": "playwright test",
+        "pretest:e2e:ui": "npm run playwright:install",
         "test:e2e:ui": "playwright test --ui",
+        "pretest:e2e:headed": "npm run playwright:install",
         "test:e2e:headed": "playwright test --headed",
         "lint": "eslint \"src/**/*.{ts,tsx}\"",
         "a11y:lhci": "lhci autorun"


### PR DESCRIPTION
## Why

Running `npm run test:e2e` locally failed all 21 specs with the same root cause: the Playwright browser binaries for the pinned `@playwright/test` version weren't present, so every spec died at `browserType.launch` before the app was ever exercised:

```
Error: browserType.launch: Executable doesn't exist at
...ms-playwright\chromium_headless_shell-1208\chrome-headless-shell-win64\...
```

The cache held browser builds from *other* Playwright versions (1169/1217/1223) but not the one the locked version (1.58.2) needs (1208). `npx playwright install` fixed it locally — this PR makes that automatic and hardens CI against the same class of failure.

## Changes

**Local — self-healing e2e (`client/package.json`)**
- Add a `playwright:install` script and `pretest:e2e` / `pretest:e2e:ui` / `pretest:e2e:headed` hooks that run `playwright install` before the matching e2e script.
- This is a fast **no-op** when the browsers are already present (no network, no download) and an auto-download when they're missing — so a fresh checkout or a Playwright bump no longer leaves contributors with a wall of red.

**CI — eliminate base-image drift (`client/Dockerfile.ci`, `.github/workflows/build-ci-image.yml`)**
- The `build-frontend` job runs inside the prebuilt `frontend-ci` image, which bakes browsers from `mcr.microsoft.com/playwright:vX-noble`. That base tag was *manually* coupled to the locked Playwright version (per the Dockerfile's own comment), so a Playwright bump without a matching tag edit reintroduces the exact version/browser mismatch in CI.
- Drive the base tag from a `PLAYWRIGHT_VERSION` build arg, resolved from `package-lock.json` in `build-ci-image.yml`. The image now always matches the client — no manual tag bump.

## Verification

- `npm run test:e2e -- --project=chromium`: the `pretest:e2e` hook runs `playwright install` (no-op, no download) and **21/21 pass**.
- Dockerfile change is a standard `ARG`-before-`FROM` pattern; the workflow already resolves the locked version (`steps.pw.outputs.version`) and now feeds it to the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)