### PR TITLE
security: add Content Security Policy and security headers to frontend (M3)

### DIFF
--- a/client/public/staticwebapp.config.json
+++ b/client/public/staticwebapp.config.json
@@ -1,0 +1,7 @@
+{
+  "globalHeaders": {
+    "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://yafp.game.gottselig.ca; worker-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds Content Security Policy header to the frontend
- Also adds X-Frame-Options and X-Content-Type-Options security headers
- Configured via `client/public/staticwebapp.config.json` (Azure Static Web Apps native `globalHeaders` mechanism)

## CSP policy decisions
- `script-src 'self'` — all JS is bundled; no external scripts
- `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com` — `unsafe-inline` required by styled-components (`createGlobalStyle`); Google Fonts CSS loaded from `index.css`
- `font-src 'self' https://fonts.gstatic.com` — Google Fonts serves font files from gstatic
- `img-src 'self' data:` — `data:` required for inline SVG scrollbar arrow sprites in CSS
- `connect-src 'self' https://yafp.game.gottselig.ca` — API backend origin
- `worker-src 'self'` — GLPK LP solver runs in a Web Worker (`solver.worker.ts`)
- `frame-ancestors 'none'` — complements X-Frame-Options: DENY
- `base-uri 'self'; form-action 'self'` — defence-in-depth

## Security finding
M3 (Medium): No CSP meant XSS attacks had unrestricted access to browser APIs and sessionStorage (which holds full factory state).

## Test plan
- [ ] App loads and functions normally in browser
- [ ] Browser devtools show CSP header on responses
- [ ] No CSP violations in browser console for normal app usage
- [ ] External stylesheets/scripts load correctly (or are blocked if they shouldn't be loaded)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)