### PR TITLE
feat: add Buildings tab to select which production machines the solver uses

### DIFF
--- a/YetAnotherFactoryPlanner.AppHost/AppHost.cs
+++ b/YetAnotherFactoryPlanner.AppHost/AppHost.cs
@@ -128,7 +128,11 @@ if (builder.ExecutionContext.IsRunMode &&
     // Keep the Vite app in local/test orchestration. Production frontend is served by Azure Static Web Apps.
     var client = builder.AddViteApp("client", "../client")
         .WithReference(api)
-        .WithEnvironment("VITE_REACT_APP_API_BASE_URL", api.GetEndpoint("http"))
+        // The client reads import.meta.env.VITE_API_BASE_URL (see client/src/api/index.ts and
+        // client/.env.example); inject that exact name so axios gets a real base URL. Otherwise
+        // baseURL is undefined, /initialize resolves against the Vite dev server, returns the SPA
+        // index.html, and the app hangs on "Loading game data...".
+        .WithEnvironment("VITE_API_BASE_URL", api.GetEndpoint("http"))
         // AddViteApp sets NODE_ENV from Environment.IsDevelopment(), which only matches the
         // literal "Development" environment name. In "Testing" that resolves to NODE_ENV=production,
         // which makes @vitejs/plugin-react skip injecting the React-Refresh preamble — every

--- a/client/src/containers/ProductionPlanner/PlannerOptions/BuildingsTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/BuildingsTab/index.tsx
@@ -1,0 +1,70 @@
+import React, { useState, useMemo, useCallback } from 'react';
+import { List, Checkbox, TextInput, Button, Group } from '@mantine/core';
+import { Search } from 'react-feather';
+import { useProductionContext } from '../../../../contexts/production';
+import { CollapsibleSection } from '../../../../components/Section';
+
+const BuildingsTab = () => {
+  const ctx = useProductionContext();
+  const [searchValue, setSearchValue] = useState('');
+
+  // The set of selectable buildings is exactly the keys of allowedBuildings,
+  // which the reducer derives from recipe.producedIn (recipe-producing machines only).
+  const buildings = useMemo(() => {
+    return Object.keys(ctx.state.allowedBuildings)
+      .map((key) => ({
+        key,
+        label: ctx.gameData.buildings[key]?.name ?? key,
+      }))
+      .sort((a, b) => (a.label > b.label ? 1 : -1));
+  }, [ctx.gameData, ctx.state.allowedBuildings]);
+
+  const renderBuilding = useCallback(({ key, label }: { key: string, label: string }) => (
+    <List.Item key={key}>
+      <Checkbox
+        label={label}
+        checked={ctx.state.allowedBuildings[key]}
+        onChange={() => {
+          ctx.dispatch({
+            type: 'SET_BUILDING_ACTIVE',
+            key,
+            active: !ctx.state.allowedBuildings[key],
+          });
+        }}
+      />
+    </List.Item>
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  ), [ctx.state, ctx.dispatch]);
+
+  const filteredBuildings = useMemo(
+    () => buildings.filter(({ label }) => label.toLowerCase().includes(searchValue.toLowerCase())),
+    [buildings, searchValue],
+  );
+  const filteredBuildingKeys = filteredBuildings.map(({ key }) => key);
+
+  return (
+    <CollapsibleSection title='Buildings' tooltip='Select which production buildings the solver may use. Disabling a building excludes every recipe made in it, regardless of the Recipes tab.'>
+      <TextInput
+        placeholder='Search...'
+        aria-label='search buildings'
+        leftSection={<Search size={16} />}
+        value={searchValue}
+        onChange={(e) => { setSearchValue(e.currentTarget.value); }}
+        style={{ marginBottom: '10px' }}
+      />
+      <Group style={{ marginTop: '5px', marginBottom: '10px' }}>
+        <Button onClick={() => { ctx.dispatch({ type: 'MASS_SET_BUILDINGS_ACTIVE', buildings: filteredBuildingKeys, active: true }) }}>
+          Select All
+        </Button>
+        <Button onClick={() => { ctx.dispatch({ type: 'MASS_SET_BUILDINGS_ACTIVE', buildings: filteredBuildingKeys, active: false }) }}>
+          Select None
+        </Button>
+      </Group>
+      <List listStyleType='none' style={{ gap: '6px' }}>
+        {filteredBuildings.map(renderBuilding)}
+      </List>
+    </CollapsibleSection>
+  );
+};
+
+export default BuildingsTab;

--- a/client/src/containers/ProductionPlanner/PlannerOptions/RecipesTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/RecipesTab/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo, useCallback } from 'react';
 import styled from 'styled-components';
-import { List, Checkbox, TextInput, Button, Group, Title, Grid } from '@mantine/core';
+import { List, Checkbox, TextInput, Button, Group, Title, Grid, Text } from '@mantine/core';
 import { Search } from 'react-feather';
 import { useProductionContext } from '../../../../contexts/production';
 import { CollapsibleSection } from '../../../../components/Section';
@@ -37,27 +37,38 @@ const RecipesTab = () => {
   }, [ctx.gameData]);
 
   const renderRecipeList = useCallback((recipeList: { key: string, label: string }[]) => {
-    return recipeList.map(({ key, label }) => ({
-      key,
-      label,
-      component: (
-        <List.Item key={key}>
-          <Checkbox
-            label={label}
-            checked={ctx.state.allowedRecipes[key]}
-            onChange={() => {
-              ctx.dispatch({
-                type: 'SET_RECIPE_ACTIVE',
-                key,
-                active: !ctx.state.allowedRecipes[key],
-              });
-            }}
-          />
-        </List.Item>
-      )
-    }));
+    return recipeList.map(({ key, label }) => {
+      // A recipe whose producing building is turned off on the Buildings tab is
+      // excluded by the solver no matter its own checkbox; dim it and say why.
+      const producedIn = ctx.gameData.recipes[key]?.producedIn;
+      const buildingDisabled = producedIn != null && ctx.state.allowedBuildings[producedIn] === false;
+      return {
+        key,
+        label,
+        component: (
+          <List.Item key={key} style={buildingDisabled ? { opacity: 0.5 } : undefined}>
+            <Checkbox
+              label={label}
+              checked={ctx.state.allowedRecipes[key]}
+              onChange={() => {
+                ctx.dispatch({
+                  type: 'SET_RECIPE_ACTIVE',
+                  key,
+                  active: !ctx.state.allowedRecipes[key],
+                });
+              }}
+            />
+            {buildingDisabled && (
+              <Text size='xs' c='dimmed' style={{ marginLeft: '32px' }}>
+                {`${ctx.gameData.buildings[producedIn!]?.name ?? producedIn} disabled`}
+              </Text>
+            )}
+          </List.Item>
+        )
+      };
+    });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ctx.state, ctx.dispatch]);
+  }, [ctx.state, ctx.gameData, ctx.dispatch]);
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const renderedBaseRecipes = useMemo(() => renderRecipeList(baseRecipes), [renderRecipeList]);

--- a/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Container, Tabs, Paper, Title, Group, Button, Switch, Space, TextInput, Popover, Text, Modal } from '@mantine/core';
-import { TrendingUp, Shuffle, Box } from 'react-feather';
+import { TrendingUp, Shuffle, Box, Tool } from 'react-feather';
 import { useProductionContext } from '../../../contexts/production';
 import ProductionTab from './ProductionTab';
 import InputsTab from './InputsTab';
 import RecipesTab from './RecipesTab';
+import BuildingsTab from './BuildingsTab';
 import { usePrevious } from '../../../hooks/usePrevious';
 
 const PlannerOptions = () => {
@@ -127,6 +128,7 @@ const PlannerOptions = () => {
           <Tabs.Tab value="production" leftSection={<TrendingUp size={16} />}>Production</Tabs.Tab>
           <Tabs.Tab value="inputs" leftSection={<Shuffle size={16} />}>Inputs</Tabs.Tab>
           <Tabs.Tab value="recipes" leftSection={<Box size={16} />}>Recipes</Tabs.Tab>
+          <Tabs.Tab value="buildings" leftSection={<Tool size={16} />}>Buildings</Tabs.Tab>
         </Tabs.List>
         <Tabs.Panel value="production">
           <TabContainer fluid>
@@ -141,6 +143,11 @@ const PlannerOptions = () => {
         <Tabs.Panel value="recipes">
           <TabContainer fluid>
             <RecipesTab />
+          </TabContainer>
+        </Tabs.Panel>
+        <Tabs.Panel value="buildings">
+          <TabContainer fluid>
+            <BuildingsTab />
           </TabContainer>
         </Tabs.Panel>
       </Tabs>

--- a/client/src/contexts/production/reducer.test.ts
+++ b/client/src/contexts/production/reducer.test.ts
@@ -163,6 +163,12 @@ describe('getInitialState', () => {
     expect(state.allowedRecipes['Recipe_AlternateIronPlate_C']).toBe(false);
   });
 
+  it('enables every recipe-producing building by default', () => {
+    const state = createInitialState();
+    expect(state.allowedBuildings['Build_SmelterMk1_C']).toBe(true);
+    expect(state.allowedBuildings['Build_ConstructorMk1_C']).toBe(true);
+  });
+
   it('has a unique key', () => {
     const state1 = createInitialState();
     const state2 = createInitialState();
@@ -455,6 +461,28 @@ describe('reducer', () => {
     });
   });
 
+  describe('SET_BUILDING_ACTIVE', () => {
+    it('disables a building', () => {
+      const state = createInitialState();
+      const result = reducer(state, { type: 'SET_BUILDING_ACTIVE', key: 'Build_ConstructorMk1_C', active: false });
+      expect(result.allowedBuildings['Build_ConstructorMk1_C']).toBe(false);
+      expect(result.allowedBuildings['Build_SmelterMk1_C']).toBe(true);
+    });
+  });
+
+  describe('MASS_SET_BUILDINGS_ACTIVE', () => {
+    it('disables multiple buildings at once', () => {
+      const state = createInitialState();
+      const result = reducer(state, {
+        type: 'MASS_SET_BUILDINGS_ACTIVE',
+        buildings: ['Build_ConstructorMk1_C', 'Build_SmelterMk1_C'],
+        active: false,
+      });
+      expect(result.allowedBuildings['Build_ConstructorMk1_C']).toBe(false);
+      expect(result.allowedBuildings['Build_SmelterMk1_C']).toBe(false);
+    });
+  });
+
   describe('LOAD_FROM_SHARED_FACTORY', () => {
     it('loads a shared factory config', () => {
       const sharedConfig = {
@@ -489,6 +517,50 @@ describe('reducer', () => {
       expect(result.weightingOptions.resources).toBe('500');
       expect(result.allowedRecipes['Recipe_IronIngot_C']).toBe(true);
       expect(result.allowedRecipes['Recipe_IronPlate_C']).toBe(true);
+    });
+
+    it('applies a present allowedBuildings list as a full overwrite', () => {
+      const sharedConfig = {
+        productionItems: [],
+        inputItems: [],
+        inputResources: [],
+        allowHandGatheredItems: false,
+        weightingOptions: { resources: 1000, power: 1, complexity: 0, buildings: 0 },
+        allowedRecipes: ['Recipe_IronIngot_C', 'Recipe_IronPlate_C'],
+        allowedBuildings: ['Build_SmelterMk1_C'],
+        nodesPositions: [],
+      };
+
+      const result = reducer(createInitialState(), {
+        type: 'LOAD_FROM_SHARED_FACTORY',
+        config: sharedConfig,
+        gameData: mockGameData,
+      });
+
+      expect(result.allowedBuildings['Build_SmelterMk1_C']).toBe(true);
+      // listed buildings stay on; everything else is forced off
+      expect(result.allowedBuildings['Build_ConstructorMk1_C']).toBe(false);
+    });
+
+    it('leaves all buildings enabled when allowedBuildings is absent (pre-feature share)', () => {
+      const sharedConfig = {
+        productionItems: [],
+        inputItems: [],
+        inputResources: [],
+        allowHandGatheredItems: false,
+        weightingOptions: { resources: 1000, power: 1, complexity: 0, buildings: 0 },
+        allowedRecipes: ['Recipe_IronIngot_C', 'Recipe_IronPlate_C'],
+        nodesPositions: [],
+      };
+
+      const result = reducer(createInitialState(), {
+        type: 'LOAD_FROM_SHARED_FACTORY',
+        config: sharedConfig,
+        gameData: mockGameData,
+      });
+
+      expect(result.allowedBuildings['Build_SmelterMk1_C']).toBe(true);
+      expect(result.allowedBuildings['Build_ConstructorMk1_C']).toBe(true);
     });
 
     it('returns initial state on error', () => {

--- a/client/src/contexts/production/reducer.tsx
+++ b/client/src/contexts/production/reducer.tsx
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid';
 import { decodeState_v1_U5 } from './legacy-state-decoders/v1_U5';
 import { decodeState_v2_U5 } from './legacy-state-decoders/v2_U5';
 import { decodeState_v3_U5 } from './legacy-state-decoders/v3_U5';
-import { ProductionItemOptions, InputItemOptions, WeightingOptions, GameModeOptions, RecipeSelectionMap, FactoryOptions, NodeInfo, TransportOptions } from './types';
+import { ProductionItemOptions, InputItemOptions, WeightingOptions, GameModeOptions, RecipeSelectionMap, BuildingSelectionMap, FactoryOptions, NodeInfo, TransportOptions } from './types';
 import { GameData, RecipeMap, ResourceMap } from '../gameData/types';
 import { MAX_PRIORITY, MaximizeBalanceMode, DEFAULT_MAXIMIZE_BALANCE_MODE } from './consts';
 import { decode, WireFactory } from '../../utilities/shared-factory/codec';
@@ -100,6 +100,17 @@ function getInitialAllowedRecipes(recipes: RecipeMap): RecipeSelectionMap {
   return recipeMap;
 }
 
+// Keyed only by buildings that actually produce a recipe (derived from recipes,
+// not gameData.buildings, so generators/extractors/foundations don't appear).
+// Buildings have no "alternates" concept, so every machine starts enabled.
+function getInitialAllowedBuildings(recipes: RecipeMap): BuildingSelectionMap {
+  const buildingMap: BuildingSelectionMap = {};
+  Object.values(recipes).forEach((data) => {
+    buildingMap[data.producedIn] = true;
+  });
+  return buildingMap;
+}
+
 export function getInitialState(gameData: GameData): FactoryOptions {
   return {
     key: nanoid(),
@@ -110,6 +121,7 @@ export function getInitialState(gameData: GameData): FactoryOptions {
     weightingOptions: getInitialWeightingOptions(),
     gameModeOptions: getInitialGameModeOptions(),
     allowedRecipes: getInitialAllowedRecipes(gameData.recipes),
+    allowedBuildings: getInitialAllowedBuildings(gameData.recipes),
     nodesPositions: [],
     maximizeBalanceMode: DEFAULT_MAXIMIZE_BALANCE_MODE,
     transportOptions: getInitialTransportOptions(),
@@ -137,6 +149,8 @@ export type FactoryAction =
   | { type: 'SET_ALL_WEIGHTS_DEFAULT', gameData: GameData }
   | { type: 'SET_RECIPE_ACTIVE', key: string, active: boolean }
   | { type: 'MASS_SET_RECIPES_ACTIVE', recipes: string[], active: boolean }
+  | { type: 'SET_BUILDING_ACTIVE', key: string, active: boolean }
+  | { type: 'MASS_SET_BUILDINGS_ACTIVE', buildings: string[], active: boolean }
   | { type: 'LOAD_FROM_SHARED_FACTORY', config: any, gameData: GameData }
   | { type: 'LOAD_FROM_LEGACY_ENCODING', encoding: string, gameData: GameData }
   | { type: 'LOAD_FROM_SESSION_STORAGE', sessionState: FactoryOptions, gameData: GameData }
@@ -283,6 +297,18 @@ export function reducer(state: FactoryOptions, action: FactoryAction): FactoryOp
       });
       return { ...state, allowedRecipes: newAllowedRecipes };
     }
+    case 'SET_BUILDING_ACTIVE': {
+      const newAllowedBuildings = { ...state.allowedBuildings };
+      newAllowedBuildings[action.key] = action.active;
+      return { ...state, allowedBuildings: newAllowedBuildings };
+    }
+    case 'MASS_SET_BUILDINGS_ACTIVE': {
+      const newAllowedBuildings = { ...state.allowedBuildings };
+      action.buildings.forEach((buildingKey) => {
+        newAllowedBuildings[buildingKey] = action.active;
+      });
+      return { ...state, allowedBuildings: newAllowedBuildings };
+    }
     case 'LOAD_FROM_SHARED_FACTORY': {
       try {
         const decoded = decode(action.config as WireFactory);
@@ -319,6 +345,15 @@ export function reducer(state: FactoryOptions, action: FactoryAction): FactoryOp
             newState.allowedRecipes[key] = true;
           }
         });
+        // allowedBuildings stores the ENABLED set and defaults to all-on, so a
+        // present list is a full overwrite: each known building is on iff it's in
+        // the decoded set. Absent (pre-feature shares) => keep the all-on default.
+        if (decoded.allowedBuildings) {
+          const enabled = new Set(decoded.allowedBuildings);
+          Object.keys(newState.allowedBuildings).forEach((key) => {
+            newState.allowedBuildings[key] = enabled.has(key);
+          });
+        }
         newState.nodesPositions = decoded.nodesPositions;
         // maximizeBalanceMode/transportOptions aren't part of the share wire shape;
         // read them defensively from the raw payload for any client-side persisted config.
@@ -346,6 +381,7 @@ export function reducer(state: FactoryOptions, action: FactoryAction): FactoryOp
           maximizeBalanceMode: action.sessionState.maximizeBalanceMode ?? DEFAULT_MAXIMIZE_BALANCE_MODE,
           transportOptions: action.sessionState.transportOptions ?? getInitialTransportOptions(),
           gameModeOptions: action.sessionState.gameModeOptions ?? getInitialGameModeOptions(),
+          allowedBuildings: action.sessionState.allowedBuildings ?? getInitialAllowedBuildings(action.gameData.recipes),
         };
       } catch (e) {
         console.error(e);

--- a/client/src/contexts/production/types.ts
+++ b/client/src/contexts/production/types.ts
@@ -31,6 +31,10 @@ export type RecipeSelectionMap = {
   [key: string]: boolean,
 };
 
+export type BuildingSelectionMap = {
+  [key: string]: boolean,
+};
+
 export type NodeInfo = {
   key: string,
   x: number,
@@ -51,6 +55,7 @@ export type FactoryOptions = {
   weightingOptions: WeightingOptions,
   gameModeOptions: GameModeOptions,
   allowedRecipes: RecipeSelectionMap,
+  allowedBuildings: BuildingSelectionMap,
   nodesPositions: NodeInfo[],
   maximizeBalanceMode: MaximizeBalanceMode,
   transportOptions: TransportOptions,

--- a/client/src/utilities/production-solver/index.test.ts
+++ b/client/src/utilities/production-solver/index.test.ts
@@ -138,6 +138,10 @@ function createValidOptions(overrides?: Partial<FactoryOptions>): FactoryOptions
       'Recipe_IronIngot_C': true,
       'Recipe_IronPlate_C': true,
     },
+    allowedBuildings: {
+      'Build_SmelterMk1_C': true,
+      'Build_ConstructorMk1_C': true,
+    },
     nodesPositions: [],
     maximizeBalanceMode: 'proportional',
     transportOptions: { beltCapacity: null, pipeCapacity: null },
@@ -222,6 +226,28 @@ describe('ProductionSolver constructor', () => {
       },
     });
     expect(() => new ProductionSolver(options, mockGameData)).toThrow(GraphError);
+  });
+
+  it('throws when targeting a recipe whose building is disabled', () => {
+    const options = createValidOptions({
+      productionItems: [{
+        key: 'prod-1',
+        itemKey: 'Desc_IronPlate_C',
+        mode: 'Recipe_IronPlate_C',
+        value: '2',
+      }],
+      // Recipe is allowed, but the Constructor that makes it is disabled.
+      allowedBuildings: {
+        'Build_SmelterMk1_C': true,
+        'Build_ConstructorMk1_C': false,
+      },
+    });
+    expect(() => new ProductionSolver(options, mockGameData)).toThrow(GraphError);
+  });
+
+  it('treats a missing allowedBuildings entry as enabled', () => {
+    const options = createValidOptions({ allowedBuildings: {} });
+    expect(() => new ProductionSolver(options, mockGameData)).not.toThrow();
   });
 
   it('allows duplicate maximization priority', () => {

--- a/client/src/utilities/production-solver/index.ts
+++ b/client/src/utilities/production-solver/index.ts
@@ -79,7 +79,10 @@ export class ProductionSolver {
   private rateTargets: RateTargets;
   private maximizeTargets: MaximizeTargets[];
   private hasPointsTarget: boolean;
-  private allowedRecipes: RecipeSelectionMap;
+  // allowedRecipes ANDed with the building filter: a recipe is usable only if its
+  // own toggle is on AND its producing building is enabled. This is the single map
+  // every solver pass gates on.
+  private effectiveAllowedRecipes: RecipeSelectionMap;
   private allowedItems: ItemMap;
   private scale: number;
   private maximizeBalanceMode: MaximizeBalanceMode;
@@ -103,10 +106,20 @@ export class ProductionSolver {
     const parsedPipe = rawPipe != null ? Number(rawPipe) : NaN;
     this.pipeCapacity = !Number.isNaN(parsedPipe) && parsedPipe > 0 ? parsedPipe : null;
 
-    this.allowedRecipes = options.allowedRecipes;
+    const allowedRecipes = options.allowedRecipes;
+    // allowedBuildings may be absent on state restored from very old session storage;
+    // the reducer backfills it, but guard here too (an unknown building => allowed).
+    const allowedBuildings = options.allowedBuildings ?? {};
+    this.effectiveAllowedRecipes = {};
+    Object.entries(allowedRecipes).forEach(([recipeKey, allowed]) => {
+      const recipeInfo = this.gameData.recipes[recipeKey];
+      const buildingAllowed = allowedBuildings[recipeInfo.producedIn] !== false;
+      this.effectiveAllowedRecipes[recipeKey] = allowed && buildingAllowed;
+    });
+
     this.allowedItems = {};
 
-    Object.entries(this.allowedRecipes).forEach(([recipeKey, allowed]) => {
+    Object.entries(this.effectiveAllowedRecipes).forEach(([recipeKey, allowed]) => {
       if (!allowed) return;
       const recipeInfo = this.gameData.recipes[recipeKey];
       recipeInfo.ingredients.forEach((i) => {
@@ -240,8 +253,8 @@ export class ProductionSolver {
           const recipeKey = item.mode;
           const recipeInfo = this.gameData.recipes[recipeKey];
           if (recipeInfo) {
-            if (!this.allowedRecipes[recipeKey]) {
-              throw new GraphError('CANNOT TARGET DISABLED RECIPE', 'Make sure the recipe you are targeting is enabled in the Recipes tab.');
+            if (!this.effectiveAllowedRecipes[recipeKey]) {
+              throw new GraphError('CANNOT TARGET DISABLED RECIPE', 'Make sure the recipe you are targeting is enabled in the Recipes tab and its building is enabled in the Buildings tab.');
             }
             const target = recipeInfo.products.find((p) => p.itemClass === item.itemKey)!;
             this.scale += target.perMinute * amount;
@@ -448,7 +461,7 @@ export class ProductionSolver {
     const objectiveVarMap = new Map<string, Var>();
 
     for (const [recipeKey, recipeInfo] of Object.entries(this.gameData.recipes)) {
-      if (!this.allowedRecipes[recipeKey]) continue;
+      if (!this.effectiveAllowedRecipes[recipeKey]) continue;
       const buildingInfo = this.gameData.buildings[recipeInfo.producedIn];
       const powerScore = buildingInfo.power > 0 ? buildingInfo.power * this.globalWeights.power : 0;
       const buildingsScore = this.globalWeights.buildings;
@@ -553,7 +566,7 @@ export class ProductionSolver {
       const binVars: Var[] = [];
 
       for (const recipeKey of itemInfo.usedInRecipes) {
-        if (!this.allowedRecipes[recipeKey]) continue;
+        if (!this.effectiveAllowedRecipes[recipeKey]) continue;
         const recipeInfo = this.gameData.recipes[recipeKey];
         const target = recipeInfo.ingredients.find((i) => i.itemClass === itemKey)!;
         const v: Var = { name: recipeKey, coef: target.perMinute };
@@ -566,7 +579,7 @@ export class ProductionSolver {
       }
 
       for (const recipeKey of itemInfo.producedFromRecipes) {
-        if (!this.allowedRecipes[recipeKey]) continue;
+        if (!this.effectiveAllowedRecipes[recipeKey]) continue;
         const recipeInfo = this.gameData.recipes[recipeKey];
         const target = recipeInfo.products.find((p) => p.itemClass === itemKey)!;
 

--- a/client/src/utilities/shared-factory/codec.test.ts
+++ b/client/src/utilities/shared-factory/codec.test.ts
@@ -25,6 +25,11 @@ function sampleConfig(): FactoryOptions {
       Recipe_IronPlate_C: true,
       Recipe_AlternateIronPlate_C: false,
     },
+    allowedBuildings: {
+      Build_SmelterMk1_C: true,
+      Build_ConstructorMk1_C: true,
+      Build_Blender_C: false,
+    },
     nodesPositions: [{ key: 'node1', x: 10, y: 20 }],
     maximizeBalanceMode: 'TRUE_MAXIMIZE' as any,
     transportOptions: { beltCapacity: null, pipeCapacity: null },
@@ -62,6 +67,8 @@ describe('encode', () => {
     expect(wire.gameModeOptions).toEqual({ recipePartsCost: 1, powerConsumption: 1 });
     // only enabled recipes survive the flatten
     expect(wire.allowedRecipes).toEqual(['Recipe_IronIngot_C', 'Recipe_IronPlate_C']);
+    // allowedBuildings flattens the same way: only the enabled set is stored
+    expect(wire.allowedBuildings).toEqual(['Build_SmelterMk1_C', 'Build_ConstructorMk1_C']);
   });
 });
 
@@ -78,6 +85,13 @@ describe('decode', () => {
     delete wire.gameModeOptions;
     const decoded = decode(wire as WireFactory);
     expect(decoded.gameModeOptions).toBeNull();
+  });
+
+  it('yields null allowedBuildings when the wire payload omits them (pre-feature share)', () => {
+    const wire = encode(sampleConfig(), '1.2') as Partial<WireFactory>;
+    delete wire.allowedBuildings;
+    const decoded = decode(wire as WireFactory);
+    expect(decoded.allowedBuildings).toBeNull();
   });
 });
 
@@ -103,6 +117,7 @@ describe('round-trip decode(encode(x))', () => {
     expect(decoded.gameModeOptions).toEqual(config.gameModeOptions);
     // allowedRecipes is map -> filtered list on encode; decode yields the enabled keys
     expect(decoded.allowedRecipes).toEqual(['Recipe_IronIngot_C', 'Recipe_IronPlate_C']);
+    expect(decoded.allowedBuildings).toEqual(['Build_SmelterMk1_C', 'Build_ConstructorMk1_C']);
     expect(decoded.nodesPositions).toEqual(config.nodesPositions);
   });
 });

--- a/client/src/utilities/shared-factory/codec.ts
+++ b/client/src/utilities/shared-factory/codec.ts
@@ -93,6 +93,8 @@ export type WireFactory = {
   weightingOptions: WireWeightingOptions,
   gameModeOptions: WireGameModeOptions,
   allowedRecipes: string[],
+  /** Enabled building keys. Added after 1.2; absent on older shares (= all enabled). */
+  allowedBuildings?: string[],
   nodesPositions: NodeInfo[],
 };
 
@@ -107,6 +109,8 @@ export type DecodedFactory = {
   gameModeOptions: GameModeOptions | null,
   /** Recipe keys that should be marked allowed. */
   allowedRecipes: string[],
+  /** Enabled building keys, or null when the share predates building selection (= all enabled). */
+  allowedBuildings: string[] | null,
   nodesPositions: NodeInfo[],
 };
 
@@ -144,6 +148,7 @@ export function encode(config: FactoryOptions, gameVersion: string): WireFactory
       powerConsumption: Number(config.gameModeOptions.powerConsumption),
     },
     allowedRecipes: Object.keys(config.allowedRecipes).filter((key) => config.allowedRecipes[key]),
+    allowedBuildings: Object.keys(config.allowedBuildings).filter((key) => config.allowedBuildings[key]),
     nodesPositions: config.nodesPositions,
   };
 }
@@ -184,6 +189,8 @@ export function decode(wire: WireFactory): DecodedFactory {
         }
       : null,
     allowedRecipes: wire.allowedRecipes,
+    // Building selection added after 1.2; older shares lack it => null = leave all enabled.
+    allowedBuildings: wire.allowedBuildings ?? null,
     nodesPositions: wire.nodesPositions,
   };
 }


### PR DESCRIPTION
## What & why

Satisfactory players unlock buildings over time. A player may have alternate recipes researched but not yet unlocked, say, the **Blender** — yet the planner would happily produce a plan requiring Blender recipes, forcing the user to hand-uncheck every one on the Recipes tab.

This adds a **Buildings** tab to toggle which production machines the solver may use. Disabling a building excludes **every** recipe produced in it, regardless of the per-recipe toggles. It's a parallel `allowedBuildings` selection map (twin of `allowedRecipes`) that ANDs with the per-recipe toggles, persisted in the shareable URL.

## Changes

- **State** — `BuildingSelectionMap` + `allowedBuildings` on `FactoryOptions`; `SET_BUILDING_ACTIVE` / `MASS_SET_BUILDINGS_ACTIVE` actions.
- **Defaults** — every recipe-producing building enabled, derived from `recipe.producedIn`; wired into `getInitialState` so fresh load **and** full reset both start all-on.
- **Solver** — a single `effectiveAllowedRecipes` map (`allowedRecipes[k] && building enabled`) gates every pass: `allowedItems`, recipe loop, item constraints, and targeting validation.
- **URL** — encodes the enabled set like `allowedRecipes`; a present list is a full overwrite, an absent field (pre-feature shares) decodes to all-enabled.
- **UI** — new Buildings tab (search + Select All/None); the Recipes tab dims recipes whose building is disabled with a hint.

Also fixes a local-dev AppHost bug that blocked the client entirely: it injected `VITE_REACT_APP_API_BASE_URL` but the client (and the deploy workflow) read `VITE_API_BASE_URL`, so axios had no base URL and the app hung on "Loading game data...". Aligned the AppHost to the canonical name.

## Testing

- Unit tests: reducer defaults/actions/decode (present overwrite + absent default), codec round-trip + absent-field, solver building-exclusion/targeting. Full suite green (121 tests).
- Manual (Playwright): Buildings tab lists the 12 recipe-producing machines all-on by default; disabling Blender with a Battery target → no solution; re-enabling → graph builds; Recipes tab dims Blender recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)