### PR TITLE
security: set AllowedOrigins in production to fix CORS wildcard (H1)

### DIFF
--- a/infra/api/api-containerapp.module.bicep
+++ b/infra/api/api-containerapp.module.bicep
@@ -77,6 +77,10 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AZURE_TOKEN_CREDENTIALS'
               value: 'ManagedIdentityCredential'
             }
+            {
+              name: 'AllowedOrigins__0'
+              value: 'https://yafp.game.gottselig.ca'
+            }
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- Adds `AllowedOrigins__0` env var to the Azure Container App deployment
- The API's `Program.cs` already has correct CORS logic that reads this key — without it, the policy fell back to `AllowAnyOrigin()` (wildcard `*`)

## Security finding
H1 (High): Production CORS policy was effectively `*` because `AllowedOrigins` was never set in the Container App environment.

## Test plan
- [ ] Bicep deploys cleanly
- [ ] API responds with `Access-Control-Allow-Origin: https://yafp.game.gottselig.ca` for preflight requests from that origin
- [ ] Other origins are rejected

🤖 Generated with [Claude Code](https://claude.ai/claude-code)