### PR TITLE
Re-introduce client Playwright smoke (post-deploy) + fix preview CORS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    # TEMP: reintroduce-client-playwright-smoke is included to exercise a real
+    # deploy (and the new client Playwright smoke) from the feature branch before
+    # merge. REVERT to [main] before merging. A matching federated credential
+    # exists on msi-yet-another-factory-planner and must be deleted afterwards.
+    branches: [main, reintroduce-client-playwright-smoke]
   pull_request:
     branches: [main]
 
@@ -123,8 +127,10 @@ jobs:
     needs: [build-and-test, build-frontend]
     # Only ever deploy main: a push to main, or a manual run targeting main.
     # workflow_dispatch can be launched from any branch, so guard the ref too.
+    # TEMP: the feature-branch ref is allowed here to test the deploy + client
+    # smoke before merge. REVERT to main-only before merging.
     if: >-
-      github.ref == 'refs/heads/main'
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/reintroduce-client-playwright-smoke')
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     # Hard cap so a hung step (e.g. a wedged smoke test) can never run for hours and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      # Pull the prebuilt frontend-ci image (Playwright browsers baked in) from
+      # GHCR for the client smoke step below.
+      packages: read
     env:
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
@@ -273,22 +276,18 @@ jobs:
           skip_app_build: true
           deployment_environment: staging
 
-      # Smoke-test the preview deployment: confirm it serves the app shell (HTTP 200
-      # + the React root div) before promoting to production. This is an HTTP-level
-      # check on purpose — a full browser-driven Playwright run in the deploy job
-      # downloads ~170 MB of browser per run and proved unreliable on the bare runner
-      # (browser-artifact downloads stalled). The client's functional behaviour
-      # (create -> share -> restore) is covered by the e2e suite in build-frontend,
-      # and the API round-trip by the API smoke above; here we just verify the static
-      # deploy is live. (The Playwright smoke spec remains in client/ for local runs.)
-      - name: Smoke-test client (SWA preview)
-        id: client_smoke
+      # Readiness gate: cheap HTTP poll until the SWA preview serves the app shell
+      # (HTTP 200 + the React root div). This waits out SWA preview propagation so
+      # the browser smoke below launches against a live deployment instead of racing
+      # the CDN. Bounded by retries + timeout-minutes.
+      - name: Wait for client preview to be live
+        id: client_live
         timeout-minutes: 5
         env:
           PREVIEW_URL: ${{ steps.swa_preview.outputs.static_web_app_url }}
         run: |
           set -euo pipefail
-          echo "Smoke-testing client preview: $PREVIEW_URL"
+          echo "Waiting for client preview: $PREVIEW_URL"
           for attempt in $(seq 1 10); do
             code=$(curl -sS -o /tmp/preview-index.html -w '%{http_code}' --max-time 30 "$PREVIEW_URL/" || echo "000")
             if [ "$code" = "200" ] && grep -q 'id="root"' /tmp/preview-index.html; then
@@ -300,6 +299,45 @@ jobs:
           done
           echo "ERROR: client preview did not serve the app shell (last http=$code)." >&2
           exit 1
+
+      # GHCR login so the smoke step can pull the prebuilt frontend-ci image.
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # Functional smoke against the REAL deployed preview + live API: drives the
+      # create -> share -> restore flow (client/tests/smoke.spec.ts) in a browser,
+      # asserting /share-factory returns a key and the share link restores via
+      # /initialize. This is the post-deploy validation the pre-deploy e2e suite
+      # (local dev server, mocked) and the API smoke can't give us.
+      #
+      # It runs inside the SAME prebuilt frontend-ci image build-frontend uses
+      # (Playwright browsers + system libs baked in) via `docker run`, so browsers
+      # are NEVER installed on the bare deploy runner — that bare-runner install is
+      # exactly what stalled the original in-job smoke. Guardrails: CI=true selects
+      # Playwright's non-blocking `line` reporter (the `html` reporter's report
+      # server hung the runner on failure); --ipc=host is Playwright's Chromium
+      # memory flag; per-test/expect timeouts live in playwright.smoke.config.ts;
+      # timeout-minutes caps the step; `docker run`'s exit code propagates pass/fail.
+      # The image's baked deps (/opt/ci/node_modules) replace the host client deps
+      # so the installed Playwright matches its baked browsers (the build-frontend
+      # pattern). The host's client/node_modules already exists from the earlier
+      # `npm ci --prefix client`, so it is removed first to avoid a nested copy.
+      - name: Smoke-test client (Playwright, deployed preview)
+        id: client_smoke
+        timeout-minutes: 8
+        env:
+          PREVIEW_URL: ${{ steps.swa_preview.outputs.static_web_app_url }}
+          CI_IMAGE: ghcr.io/greven145/yet-another-factory-planner/frontend-ci@sha256:56b9e36b41b193f3f911b85d8af6a67867b506b974b3ad66a3e1864ae7ee85f4 # :latest
+        run: |
+          set -euo pipefail
+          echo "Smoke-testing client preview in browser: $PREVIEW_URL"
+          docker run --rm --ipc=host \
+            -e CI=true \
+            -e SMOKE_URL="$PREVIEW_URL" \
+            -v "$PWD/client:/client" \
+            -w /client \
+            "$CI_IMAGE" \
+            sh -c 'rm -rf ./node_modules && cp -a /opt/ci/node_modules ./node_modules && npm run test:smoke'
 
       # Promote the already-built client/dist to production by re-uploading
       # WITHOUT the deployment_environment input.  No rebuild occurs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,7 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    # TEMP: reintroduce-client-playwright-smoke is included to exercise a real
-    # deploy (and the new client Playwright smoke) from the feature branch before
-    # merge. REVERT to [main] before merging. A matching federated credential
-    # exists on msi-yet-another-factory-planner and must be deleted afterwards.
-    branches: [main, reintroduce-client-playwright-smoke]
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -127,10 +123,8 @@ jobs:
     needs: [build-and-test, build-frontend]
     # Only ever deploy main: a push to main, or a manual run targeting main.
     # workflow_dispatch can be launched from any branch, so guard the ref too.
-    # TEMP: the feature-branch ref is allowed here to test the deploy + client
-    # smoke before merge. REVERT to main-only before merging.
     if: >-
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/reintroduce-client-playwright-smoke')
+      github.ref == 'refs/heads/main'
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     # Hard cap so a hung step (e.g. a wedged smoke test) can never run for hours and

--- a/YetAnotherFactoryPlanner.AppHost/infra/api/api-containerapp.module.bicep
+++ b/YetAnotherFactoryPlanner.AppHost/infra/api/api-containerapp.module.bicep
@@ -111,6 +111,15 @@ resource api 'Microsoft.App/containerApps@2025-02-02-preview' = {
               name: 'AllowedOrigins__0'
               value: 'https://yafp.game.gottselig.ca'
             }
+            // SWA "staging" preview environment origin. The blue-green client
+            // pipeline deploys to this named preview, runs the functional smoke
+            // against it, then promotes to production — so the preview must be
+            // allowed to call the API or every request is CORS-blocked. This is a
+            // stable per-resource hostname (SWA default name + "-staging").
+            {
+              name: 'AllowedOrigins__1'
+              value: 'https://thankful-dune-099ce8c0f-staging.eastus2.7.azurestaticapps.net'
+            }
           ]
           // ACA health probes. Cold start is ~27s (measured), so the startup probe
           // gives a 60s window (6 failures × 10s period) before ACA gives up.

--- a/client/package.json
+++ b/client/package.json
@@ -26,7 +26,9 @@
         "pretest:e2e:headed": "npm run playwright:install",
         "test:e2e:headed": "playwright test --headed",
         "lint": "eslint \"src/**/*.{ts,tsx}\"",
-        "a11y:lhci": "lhci autorun"
+        "a11y:lhci": "lhci autorun",
+        "pretest:smoke": "npm run playwright:install",
+        "test:smoke": "node scripts/smoke-runner.js"
     },
     "browserslist": {
         "production": [

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -2,6 +2,9 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  // Exclude the smoke suite — it targets a deployed URL and is run separately
+  // via `npm run test:smoke` / playwright.smoke.config.ts.
+  testIgnore: '**/smoke.spec.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/client/playwright.smoke.config.ts
+++ b/client/playwright.smoke.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Base URL for smoke tests. Set SMOKE_URL in the environment, or pass
+// --url <url> via the `test:smoke` npm script (which maps it to this var).
+// Example: npm run test:smoke -- --url https://preview-abc.azurestaticapps.net
+const baseURL = process.env.SMOKE_URL || 'http://localhost:3000';
+
+export default defineConfig({
+  testDir: './tests',
+  testMatch: '**/smoke.spec.ts',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  // Cap each test so a hung interaction fails fast instead of running until the
+  // job timeout (a deployed app + create/share flow should finish well under this).
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  // 'html' starts a blocking report server on CI (default open: 'on-failure'),
+  // which hangs the runner indefinitely on a failed smoke test. Use the streaming
+  // 'line' reporter in CI; keep 'html' for local debugging.
+  reporter: process.env.CI ? 'line' : 'html',
+
+  // No webServer block — smoke tests run against an already-deployed URL.
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    // Give the deployed app extra time to respond.
+    actionTimeout: 30_000,
+    navigationTimeout: 60_000,
+  },
+
+  projects: [
+    {
+      name: 'smoke-chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/client/scripts/smoke-runner.js
+++ b/client/scripts/smoke-runner.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Thin shim that lets the pipeline invoke smoke tests as:
+//
+//   npm run test:smoke -- --url <preview_url>
+//
+// Playwright's CLI does not have a --url flag; this script extracts it and
+// sets SMOKE_URL in the environment before forwarding the remaining args to
+// `playwright test --config playwright.smoke.config.ts`.
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+
+const args = process.argv.slice(2);
+
+// Extract --url <value> if present.
+const urlIndex = args.indexOf('--url');
+if (urlIndex !== -1) {
+  const urlValue = args[urlIndex + 1];
+  if (urlValue && !urlValue.startsWith('-')) {
+    process.env.SMOKE_URL = urlValue;
+    args.splice(urlIndex, 2); // remove --url <value> from the forwarded args
+  } else {
+    console.error('smoke-runner: --url requires a URL argument');
+    process.exit(1);
+  }
+}
+
+// Fail fast with a clear message rather than letting Playwright fall back to
+// localhost and surface a confusing CONNECTION_REFUSED on CI.
+if (!process.env.SMOKE_URL) {
+  console.error('smoke-runner: SMOKE_URL is not set. Pass --url <url> or set SMOKE_URL.');
+  process.exit(1);
+}
+
+// Use the locally installed playwright binary (not npx) to avoid version skew,
+// and propagate its exit code explicitly so CI sees real pass/fail.
+const result = spawnSync(
+  'node_modules/.bin/playwright',
+  ['test', '--config', 'playwright.smoke.config.ts', ...args],
+  { stdio: 'inherit', env: process.env },
+);
+process.exit(result.status ?? 1);

--- a/client/tests/smoke.spec.ts
+++ b/client/tests/smoke.spec.ts
@@ -1,0 +1,174 @@
+/**
+ * Smoke tests for the deployed Yet Another Factory Planner app.
+ *
+ * These tests run against an already-deployed URL (no local dev server).
+ * They exercise the live API — no route mocking — so both the client and the
+ * backend /share-factory + /initialize endpoints must be reachable.
+ *
+ * URL configuration
+ * -----------------
+ * Set SMOKE_URL in the environment, or use the npm script which maps --url:
+ *
+ *   npm run test:smoke -- --url https://preview-abc.azurestaticapps.net
+ *   SMOKE_URL=https://preview-abc.azurestaticapps.net npm run test:smoke
+ *
+ * The baseURL is wired in playwright.smoke.config.ts.
+ *
+ * Separation from a11y suite
+ * --------------------------
+ * This file is picked up ONLY by playwright.smoke.config.ts (testMatch:
+ * "smoke.spec.ts"). The default playwright.config.ts picks up the a11y and
+ * main e2e suites (which mock the API and spin up a local dev server).
+ * There is no axe import here.
+ */
+
+import { test, expect } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Open the Control Panel drawer and wait for it to be interactive. */
+async function openControlPanel(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    sessionStorage.setItem('drawer-open', '"false"');
+  });
+  await page.goto('/');
+
+  // Wait for the app shell to actually mount. The game-version combobox is the
+  // real readiness signal (a bare `#root > *` matches the Mantine <style> tag
+  // injected before React renders, which would return a false-green).
+  await expect(
+    page.getByRole('combobox', { name: 'Game version' }),
+  ).toBeVisible({ timeout: 30_000 });
+
+  const openBtn = page.getByRole('button', { name: 'Open Control Panel' });
+  await openBtn.waitFor({ state: 'visible', timeout: 30_000 });
+  await openBtn.click();
+}
+
+// ---------------------------------------------------------------------------
+// Suite 1: App shell mounts
+// ---------------------------------------------------------------------------
+
+test.describe('Smoke: app shell', () => {
+  test('page loads without a blank screen or uncaught error', async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    // App-shell-mounted assertion: the game-version combobox is the real
+    // readiness signal — it only renders once React has mounted the header.
+    // (A bare `#root > *` would match the Mantine <style> tag injected before
+    // React renders, producing a false-green.)
+    await expect(
+      page.getByRole('combobox', { name: 'Game version' }),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Page must not be a plain error page (5xx / blank).
+    const bodyText = await page.locator('body').innerText();
+    expect(bodyText.trim().length).toBeGreaterThan(0);
+
+    // No critical JS errors (network 4xx/5xx are logged as errors; filter known
+    // non-fatal ones that occur even in production).
+    const critical = consoleErrors.filter(
+      (e) =>
+        !e.includes('wheel sensitivity') &&
+        !e.includes('popperFactory') &&
+        !e.includes('Infinity'),
+    );
+    expect(critical, `Unexpected console errors: ${critical.join('\n')}`).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 2: Core create → share → restore flow (live API)
+// ---------------------------------------------------------------------------
+
+test.describe('Smoke: create → share → restore (live API)', () => {
+  test('builds a minimal plan, shares it, and the share link restores the plan', async ({ page }) => {
+    // ------------------------------------------------------------------ setup
+    await openControlPanel(page);
+
+    // Ensure the Production tab is active.
+    await page.getByRole('tab', { name: 'Production', exact: true }).click();
+
+    // ------------------------------------------------------------------ add a product
+    await page.getByRole('button', { name: '+ Add Product' }).click();
+
+    // Select "Iron Plate" from the item combobox.
+    const itemInput = page.getByPlaceholder('Select an item');
+    await itemInput.click();
+    await page.getByRole('option', { name: 'Iron Plate', exact: true }).click();
+
+    // The Amount input must appear, confirming the item was accepted.
+    const amountInput = page.getByPlaceholder('Amount');
+    await expect(amountInput).toBeVisible();
+    // Leave the default amount (the solver doesn't require a non-zero value to
+    // generate a shareable config; the share payload is always sent).
+
+    // ------------------------------------------------------------------ share
+    const saveShareBtn = page.getByRole('button', { name: 'Save & Share' });
+    await expect(saveShareBtn).toBeVisible();
+    await expect(saveShareBtn).toBeEnabled();
+
+    // Intercept the /share-factory request so we can assert the response key.
+    const shareResponsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('/share-factory') && resp.status() === 201,
+      { timeout: 30_000 },
+    );
+
+    await saveShareBtn.click();
+
+    // The API must respond with a 201 and a key.
+    const shareResponse = await shareResponsePromise;
+    const shareJson = await shareResponse.json();
+    const shareKey: string = shareJson?.data?.key;
+    expect(shareKey, 'share-factory API must return a key').toBeTruthy();
+    expect(typeof shareKey).toBe('string');
+    expect(shareKey.length).toBeGreaterThan(0);
+
+    // The share link input must populate with a URL containing the key.
+    const shareLinkInput = page.getByPlaceholder('Save factory to generate a link');
+    await expect(shareLinkInput).not.toHaveValue('', { timeout: 10_000 });
+    const linkValue = await shareLinkInput.inputValue();
+    expect(linkValue, 'share link must contain the factory key').toContain(shareKey);
+    expect(linkValue).toMatch(/^https?:\/\//);
+
+    // ------------------------------------------------------------------ restore
+    // Navigate to the share URL and verify the factory restores via /initialize.
+    const restoreResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('/initialize') &&
+        resp.url().includes(shareKey) &&
+        resp.status() === 200,
+      { timeout: 30_000 },
+    );
+
+    // The share link uses the same host as the deployed SPA, so goto it directly.
+    await page.goto(linkValue, { waitUntil: 'domcontentloaded' });
+
+    // The initialize call with the factory key must succeed.
+    const restoreResponse = await restoreResponsePromise;
+    const restoreJson = await restoreResponse.json();
+    expect(
+      restoreJson?.data?.factory_config,
+      '/initialize?factoryKey=... must return a factory_config',
+    ).toBeTruthy();
+
+    // Open the drawer and confirm the product we saved is shown.
+    const openBtn = page.getByRole('button', { name: 'Open Control Panel' });
+    await openBtn.waitFor({ state: 'visible', timeout: 30_000 });
+    await openBtn.click();
+
+    await page.getByRole('tab', { name: 'Production', exact: true }).click();
+
+    // The item selector must contain "Iron Plate" (the item we saved).
+    // The Mantine Select renders the selected value inside the combobox input.
+    const selectedItem = page.getByPlaceholder('Select an item').first();
+    await expect(selectedItem).toHaveValue(/Iron Plate/i, { timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
## What

Re-introduces the client **Playwright smoke** as a post-deploy gate that validates the real deployed SWA **preview** + live API before promoting the client to production, and fixes the API CORS gap that smoke immediately surfaced.

## Why

The original in-job smoke was removed (`f09ac77`) after it hung the bare `ubuntu-latest` deploy runner (html reporter's blocking report server on failure; Playwright browser download stalling; no timeouts). That left a coverage gap: nothing exercised **create → share → restore** against the actual deployed preview + live API — only a `curl` HTTP shell check ran post-deploy.

## How

- **Recover** the hardened smoke artifacts (`client/tests/smoke.spec.ts`, `scripts/smoke-runner.js`, `playwright.smoke.config.ts`) and re-add the `test:smoke`/`pretest:smoke` scripts + `testIgnore`.
- **Run it where browsers already exist:** the deploy job pulls the prebuilt `frontend-ci` image and runs the smoke via `docker run` — browsers are **never** installed on the bare runner (the original failure mode). Guardrails: non-blocking `line` reporter on CI, per-test/expect timeouts, step `timeout-minutes`, and `docker run` exit-code propagation. The smoke stays a step in the lock-holding deploy job, preserving the single continuous `deploy-production` lock; the existing `curl` poll is kept as a readiness gate.
- **CORS fix (`api-containerapp.module.bicep`):** the API only allowed the production custom domain, so the SWA preview origin was CORS-blocked and the preview was non-functional for API calls. Added the stable SWA `staging` preview origin as `AllowedOrigins__1`.

## Validation

Exercised a real deploy from this branch (temporary trigger + federated credential, both since reverted/deleted):

- **Run 1** — smoke correctly **failed** against the preview (CORS), promote was **skipped**, API was **not** rolled back. Caught the latent CORS bug.
- **Run 2** (with CORS fix) — **fully green**: API blue-green shift → preview deploy → `Smoke-test client (Playwright): 2 passed` → **promote to production**.

## Notes

- The TEMP branch-trigger commit is reverted in this branch (net-zero on `ci.yml` triggers; deploy is main-only again). The branch-specific federated credential has been deleted.
- Two intended production changes already landed from the validation deploy: the API CORS origin, and a client promote (functionally identical to main — only test files changed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)