### PR TITLE
security: disable SWA config file updates in staging + document share ID design (L3, L4)

### DIFF
--- a/api.web/Services/ShareFactoryId.cs
+++ b/api.web/Services/ShareFactoryId.cs
@@ -35,6 +35,9 @@ public static class ShareFactoryId
     public static string Compute(FactoryConfigSchema config)
     {
         var canonical = Canonicalize(config);
+        // This ID is a content hash — deterministic and reproducible from the config alone.
+        // It is NOT a secret: anyone who knows the factory config can compute the same ID.
+        // It serves as a stable, short identifier for deduplication, not as an access-control mechanism.
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(canonical));
         return Convert.ToHexString(hash)[..16].ToLowerInvariant();
     }

--- a/infra/app/swa.bicep
+++ b/infra/app/swa.bicep
@@ -12,7 +12,7 @@ resource staticWebApp 'Microsoft.Web/staticSites@2024-11-01' = {
   properties: {
     provider: 'Custom'
     stagingEnvironmentPolicy: 'Enabled'
-    allowConfigFileUpdates: true
+    allowConfigFileUpdates: false
   }
   tags: union(tags, {
     'azd-service-name': 'web'


### PR DESCRIPTION
## Summary
- L3: Sets `allowConfigFileUpdates: false` in SWA Bicep to prevent PR authors from overriding routing/security headers on staging environments
- L4: Adds code comment clarifying that the share ID is a content hash (not a secret), so future developers don't assume it provides confidentiality

## Security findings
L3 (Low): `allowConfigFileUpdates: true` let PR authors weaken security config on staging.
L4 (Low): Share ID design was undocumented, risking misuse as an access-control mechanism.

## Test plan
- [ ] Bicep template is valid
- [ ] No functional change to the API share logic

🤖 Generated with [Claude Code](https://claude.ai/claude-code)