### PR TITLE
fix: align VITE_API_BASE_URL env var name between Dockerfile and client code (L2)

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,1 @@
-REACT_APP_API_BASE_URL="http://localhost:8000/"
+VITE_API_BASE_URL="http://localhost:8000/"

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { PlainObject } from "./types";
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_REACT_APP_API_BASE_URL,
+  baseURL: import.meta.env.VITE_API_BASE_URL,
   responseType: 'json',
 });
 


### PR DESCRIPTION
## Summary
- Fixes env var name mismatch: client code was reading `VITE_REACT_APP_API_BASE_URL` while Dockerfile set `VITE_API_BASE_URL`
- In Docker/production builds, `baseURL` was resolving to `undefined`, breaking all API calls
- Also fixes `.env.example` which used the CRA-style `REACT_APP_API_BASE_URL` (missing `VITE_` prefix entirely)

## Security finding
L2: Env var name mismatch causing broken API in production Docker builds.

## Test plan
- [ ] `docker build` of `client/Dockerfile` still succeeds
- [ ] App in Docker can reach the API (no `undefined` in network requests)
- [ ] Local dev (`vite dev`) still works with `.env.local` setting `VITE_API_BASE_URL`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)