### PR TITLE
fix: bump MessagePack transitive pin to 2.5.302

### DIFF
--- a/YetAnotherFactoryPlanner.AppHost/YetAnotherFactoryPlanner.AppHost.csproj
+++ b/YetAnotherFactoryPlanner.AppHost/YetAnotherFactoryPlanner.AppHost.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <!-- Pin transitive MessagePack (via StreamJsonRpc) to patched version for CVE-2026-48109 / GHSA-hv8m-jj95-wg3x -->
-    <PackageReference Include="MessagePack" Version="2.5.301" />
-    <PackageReference Include="MessagePack.Annotations" Version="2.5.301" />
+    <PackageReference Include="MessagePack" Version="2.5.302" />
+    <PackageReference Include="MessagePack.Annotations" Version="2.5.302" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Bumps the `MessagePack` and `MessagePack.Annotations` transitive pin in `YetAnotherFactoryPlanner.AppHost` from `2.5.301` → `2.5.302`
- Unblocks Dependabot PRs #112, #113, #114 which update Aspire hosting packages to 13.4.5 — those packages pull in `StreamJsonRpc 2.25.29` which requires `MessagePack >= 2.5.302`, causing a NU1605 error against our 2.5.301 pin
- `2.5.302` still covers the original CVE-2026-48109 / GHSA-hv8m-jj95-wg3x fix

## Test plan
- [ ] CI passes (.NET build & test)
- [ ] After merge, Dependabot PRs #112, #113, #114 can be rebased and should pass CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)