### PR TITLE
fix: get all integration tests to 13/13 green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ playwright-report/
 *.png
 .playwright-cli/
 .playwright-mcp/
+.playwright/
+
+# Agent skills (installed locally, not part of the repo)
+.agents/
 
 # Environment
 .env.local

--- a/YetAnotherFactoryPlanner.AppHost/AppHost.cs
+++ b/YetAnotherFactoryPlanner.AppHost/AppHost.cs
@@ -54,6 +54,12 @@ if (builder.ExecutionContext.IsRunMode &&
     var client = builder.AddViteApp("client", "../client")
         .WithReference(api)
         .WithEnvironment("VITE_REACT_APP_API_BASE_URL", api.GetEndpoint("http"))
+        // AddViteApp sets NODE_ENV from Environment.IsDevelopment(), which only matches the
+        // literal "Development" environment name. In "Testing" that resolves to NODE_ENV=production,
+        // which makes @vitejs/plugin-react skip injecting the React-Refresh preamble — every
+        // component module then throws "$RefreshReg$ is not defined" on load and the app never
+        // mounts. Force dev mode here so Playwright-driven integration tests get a working app.
+        .WithEnvironment("NODE_ENV", "development")
         .WaitFor(api);
 }
 

--- a/YetAnotherFactoryPlanner.IntegrationTests/ControlPanelPlaywrightTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/ControlPanelPlaywrightTests.cs
@@ -121,7 +121,11 @@ public sealed class ControlPanelPlaywrightTests(AppHostFixture appHost, BrowserF
 
 	private static async Task SetAmountAsync(IPage page, string amount)
 	{
-		var amountInput = page.GetByLabel("Amount").First;
+		// The production-goal row's amount field only has a placeholder, not a <label>
+		// or aria-label — GetByLabel("Amount") instead substring-matches the Inputs tab's
+		// item-specific aria-labels (e.g. "Iron Ore amount"), which live on a different,
+		// inactive tab.
+		var amountInput = page.GetByPlaceholder("Amount").First;
 		await amountInput.ClickAsync();
 		await amountInput.FillAsync(amount);
 	}

--- a/YetAnotherFactoryPlanner.IntegrationTests/GraphPlaywrightTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/GraphPlaywrightTests.cs
@@ -140,7 +140,11 @@ public sealed class GraphPlaywrightTests(AppHostFixture appHost, BrowserFixture 
 
 	private static async Task SetAmountAsync(IPage page, string amount)
 	{
-		var amountInput = page.GetByLabel("Amount").First;
+		// The production-goal row's amount field only has a placeholder, not a <label>
+		// or aria-label — GetByLabel("Amount") instead substring-matches the Inputs tab's
+		// item-specific aria-labels (e.g. "Iron Ore amount"), which live on a different,
+		// inactive tab.
+		var amountInput = page.GetByPlaceholder("Amount").First;
 		await amountInput.ClickAsync();
 		await amountInput.FillAsync(amount);
 	}

--- a/YetAnotherFactoryPlanner.IntegrationTests/YetAnotherFactoryPlanner.IntegrationTests.csproj
+++ b/YetAnotherFactoryPlanner.IntegrationTests/YetAnotherFactoryPlanner.IntegrationTests.csproj
@@ -38,9 +38,12 @@
     Actions): CI builds the solution but never runs these integration tests, so
     the download is wasted and made the .NET build flaky (transient ECONNRESET).
     When these tests are added to CI, install browsers in a dedicated step.
+
+    Uses bash + the bundled node driver directly instead of playwright.ps1, so
+    this doesn't depend on PowerShell being installed.
   -->
   <Target Name="InstallPlaywright" AfterTargets="Build" Condition="'$(CI)' != 'true'">
-    <Exec Command="pwsh $(OutputPath)playwright.ps1 install chromium" />
+    <Exec Command="bash $(MSBuildThisFileDirectory)../scripts/install-playwright-browsers.sh $(OutputPath) install chromium" />
   </Target>
 
 </Project>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -125,60 +125,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/compat-data": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/core": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.29.7",
-                "@babel/generator": "^7.29.7",
-                "@babel/helper-compilation-targets": "^7.29.7",
-                "@babel/helper-module-transforms": "^7.29.7",
-                "@babel/helpers": "^7.29.7",
-                "@babel/parser": "^7.29.7",
-                "@babel/template": "^7.29.7",
-                "@babel/traverse": "^7.29.7",
-                "@babel/types": "^7.29.7",
-                "@jridgewell/remapping": "^2.3.5",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@babel/core/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@babel/generator": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -209,46 +155,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/compat-data": "^7.29.7",
-                "@babel/helper-validator-option": "^7.29.7",
-                "browserslist": "^4.24.0",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-            "dev": true,
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "yallist": "^3.0.2"
-            }
-        },
-        "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "dev": true,
-            "license": "ISC",
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/@babel/helper-globals": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
@@ -271,25 +177,6 @@
             },
             "engines": {
                 "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-module-transforms": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.29.7",
-                "@babel/helper-validator-identifier": "^7.29.7",
-                "@babel/traverse": "^7.29.7"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
@@ -318,32 +205,6 @@
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helper-validator-option": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/helpers": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/template": "^7.29.7",
-                "@babel/types": "^7.29.7"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -1533,18 +1394,6 @@
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
-        "node_modules/@jridgewell/remapping": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            }
-        },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
@@ -2683,7 +2532,7 @@
             "version": "19.2.17",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
             "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-            "devOptional": true,
+            "dev": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -3666,20 +3515,6 @@
                 "bare-path": "^3.0.0"
             }
         },
-        "node_modules/baseline-browser-mapping": {
-            "version": "2.10.38",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "peer": true,
-            "bin": {
-                "baseline-browser-mapping": "dist/cli.cjs"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            }
-        },
         "node_modules/basic-ftp": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
@@ -3766,41 +3601,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
-                "update-browserslist-db": "^1.2.3"
-            },
-            "bin": {
-                "browserslist": "cli.js"
-            },
-            "engines": {
-                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
         "node_modules/buffer-crc32": {
@@ -3900,28 +3700,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/caniuse-lite": {
-            "version": "1.0.30001799",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "CC-BY-4.0",
-            "peer": true
         },
         "node_modules/chai": {
             "version": "6.2.2",
@@ -4610,14 +4388,6 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/electron-to-chromium": {
-            "version": "1.5.375",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
-            "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
-            "dev": true,
-            "license": "ISC",
-            "peer": true
         },
         "node_modules/email-addresses": {
             "version": "5.0.0",
@@ -5798,17 +5568,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/gensync": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/get-caller-file": {
@@ -7178,20 +6937,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "bin": {
-                "json5": "lib/cli.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/jsonfile": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -8163,17 +7908,6 @@
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/node-releases": {
-            "version": "2.0.47",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/nwsapi": {
@@ -10547,38 +10281,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/browserslist"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/browserslist"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "escalade": "^3.2.0",
-                "picocolors": "^1.1.1"
-            },
-            "bin": {
-                "update-browserslist-db": "cli.js"
-            },
-            "peerDependencies": {
-                "browserslist": ">= 4.21.0"
-            }
-        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -11149,14 +10851,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true,
-            "license": "ISC",
-            "peer": true
-        },
         "node_modules/yargs": {
             "version": "15.4.1",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
@@ -11322,46 +11016,6 @@
                 "picocolors": "^1.1.1"
             }
         },
-        "@babel/compat-data": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
-            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
-            "dev": true,
-            "peer": true
-        },
-        "@babel/core": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
-            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "@babel/code-frame": "^7.29.7",
-                "@babel/generator": "^7.29.7",
-                "@babel/helper-compilation-targets": "^7.29.7",
-                "@babel/helper-module-transforms": "^7.29.7",
-                "@babel/helpers": "^7.29.7",
-                "@babel/parser": "^7.29.7",
-                "@babel/template": "^7.29.7",
-                "@babel/traverse": "^7.29.7",
-                "@babel/types": "^7.29.7",
-                "@jridgewell/remapping": "^2.3.5",
-                "convert-source-map": "^2.0.0",
-                "debug": "^4.1.0",
-                "gensync": "^1.0.0-beta.2",
-                "json5": "^2.2.3",
-                "semver": "^6.3.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-                    "dev": true,
-                    "peer": true
-                }
-            }
-        },
         "@babel/generator": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
@@ -11384,39 +11038,6 @@
                 "@babel/types": "^7.27.3"
             }
         },
-        "@babel/helper-compilation-targets": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
-            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "@babel/compat-data": "^7.29.7",
-                "@babel/helper-validator-option": "^7.29.7",
-                "browserslist": "^4.24.0",
-                "lru-cache": "^5.1.1",
-                "semver": "^6.3.1"
-            },
-            "dependencies": {
-                "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-                    "dev": true,
-                    "peer": true,
-                    "requires": {
-                        "yallist": "^3.0.2"
-                    }
-                },
-                "semver": {
-                    "version": "6.3.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-                    "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-                    "dev": true,
-                    "peer": true
-                }
-            }
-        },
         "@babel/helper-globals": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
@@ -11431,18 +11052,6 @@
             "requires": {
                 "@babel/traverse": "^7.29.7",
                 "@babel/types": "^7.29.7"
-            }
-        },
-        "@babel/helper-module-transforms": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
-            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "@babel/helper-module-imports": "^7.29.7",
-                "@babel/helper-validator-identifier": "^7.29.7",
-                "@babel/traverse": "^7.29.7"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -11462,24 +11071,6 @@
             "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
             "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true
-        },
-        "@babel/helper-validator-option": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
-            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
-            "dev": true,
-            "peer": true
-        },
-        "@babel/helpers": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
-            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "@babel/template": "^7.29.7",
-                "@babel/types": "^7.29.7"
-            }
         },
         "@babel/parser": {
             "version": "7.29.7",
@@ -11544,8 +11135,7 @@
         "@commander-js/extra-typings": {
             "version": "13.1.0",
             "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-13.1.0.tgz",
-            "integrity": "sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg==",
-            "requires": {}
+            "integrity": "sha512-q5P52BYb1hwVWE6dtID7VvuJWrlfbCv4klj7BjUUOqMz4jbSZD4C9fJ9lRjL2jnBGTg+gDDlaXN51rkWcLk4fg=="
         },
         "@csstools/color-helpers": {
             "version": "5.1.0",
@@ -11557,8 +11147,7 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
             "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@csstools/css-color-parser": {
             "version": "3.1.0",
@@ -11574,8 +11163,7 @@
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
             "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@csstools/css-tokenizer": {
             "version": "3.0.4",
@@ -12030,8 +11618,7 @@
         "@fortawesome/react-fontawesome": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.2.0.tgz",
-            "integrity": "sha512-E9Gu1hqd6JussVO26EC4WqRZssXMnQr2ol7ZNWkkFOH8jZUaxDJ9Z9WF9wIVkC+kJGXUdY3tlffpDwEKfgQrQw==",
-            "requires": {}
+            "integrity": "sha512-E9Gu1hqd6JussVO26EC4WqRZssXMnQr2ol7ZNWkkFOH8jZUaxDJ9Z9WF9wIVkC+kJGXUdY3tlffpDwEKfgQrQw=="
         },
         "@humanfs/core": {
             "version": "0.19.2",
@@ -12129,17 +11716,6 @@
                 "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
-        "@jridgewell/remapping": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-            "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "@jridgewell/gen-mapping": "^0.3.5",
-                "@jridgewell/trace-mapping": "^0.3.24"
-            }
-        },
         "@jridgewell/resolve-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
@@ -12213,8 +11789,7 @@
         "@mantine/hooks": {
             "version": "9.3.1",
             "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.3.1.tgz",
-            "integrity": "sha512-zAOlxV59j5CDgAnExN+ypaR6dVW1vwMKDvKUxIlUVd/e52qxYnPyYRD+shJmyOLaZRuQmVF0R/7mJAjt2jw9cA==",
-            "requires": {}
+            "integrity": "sha512-zAOlxV59j5CDgAnExN+ypaR6dVW1vwMKDvKUxIlUVd/e52qxYnPyYRD+shJmyOLaZRuQmVF0R/7mJAjt2jw9cA=="
         },
         "@napi-rs/wasm-runtime": {
             "version": "1.1.5",
@@ -12606,8 +12181,7 @@
             "version": "14.6.1",
             "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
             "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@tootallnate/quickjs-emscripten": {
             "version": "0.23.0",
@@ -12908,7 +12482,7 @@
             "version": "19.2.17",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
             "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-            "devOptional": true,
+            "dev": true,
             "requires": {
                 "csstype": "^3.2.2"
             }
@@ -12927,8 +12501,7 @@
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@types/seedrandom": {
             "version": "3.0.8",
@@ -13031,8 +12604,7 @@
             "version": "8.61.1",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
             "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "@typescript-eslint/type-utils": {
             "version": "8.61.1",
@@ -13242,8 +12814,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "agent-base": {
             "version": "7.1.4",
@@ -13453,8 +13024,7 @@
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
             "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "babel-plugin-styled-components": {
             "version": "2.3.0",
@@ -13478,8 +13048,7 @@
             "version": "2.9.1",
             "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
             "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "bare-fs": {
             "version": "4.7.2",
@@ -13528,13 +13097,6 @@
             "requires": {
                 "bare-path": "^3.0.0"
             }
-        },
-        "baseline-browser-mapping": {
-            "version": "2.10.38",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-            "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
-            "dev": true,
-            "peer": true
         },
         "basic-ftp": {
             "version": "5.3.1",
@@ -13606,20 +13168,6 @@
                 "fill-range": "^7.1.1"
             }
         },
-        "browserslist": {
-            "version": "4.28.2",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "baseline-browser-mapping": "^2.10.12",
-                "caniuse-lite": "^1.0.30001782",
-                "electron-to-chromium": "^1.5.328",
-                "node-releases": "^2.0.36",
-                "update-browserslist-db": "^1.2.3"
-            }
-        },
         "buffer-crc32": {
             "version": "0.2.13",
             "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -13679,13 +13227,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
             "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="
-        },
-        "caniuse-lite": {
-            "version": "1.0.30001799",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-            "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
-            "dev": true,
-            "peer": true
         },
         "chai": {
             "version": "6.2.2",
@@ -13970,8 +13511,7 @@
         "cytoscape-popper": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/cytoscape-popper/-/cytoscape-popper-4.0.1.tgz",
-            "integrity": "sha512-u2gYDMMvGSlAJbNfKvMljOM/p+BrHu0A4VcpELa+xJf54HoMn+nV0iuhALZx+O89b74SKJRy7jYo2WfkD5uvsw==",
-            "requires": {}
+            "integrity": "sha512-u2gYDMMvGSlAJbNfKvMljOM/p+BrHu0A4VcpELa+xJf54HoMn+nV0iuhALZx+O89b74SKJRy7jYo2WfkD5uvsw=="
         },
         "damerau-levenshtein": {
             "version": "1.0.8",
@@ -14178,13 +13718,6 @@
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true
-        },
-        "electron-to-chromium": {
-            "version": "1.5.375",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
-            "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
-            "dev": true,
-            "peer": true
         },
         "email-addresses": {
             "version": "5.0.0",
@@ -14526,8 +14059,7 @@
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
             "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-scope": {
             "version": "8.4.0",
@@ -14788,8 +14320,7 @@
             "version": "6.5.0",
             "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
             "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "figures": {
             "version": "2.0.0",
@@ -15003,13 +14534,6 @@
             "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
             "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
             "dev": true
-        },
-        "gensync": {
-            "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-            "dev": true,
-            "peer": true
         },
         "get-caller-file": {
             "version": "2.0.5",
@@ -15911,13 +15435,6 @@
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
         },
-        "json5": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-            "dev": true,
-            "peer": true
-        },
         "jsonfile": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
@@ -16083,8 +15600,7 @@
                     "version": "7.5.11",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
                     "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-                    "dev": true,
-                    "requires": {}
+                    "dev": true
                 },
                 "yargs": {
                     "version": "17.7.2",
@@ -16520,13 +16036,6 @@
                     }
                 }
             }
-        },
-        "node-releases": {
-            "version": "2.0.47",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
-            "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
-            "dev": true,
-            "peer": true
         },
         "nwsapi": {
             "version": "2.2.23",
@@ -17071,8 +16580,7 @@
         "react-number-format": {
             "version": "5.4.5",
             "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.5.tgz",
-            "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==",
-            "requires": {}
+            "integrity": "sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw=="
         },
         "react-remove-scroll": {
             "version": "2.7.2",
@@ -17977,8 +17485,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
             "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "tslib": {
             "version": "2.8.1",
@@ -18134,17 +17641,6 @@
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "dev": true
-        },
-        "update-browserslist-db": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-            "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-            "dev": true,
-            "peer": true,
-            "requires": {
-                "escalade": "^3.2.0",
-                "picocolors": "^1.1.1"
-            }
         },
         "uri-js": {
             "version": "4.4.1",
@@ -18422,8 +17918,7 @@
             "version": "8.21.0",
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
             "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "xdg-basedir": {
             "version": "4.0.0",
@@ -18448,13 +17943,6 @@
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
             "dev": true
-        },
-        "yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-            "dev": true,
-            "peer": true
         },
         "yargs": {
             "version": "15.4.1",

--- a/client/src/containers/ProductionPlanner/index.tsx
+++ b/client/src/containers/ProductionPlanner/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Loader, Divider, Text, Title } from '@mantine/core';
+import { Loader, Divider, Text, Title, Button } from '@mantine/core';
 import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 import bgImage from '../../assets/stripe-bg.png';
@@ -48,6 +48,12 @@ const ProductionPlanner = () => {
                   <Title style={{ marginTop: '15px' }}>
                     An error occurred connecting to the server x_x
                   </Title>
+                  <Button
+                    style={{ marginTop: '20px' }}
+                    onClick={() => { window.location.href = window.location.pathname; }}
+                  >
+                    Start a new factory
+                  </Button>
                 </>
               ) : (
                 <>

--- a/scripts/install-playwright-browsers.sh
+++ b/scripts/install-playwright-browsers.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Installs Playwright browsers for a .NET test project's build output, without
+# requiring PowerShell (the official playwright.ps1 wrapper just loads
+# Microsoft.Playwright.dll and forwards args to it; this calls the same
+# bundled node driver directly).
+set -euo pipefail
+
+output_dir="$1"
+shift
+
+node_bin=$(find "$output_dir/.playwright/node" -maxdepth 2 -type f \( -name node -o -name node.exe \) | head -n1)
+if [ -z "$node_bin" ]; then
+  echo "Could not find bundled Playwright node driver under $output_dir/.playwright/node" >&2
+  exit 1
+fi
+
+"$node_bin" "$output_dir/.playwright/package/cli.js" "$@"


### PR DESCRIPTION
## Summary

- **`NODE_ENV=development` for Testing environment** (`AppHost.cs`): `AddViteApp`'s `WithNodeDefaults()` derives `NODE_ENV` from `Environment.IsDevelopment()`, which only returns `true` for the literal `"Development"` environment name. Under `"Testing"` (used by the Aspire test fixture), `NODE_ENV` was `production`, causing `@vitejs/plugin-react` to skip injecting the React-Refresh preamble into `index.html`. Every `.tsx` module then threw `$RefreshReg$ is not defined` on load and the React root never mounted — all 7 UI Playwright tests timed out.
- **`GetByPlaceholder` instead of `GetByLabel` for amount input** (`ControlPanelPlaywrightTests.cs`, `GraphPlaywrightTests.cs`): The production-goal row's amount field uses `placeholder='Amount'`, not an `aria-label`. A prior refactor added item-specific `aria-label`s to the Inputs tab (e.g. `"Iron Ore amount"`), so `GetByLabel("Amount")` started substring-matching those invisible off-tab fields instead of the intended input.
- **"Start a new factory" recovery button on error screen** (`ProductionPlanner/index.tsx` — Bug 2): The API-error overlay had no recovery action. Added a button that strips the bad `?factory=` query param by navigating to `window.location.pathname`.
- **Bash-based Playwright browser install** (`scripts/install-playwright-browsers.sh`, `.csproj`): The MSBuild `InstallPlaywright` target called `pwsh playwright.ps1`, requiring PowerShell. Replaced with a bash wrapper that invokes the bundled Node driver directly.
- **`.gitignore`**: Added `.playwright/` (local browser binaries) and `.agents/` (locally installed agent skills).

## Test plan

- [x] `dotnet test YetAnotherFactoryPlanner.IntegrationTests` — **13/13 passed** (was 6/13 before)
- [x] `dotnet test api.Tests` — 34/34 passed (unchanged)
- [x] `npm run test` (Vitest) — 108/108 passed (unchanged)
- [x] `npm run test:e2e` (Playwright e2e) — 63/63 passed (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)