### PR TITLE
security: scope Cosmos DB managed identity role to database/container (M1)

### DIFF
--- a/infra/api-roles-cosmos-db/api-roles-cosmos-db.module.bicep
+++ b/infra/api-roles-cosmos-db/api-roles-cosmos-db.module.bicep
@@ -7,6 +7,14 @@ param principalId string
 
 resource cosmos_db 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' existing = {
   name: cosmos_db_outputs_name
+
+  resource database 'sqlDatabases' existing = {
+    name: 'shared-factory'
+
+    resource container 'containers' existing = {
+      name: 'factories'
+    }
+  }
 }
 
 resource cosmos_db_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRoleDefinitions@2024-08-15' existing = {
@@ -15,11 +23,11 @@ resource cosmos_db_roleDefinition 'Microsoft.DocumentDB/databaseAccounts/sqlRole
 }
 
 resource cosmos_db_roleAssignment 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-08-15' = {
-  name: guid(principalId, cosmos_db_roleDefinition.id, cosmos_db.id)
+  name: guid(principalId, cosmos_db_roleDefinition.id, cosmos_db::database::container.id)
   properties: {
     principalId: principalId
     roleDefinitionId: cosmos_db_roleDefinition.id
-    scope: cosmos_db.id
+    scope: cosmos_db::database::container.id
   }
   parent: cosmos_db
 }


### PR DESCRIPTION
## Summary
- Narrows the Cosmos DB role assignment from account scope to database/container scope
- Implements least-privilege access for the API's managed identity

## Security finding
M1 (Medium): Cosmos DB managed identity role was scoped to the entire account, giving broader access than required.

## Test plan
- [ ] Bicep template validates (`az bicep build` or `az deployment ... --what-if`)
- [ ] API can still read/write its own database/container after deployment
- [ ] API cannot access other databases/containers in the same account

🤖 Generated with [Claude Code](https://claude.ai/claude-code)