### PR TITLE
fix: apply recipe cost multiplier to per-cycle quantities, not perMinute rates

### DIFF
--- a/client/src/utilities/production-solver/index.test.ts
+++ b/client/src/utilities/production-solver/index.test.ts
@@ -372,3 +372,98 @@ describe('POINTS_ITEM_KEY', () => {
     expect(POINTS_ITEM_KEY.length).toBeGreaterThan(0);
   });
 });
+
+describe('ProductionSolver game mode multipliers (recipe cost)', () => {
+  // The game applies the recipe cost multiplier to integer *per-cycle quantities*,
+  // then rounds to the nearest whole number, and converts back to perMinute.
+  // This differs from naively multiplying the stored perMinute rate directly.
+  //
+  // To derive per-cycle quantities we use:
+  //   craftTime = 60 / GCD(all perMinutes in the recipe)
+  //   perCycleQty = perMinute / GCD
+  //
+  // Mock recipe maths:
+  //   Iron Ingot: 30 ore/min → 30 ingots/min.  GCD = 30 → 1 ore/cycle, craftTime = 2 s
+  //   Iron Plate: 30 ingots/min → 20 plates/min. GCD = 10 → 3 ingots/cycle, craftTime = 6 s
+
+  it('1.5x: rounds per-cycle ingredient quantity rather than scaling perMinute directly', async () => {
+    // Iron Ingot 1.5x: round(1 × 1.5) = 2 ore/cycle → 60 ore/min  (naive: 45/min)
+    // Iron Plate 1.5x: round(3 × 1.5) = round(4.5) = 5 ingots/cycle → 50 ingots/min  (naive: 45/min)
+    // For 10 plates/min: 0.5 constructor × 50 = 25 ingots → 25/30 smelter × 60 = 50 ore/min
+    const options = createValidOptions({
+      productionItems: [{ key: 'prod-1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '10' }],
+      gameModeOptions: { recipePartsCost: '1.5', powerConsumption: '1' },
+    });
+    const { productionGraph, error } = await new ProductionSolver(options, mockGameData).exec();
+
+    expect(error).toBeNull();
+    const oreNode = productionGraph!.nodes['Desc_OreIron_C'];
+    // Correct (per-cycle rounding): 50 ore/min
+    // Naive (direct ×1.5):          33.75 ore/min
+    expect(oreNode.multiplier).toBeCloseTo(50, 2);
+  });
+
+  it('0.75x: per-cycle rounding leaves small quantities unchanged when they round back to original', async () => {
+    // Iron Ingot 0.75x: round(1 × 0.75) = round(0.75) = 1 ore/cycle → 30 ore/min  (naive: 22.5/min)
+    // Iron Plate 0.75x: round(3 × 0.75) = round(2.25) = 2 ingots/cycle → 20 ingots/min  (naive: 22.5/min)
+    // For 10 plates/min: 0.5 constructor × 20 = 10 ingots → 1/3 smelter × 30 = 10 ore/min
+    const options = createValidOptions({
+      productionItems: [{ key: 'prod-1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '10' }],
+      gameModeOptions: { recipePartsCost: '0.75', powerConsumption: '1' },
+    });
+    const { productionGraph, error } = await new ProductionSolver(options, mockGameData).exec();
+
+    expect(error).toBeNull();
+    const oreNode = productionGraph!.nodes['Desc_OreIron_C'];
+    // Correct (per-cycle rounding): 10 ore/min (rounds back to base rate — no effective discount)
+    // Naive (direct ×0.75):         ≈ 8.44 ore/min
+    expect(oreNode.multiplier).toBeCloseTo(10, 2);
+  });
+
+  it('recipe cost multiplier does not affect product output rates', async () => {
+    // Products are never scaled; only ingredients change.
+    const options = createValidOptions({
+      productionItems: [{ key: 'prod-1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '10' }],
+      gameModeOptions: { recipePartsCost: '1.5', powerConsumption: '1' },
+    });
+    const { productionGraph, error } = await new ProductionSolver(options, mockGameData).exec();
+
+    expect(error).toBeNull();
+    const plateNode = productionGraph!.nodes['Desc_IronPlate_C'];
+    expect(plateNode.multiplier).toBeCloseTo(10, 2);
+  });
+
+  it('0.25x: per-cycle quantities that round to zero are clamped to a minimum of 1', async () => {
+    // Iron Ingot: per-cycle ore = 1. round(1 × 0.25) = round(0.25) = 0 → clamped to 1 → 30 ore/min
+    // Iron Plate: per-cycle ingots = 3. round(3 × 0.25) = round(0.75) = 1 → 10 ingots/min
+    // For 10 plates/min: 0.5 constructor × 10 = 5 ingots/min → 5/30 smelter × 30 = 5 ore/min
+    //
+    // Without the clamp: ore ingredient becomes 0/min, the ore resource node never appears
+    // in the graph, and the plan incorrectly claims zero ore is needed.
+    const options = createValidOptions({
+      productionItems: [{ key: 'prod-1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '10' }],
+      gameModeOptions: { recipePartsCost: '0.25', powerConsumption: '1' },
+    });
+    const { productionGraph, error } = await new ProductionSolver(options, mockGameData).exec();
+
+    expect(error).toBeNull();
+    const oreNode = productionGraph!.nodes['Desc_OreIron_C'];
+    expect(oreNode).toBeDefined();
+    expect(oreNode.multiplier).toBeCloseTo(5, 2);
+  });
+
+  it('2x: exact doubling produces the same result whether using per-cycle or direct scaling', async () => {
+    // Both approaches give the same result when perCycle * multiplier is already an integer.
+    // Iron Ingot 2x: 1 × 2 = 2 → 60 ore/min; Iron Plate 2x: 3 × 2 = 6 → 60 ingots/min
+    // For 10 plates/min: 0.5 constructor × 60 = 30 ingots → 1 smelter × 60 = 60 ore/min
+    const options = createValidOptions({
+      productionItems: [{ key: 'prod-1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '10' }],
+      gameModeOptions: { recipePartsCost: '2', powerConsumption: '1' },
+    });
+    const { productionGraph, error } = await new ProductionSolver(options, mockGameData).exec();
+
+    expect(error).toBeNull();
+    const oreNode = productionGraph!.nodes['Desc_OreIron_C'];
+    expect(oreNode.multiplier).toBeCloseTo(60, 2);
+  });
+});

--- a/client/src/utilities/production-solver/index.ts
+++ b/client/src/utilities/production-solver/index.ts
@@ -37,6 +37,18 @@ export type {
 } from './models';
 
 const MIN_RESOURCE_WEIGHT = 0.0001;
+
+// GCD helpers used to derive per-cycle ingredient quantities from stored perMinute rates.
+// perMinute = 60 * quantity / craftTime, so GCD(all perMinutes) = 60 / craftTime,
+// and quantity = perMinute / GCD. We scale to integers to avoid floating-point drift.
+function gcdIntegers(a: number, b: number): number {
+  while (b > 0) { [a, b] = [b, a % b]; }
+  return a;
+}
+function gcdFloats(a: number, b: number): number {
+  const scale = 1e6;
+  return gcdIntegers(Math.round(a * scale), Math.round(b * scale)) / scale;
+}
 const MAXIMIZE_WEIGHT = 1e5;
 const ENFORCE_BIN_WEIGHT = 1000;
 const TIME_LIMIT = 3.0;
@@ -283,6 +295,11 @@ export class ProductionSolver {
   // Returns a copy of gameData with 1.2 Game Mode multipliers baked in: recipe ingredient costs
   // scaled by recipeCostMultiplier (outputs untouched) and consumer power scaled by powerMultiplier
   // (generators, power < 0, left alone). All downstream solver/report logic then reads scaled values.
+  //
+  // The game applies the cost multiplier to the integer *per-cycle quantities*, not to the stored
+  // perMinute rates directly. The cycle time is derived from the GCD of all perMinute values in the
+  // recipe (ingredients + products): craftTime = 60 / GCD, perCycleQty = perMinute / GCD.
+  // Scaled quantities are rounded to the nearest whole number (minimum 1 per the game's floor).
   private static applyGameModeMultipliers(gameData: GameData, recipeCostMultiplier: number, powerMultiplier: number): GameData {
     if (recipeCostMultiplier === 1 && powerMultiplier === 1) {
       return gameData;
@@ -290,10 +307,23 @@ export class ProductionSolver {
 
     const recipes: GameData['recipes'] = {};
     for (const [key, recipe] of Object.entries(gameData.recipes)) {
-      recipes[key] = recipeCostMultiplier === 1 ? recipe : {
-        ...recipe,
-        ingredients: recipe.ingredients.map((i) => ({ ...i, perMinute: i.perMinute * recipeCostMultiplier })),
-      };
+      if (recipeCostMultiplier === 1) {
+        recipes[key] = recipe;
+      } else {
+        const allRates = [
+          ...recipe.ingredients.map((i) => i.perMinute),
+          ...recipe.products.map((p) => p.perMinute),
+        ];
+        const gcd = allRates.reduce(gcdFloats);
+        recipes[key] = {
+          ...recipe,
+          ingredients: recipe.ingredients.map((i) => {
+            const perCycle = Math.round(i.perMinute / gcd);
+            const scaledPerCycle = Math.max(1, Math.round(perCycle * recipeCostMultiplier));
+            return { ...i, perMinute: scaledPerCycle * gcd };
+          }),
+        };
+      }
     }
 
     const buildings: GameData['buildings'] = {};


### PR DESCRIPTION
## Summary

- The game mode Recipe Parts Cost Multiplier was being applied naively by multiplying stored `perMinute` rates directly. The game instead applies the multiplier to integer **per-cycle quantities**, then rounds to the nearest whole number.
- Fixed `applyGameModeMultipliers` to derive per-cycle quantities via `60 / GCD(all perMinute values in the recipe)`, scale them, round, and convert back to perMinute. Quantities are clamped to a minimum of 1 so zero-cost ingredients don't vanish from the production graph.
- Added 5 TDD-driven tests covering 0.25×, 0.75×, 1.5×, 2× multipliers and the products-are-never-scaled invariant.

## Root cause

The `perMinute` rate stored in the recipe JSON is `60 * integerQuantity / craftTime` (see `ParseDocs/Parser.cs`). A 1.5× multiplier on Iron Plate's ingredient (3 ingots/6s cycle) should give `round(4.5) = 5 ingots/cycle → 50/min`, not `30 × 1.5 = 45/min`. For multipliers like 0.75× on a 1-per-cycle ingredient, the correct result is no change (rounds back to 1), not a fractional rate the game never produces.

## Test plan

- [ ] All 24 solver tests pass: `npx vitest run src/utilities/production-solver/index.test.ts`
- [ ] Full test suite passes: `npx vitest run`
- [ ] Manually test the planner with a non-default Recipe Parts Cost Multiplier (e.g. 1.5×) and verify resource consumption matches in-game expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Tc4khR6CLtScA6auyUW6r