### PR TITLE
security: switch Container Apps log destination to azure-monitor (M4)

### DIFF
--- a/infra/env/env.module.bicep
+++ b/infra/env/env.module.bicep
@@ -43,11 +43,7 @@ resource env 'Microsoft.App/managedEnvironments@2025-01-01' = {
   location: location
   properties: {
     appLogsConfiguration: {
-      destination: 'log-analytics'
-      logAnalyticsConfiguration: {
-        customerId: env_law.properties.customerId
-        sharedKey: env_law.listKeys().primarySharedKey
-      }
+      destination: 'azure-monitor'
     }
     workloadProfiles: [
       {
@@ -65,6 +61,30 @@ resource aspireDashboard 'Microsoft.App/managedEnvironments/dotNetComponents@202
     componentType: 'AspireDashboard'
   }
   parent: env
+}
+
+resource env_diagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'env-diagnostics'
+  scope: env
+  properties: {
+    workspaceId: env_law.id
+    logs: [
+      {
+        category: 'ContainerAppConsoleLogs'
+        enabled: true
+      }
+      {
+        category: 'ContainerAppSystemLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+      }
+    ]
+  }
 }
 
 output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = env_law.name


### PR DESCRIPTION
## Summary

- **Finding M4**: `listKeys().primarySharedKey` was passed directly into the Container Apps Managed Environment config, causing the Log Analytics workspace shared key to be stored in ARM deployment history (readable by anyone with Reader access to the subscription/resource group)
- Switches `appLogsConfiguration.destination` from `log-analytics` to `azure-monitor` — no shared key is required or passed at deploy time
- Adds a `Microsoft.Insights/diagnosticSettings` resource scoped to the managed environment that routes logs to the same Log Analytics workspace via managed identity, preserving existing observability

## What changed

`infra/env/env.module.bicep`:
- Removed `logAnalyticsConfiguration` block (and its `listKeys()` call) from the managed environment resource
- Changed `destination` to `azure-monitor`
- Added `env_diagnostics` diagnostic setting routing `ContainerAppConsoleLogs`, `ContainerAppSystemLogs`, and `AllMetrics` to the existing `env_law` workspace

## Manual action required

Rotate the existing Log Analytics workspace primary shared key in the Azure Portal to invalidate the value already stored in prior ARM deployment history:
> Log Analytics workspace → Agents → Regenerate primary key

## Test plan

- [ ] Deploy to a staging environment and confirm Container App logs appear in the Log Analytics workspace
- [ ] Confirm the Aspire Dashboard component (`aspireDashboard`) still functions after the destination change
- [ ] Verify no `listKeys` calls remain in the infra Bicep files: `grep -r "listKeys" infra/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)