### PR TITLE
Multi-factory library with autosave

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import Main from './containers/Main';
 import { theme } from './theme';
 import GlobalStylesheet from './global-stylesheet';
 import { GlobalContextProvider } from './contexts/global';
+import { LibraryProvider } from './contexts/library';
 import { GameDataProvider } from './contexts/gameData';
 
 function App() {
@@ -26,9 +27,11 @@ const ThemeTransfer = () => {
     <ThemeProvider theme={mergedTheme}>
       <GlobalStylesheet />
       <GlobalContextProvider>
-        <GameDataProvider>
-          <Main />
-        </GameDataProvider>
+        <LibraryProvider>
+          <GameDataProvider>
+            <Main />
+          </GameDataProvider>
+        </LibraryProvider>
       </GlobalContextProvider>
     </ThemeProvider>
   );

--- a/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
+++ b/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
@@ -24,6 +24,7 @@ const gameDataValue = {
   loading: false,
   loadingError: false,
   completedThisFrame: false,
+  reinitToken: 0,
   gameVersion: DEFAULT_GAME_VERSION,
   setGameVersion: () => {},
 } as GameDataContextType;

--- a/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
@@ -9,6 +9,7 @@ import { Plus, Share2, MoreHorizontal, Edit2, Copy, Trash2, RotateCcw } from 're
 import { useProductionContext } from '../../../contexts/production';
 import { useLibraryContext } from '../../../contexts/library';
 import { labelOf, relativeTime } from '../../../utilities/factory-label';
+import { canShareFactory } from '../../../utilities/shared-factory/codec';
 import { RenameDialog, DeleteDialog } from './factory-dialogs';
 
 const FactorySwitcher = () => {
@@ -26,12 +27,10 @@ const FactorySwitcher = () => {
   // editing AND shows the correct label the instant you switch tabs — deriving the
   // active label from the reducer state instead lags a render behind the switch and
   // flashes the previous factory's name.
-  const labelFor = (id: string) => labelOf(lib.factories.find((f) => f.id === id)!, ctx.gameData);
   const activeLabel = labelOf(activeFactory, ctx.gameData);
 
-  // The API only accepts factories with at least one selected product, so guard the
-  // Share button rather than firing a POST that 400s with no feedback.
-  const canShare = ctx.state.productionItems.some((i) => i.itemKey);
+  // Guard the Share button rather than firing a POST that 400s with no feedback.
+  const canShare = canShareFactory(ctx.state);
   const onShare = () => { ctx.generateShareLink(); setCopied(true); setTimeout(() => setCopied(false), 2500); };
 
   return (
@@ -58,13 +57,16 @@ const FactorySwitcher = () => {
             {/* Drop the track's built-in bottom margin; the band padding controls
                 spacing now so the controls align to the tab track. */}
             <Tabs.List style={{ flexWrap: 'nowrap', marginBottom: 0 }}>
-              {lib.factories.map((f) => (
-                <Tabs.Tab key={f.id} value={f.id} title={`${labelFor(f.id)} · edited ${relativeTime(f.updatedAt)}`}>
-                  <span style={{ display: 'inline-block', maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', verticalAlign: 'bottom' }}>
-                    {labelFor(f.id)}
-                  </span>
-                </Tabs.Tab>
-              ))}
+              {lib.factories.map((f) => {
+                const label = labelOf(f, ctx.gameData);
+                return (
+                  <Tabs.Tab key={f.id} value={f.id} title={`${label} · edited ${relativeTime(f.updatedAt)}`}>
+                    <span style={{ display: 'inline-block', maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', verticalAlign: 'bottom' }}>
+                      {label}
+                    </span>
+                  </Tabs.Tab>
+                );
+              })}
             </Tabs.List>
           </Tabs>
         </div>

--- a/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
@@ -1,0 +1,115 @@
+// The factory switcher, rendered in the MAIN content column (between the graph and
+// the PlannerResults view tabs). Tabs reuse the app's `segmented-tabs` look (steel
+// track, FICSIT-orange active segment, monospace uppercase) so it reads as a native
+// control, presented as a header band with a divider above the view tabs. Switching
+// = the tabs; per-factory actions sit in a "⋯" menu + Share beside.
+import React, { useState } from 'react';
+import { Tabs, Group, Menu, Text, ActionIcon, Tooltip, Button, Popover } from '@mantine/core';
+import { Plus, Share2, MoreHorizontal, Edit2, Copy, Trash2, RotateCcw } from 'react-feather';
+import { useProductionContext } from '../../../contexts/production';
+import { useLibraryContext } from '../../../contexts/library';
+import { labelOf, relativeTime } from '../../../utilities/factory-label';
+import { RenameDialog, DeleteDialog } from './factory-dialogs';
+
+const FactorySwitcher = () => {
+  const ctx = useProductionContext();
+  const lib = useLibraryContext();
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const activeFactory = lib.activeFactory;
+  if (!activeFactory) return null;
+
+  // Label every tab (including the active one) from its stored config. Autosave keeps
+  // the active factory's config in sync with live edits, so this stays current while
+  // editing AND shows the correct label the instant you switch tabs — deriving the
+  // active label from the reducer state instead lags a render behind the switch and
+  // flashes the previous factory's name.
+  const labelFor = (id: string) => labelOf(lib.factories.find((f) => f.id === id)!, ctx.gameData);
+  const activeLabel = labelOf(activeFactory, ctx.gameData);
+
+  // The API only accepts factories with at least one selected product, so guard the
+  // Share button rather than firing a POST that 400s with no feedback.
+  const canShare = ctx.state.productionItems.some((i) => i.itemKey);
+  const onShare = () => { ctx.generateShareLink(); setCopied(true); setTimeout(() => setCopied(false), 2500); };
+
+  return (
+    // Present the switcher as a top "header band" — controls aligned to the tab
+    // track, closed by a thin rule using the graph-area border token, so "which
+    // factory" reads as a level above the graph/report view tabs below.
+    <div
+      style={{
+        marginTop: 12,
+        marginBottom: 16,
+        paddingBottom: 12,
+        borderBottom: '1px solid var(--yafp-graph-border)',
+      }}
+    >
+      <Group gap="xs" wrap="nowrap" align="center">
+        {/* Factory switcher — native segmented-tabs look, horizontally scrollable */}
+        <div style={{ flex: 1, minWidth: 0, overflowX: 'auto' }}>
+          <Tabs
+            value={lib.activeId}
+            onChange={(v) => v && lib.select(v)}
+            variant="pills"
+            className="segmented-tabs"
+          >
+            {/* Drop the track's built-in bottom margin; the band padding controls
+                spacing now so the controls align to the tab track. */}
+            <Tabs.List style={{ flexWrap: 'nowrap', marginBottom: 0 }}>
+              {lib.factories.map((f) => (
+                <Tabs.Tab key={f.id} value={f.id} title={`${labelFor(f.id)} · edited ${relativeTime(f.updatedAt)}`}>
+                  <span style={{ display: 'inline-block', maxWidth: 180, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', verticalAlign: 'bottom' }}>
+                    {labelFor(f.id)}
+                  </span>
+                </Tabs.Tab>
+              ))}
+            </Tabs.List>
+          </Tabs>
+        </div>
+
+        {/* New */}
+        <Tooltip label="New factory" withArrow>
+          <ActionIcon variant="default" size="lg" aria-label="New factory" onClick={() => lib.create()} styles={{ root: { color: 'var(--mantine-color-text)' } }}>
+            <Plus size={18} />
+          </ActionIcon>
+        </Tooltip>
+
+        {/* Active-factory actions */}
+        <Menu position="bottom-end" withArrow shadow="md">
+          <Menu.Target>
+            <ActionIcon variant="default" size="lg" aria-label="Factory actions" styles={{ root: { color: 'var(--mantine-color-text)' } }}>
+              <MoreHorizontal size={18} />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item leftSection={<Edit2 size={14} />} onClick={() => setRenameOpen(true)}>Rename</Menu.Item>
+            <Menu.Item leftSection={<Copy size={14} />} onClick={() => lib.duplicate(lib.activeId)}>Duplicate</Menu.Item>
+            <Menu.Item leftSection={<Trash2 size={14} />} color="red" onClick={() => setDeleteOpen(true)}>Delete</Menu.Item>
+            <Menu.Divider />
+            <Menu.Item leftSection={<RotateCcw size={14} />} onClick={() => ctx.dispatch({ type: 'RESET_FACTORY', gameData: ctx.gameData })}>Reset to empty</Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+
+        {/* Share */}
+        <Tooltip label="Add a product to share this factory" withArrow disabled={canShare}>
+          <Popover opened={copied && canShare} position="bottom-end" withArrow>
+            <Popover.Target>
+              {/* Span wrapper so the Tooltip still works while the Button is disabled. */}
+              <span>
+                <Button color="positive.8" leftSection={<Share2 size={16} />} loading={ctx.shareLink.loading} disabled={!canShare} onClick={onShare}>Share</Button>
+              </span>
+            </Popover.Target>
+            <Popover.Dropdown><Text size="sm">{ctx.shareLink.link ? 'Link copied!' : 'Generating…'}</Text></Popover.Dropdown>
+          </Popover>
+        </Tooltip>
+      </Group>
+
+      <RenameDialog opened={renameOpen} initial={activeFactory.nickname ?? ''} onClose={() => setRenameOpen(false)} onSubmit={(v) => lib.rename(lib.activeId, v)} />
+      <DeleteDialog opened={deleteOpen} label={activeLabel} onClose={() => setDeleteOpen(false)} onConfirm={() => lib.remove(lib.activeId)} />
+    </div>
+  );
+};
+
+export default FactorySwitcher;

--- a/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
@@ -68,6 +68,14 @@ const FactorySwitcher = () => {
                 );
               })}
             </Tabs.List>
+            {/* The switched content (graph/report) lives below in PlannerResults, not
+                in tab panels — this Tabs is used purely as a factory selector. Mantine
+                still emits aria-controls on every tab, so render an empty, hidden panel
+                per factory (keepMounted, so inactive tabs resolve too) to keep those
+                references valid (WCAG aria-valid-attr-value). */}
+            {lib.factories.map((f) => (
+              <Tabs.Panel key={f.id} value={f.id} keepMounted style={{ display: 'none' }} />
+            ))}
           </Tabs>
         </div>
 
@@ -96,15 +104,18 @@ const FactorySwitcher = () => {
 
         {/* Share */}
         <Tooltip label="Add a product to share this factory" withArrow disabled={canShare}>
-          <Popover opened={copied && canShare} position="bottom-end" withArrow>
-            <Popover.Target>
-              {/* Span wrapper so the Tooltip still works while the Button is disabled. */}
-              <span>
+          {/* The span keeps the Tooltip working while the Button is disabled (a
+              disabled control emits no pointer events). The Popover targets the Button
+              itself — not the span — so its aria-haspopup/aria-expanded land on an
+              element that supports them (WCAG aria-allowed-attr). */}
+          <span>
+            <Popover opened={copied && canShare} position="bottom-end" withArrow>
+              <Popover.Target>
                 <Button color="positive.8" leftSection={<Share2 size={16} />} loading={ctx.shareLink.loading} disabled={!canShare} onClick={onShare}>Share</Button>
-              </span>
-            </Popover.Target>
-            <Popover.Dropdown><Text size="sm">{ctx.shareLink.link ? 'Link copied!' : 'Generating…'}</Text></Popover.Dropdown>
-          </Popover>
+              </Popover.Target>
+              <Popover.Dropdown><Text size="sm">{ctx.shareLink.link ? 'Link copied!' : 'Generating…'}</Text></Popover.Dropdown>
+            </Popover>
+          </span>
         </Tooltip>
       </Group>
 

--- a/client/src/containers/ProductionPlanner/PlannerOptions/ProductionTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/ProductionTab/index.tsx
@@ -382,7 +382,7 @@ const ProductionTab = () => {
       </CollapsibleSection>
       <CollapsibleSection title='Weighting Options' tooltip='Tune how the solver trades off resources, power, complexity, and building count when optimizing.'>
         {renderWeightInputs()}
-        <Button color='red' onClick={() => { ctx.dispatch({ type: 'SET_ALL_WEIGHTS_DEFAULT', gameData: ctx.gameData }) }} style={{ marginTop: '15px' }}>
+        <Button color='danger.8' onClick={() => { ctx.dispatch({ type: 'SET_ALL_WEIGHTS_DEFAULT', gameData: ctx.gameData }) }} style={{ marginTop: '15px' }}>
           Reset All Weights
         </Button>
       </CollapsibleSection>

--- a/client/src/containers/ProductionPlanner/PlannerOptions/WelcomeCard.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/WelcomeCard.tsx
@@ -1,0 +1,24 @@
+// The Welcome card, hosted at the top of the drawer (where the old Control Panel
+// header used to be). The factory switcher lives in the main body (FactorySwitcher),
+// so this only reclaims that vertical space with the greeting + FICSIT tip.
+import React from 'react';
+import { Title, Text, Divider } from '@mantine/core';
+import { useGlobalContext } from '../../../contexts/global';
+import Card from '../../../components/Card';
+
+const WelcomeCard = () => {
+  const globalCtx = useGlobalContext();
+  return (
+    <Card style={{ padding: '12px 14px' }}>
+      <Title order={3}>Welcome back &lt;Engineer ID #{globalCtx.engineerId}&gt;</Title>
+      <Text>
+        This tool has been created to increase the efficiency of your work towards Project Assembly.<br />
+        We hope that you will continue to be effective.
+      </Text>
+      <Divider style={{ marginTop: '10px', marginBottom: '10px' }} />
+      <Text style={{ fontSize: '13px' }}>{globalCtx.ficsitTip}</Text>
+    </Card>
+  );
+};
+
+export default WelcomeCard;

--- a/client/src/containers/ProductionPlanner/PlannerOptions/factory-dialogs.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/factory-dialogs.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, TextInput, Button, Group, Text } from '@mantine/core';
+
+export const RenameDialog = ({
+  opened,
+  initial,
+  onClose,
+  onSubmit,
+}: {
+  opened: boolean;
+  initial: string;
+  onClose: () => void;
+  onSubmit: (value: string) => void;
+}) => {
+  const [value, setValue] = useState(initial);
+  useEffect(() => { if (opened) setValue(initial); }, [opened, initial]);
+  return (
+    <Modal opened={opened} onClose={onClose} title="Rename factory">
+      <TextInput
+        data-autofocus
+        label="Nickname"
+        placeholder="e.g. Main bus — rotors"
+        value={value}
+        onChange={(e) => setValue(e.currentTarget.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') { onSubmit(value); onClose(); } }}
+      />
+      <Text size="xs" c="dimmed" mt={6}>Leave empty to fall back to the auto-label.</Text>
+      <Group justify="flex-end" mt="md">
+        <Button variant="default" styles={{ root: { color: 'var(--mantine-color-text)' } }} onClick={onClose}>Cancel</Button>
+        <Button onClick={() => { onSubmit(value); onClose(); }}>Save</Button>
+      </Group>
+    </Modal>
+  );
+};
+
+export const DeleteDialog = ({
+  opened,
+  label,
+  onClose,
+  onConfirm,
+}: {
+  opened: boolean;
+  label: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}) => (
+  <Modal opened={opened} onClose={onClose} title="Delete factory">
+    <Text>Delete <strong>{label}</strong>? This can't be undone.</Text>
+    <Group justify="flex-end" mt="md">
+      <Button variant="default" styles={{ root: { color: 'var(--mantine-color-text)' } }} onClick={onClose}>Cancel</Button>
+      <Button color="danger.8" onClick={() => { onConfirm(); onClose(); }}>Delete</Button>
+    </Group>
+  </Modal>
+);

--- a/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
-import { Container, Tabs, Paper, Title, Group, Button, Switch, Space, TextInput, Popover, Text, Modal } from '@mantine/core';
+import { Container, Tabs } from '@mantine/core';
 import { TrendingUp, Shuffle, Box, Tool } from 'react-feather';
 import { useProductionContext } from '../../../contexts/production';
 import ProductionTab from './ProductionTab';
@@ -8,121 +8,27 @@ import InputsTab from './InputsTab';
 import RecipesTab from './RecipesTab';
 import BuildingsTab from './BuildingsTab';
 import { usePrevious } from '../../../hooks/usePrevious';
+// The old Calculate/Auto-calc/Save&Share/Reset header is gone: WelcomeCard hosts the
+// relocated greeting and the factory switcher lives in the main body (FactorySwitcher).
+import WelcomeCard from './WelcomeCard';
 
 const PlannerOptions = () => {
   const ctx = useProductionContext();
-  const [popoverOpened, setPopoverOpened] = useState(false);
-  const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+  // Drop the container chrome around the tab sections so the section cards sit flush
+  // on the drawer surface, aligned with the Welcome card above.
+  const flush = true;
 
+  // Copy the share link to the clipboard when one is generated.
   const prevShareLink = usePrevious(ctx.shareLink.link);
   useEffect(() => {
     if (ctx.shareLink.copyToClipboard && ctx.shareLink.link && ctx.shareLink.link !== prevShareLink) {
       navigator.clipboard.writeText(ctx.shareLink.link);
-      setPopoverOpened(true);
     }
   }, [ctx.shareLink, prevShareLink]);
 
-  useEffect(() => {
-    if (!popoverOpened) return;
-    const timer = setTimeout(() => { setPopoverOpened(false); }, 3000);
-    return () => clearTimeout(timer);
-  }, [popoverOpened]);
-
-  const handleLinkInputClicked = () => {
-    if (ctx.shareLink) {
-      navigator.clipboard.writeText(ctx.shareLink.link);
-      setPopoverOpened(true);
-    }
-  }
-  
   return (
     <>
-      <Paper style={{ marginBottom: '20px', paddingTop: '10px' }}>
-        <Title order={2} style={{ marginBottom: '15px' }}>Control Panel</Title>
-        <Group style={{ marginBottom: '15px' }}>
-          <Button
-            onClick={() => { ctx.calculate(); }}
-            disabled={ctx.autoCalculate}
-            style={{ marginRight: '15px', width: '125px' }}
-          >
-            Calculate
-          </Button>
-          <Switch
-            size='md'
-            label='Auto-calculate (disable if things get laggy)'
-            checked={ctx.autoCalculate}
-            onChange={(e) => { ctx.setAutoCalculate(e.currentTarget.checked); }}
-          />
-        </Group>
-        <Group style={{ marginBottom: '15px' }}>
-          <Button
-            color='positive.8'
-            onClick={() => { ctx.generateShareLink(); }}
-            loading={ctx.shareLink.loading}
-            style={{ width: '125px' }}
-          >
-            Save & Share
-          </Button>
-          <Popover
-            opened={popoverOpened}
-            onClose={() => setPopoverOpened(false)}
-            position='right'
-            withArrow
-            withRoles={false}
-          >
-            <Popover.Target>
-              <TextInput
-                value={ctx.shareLink.link}
-                placeholder='Save factory to generate a link'
-                readOnly={true}
-                onClick={() => { handleLinkInputClicked(); }}
-                style={{ flex: '1 1 auto' }}
-              />
-            </Popover.Target>
-            <Popover.Dropdown>
-              <Text>Link copied!</Text>
-            </Popover.Dropdown>
-          </Popover>
-        </Group>
-        <Space />
-        <Group style={{ marginBottom: '15px' }} justify='flex-end'>
-          <Button
-            color='danger.8'
-            onClick={() => { setResetConfirmOpen(true); }}
-          >
-            Reset ALL Factory Options
-          </Button>
-        </Group>
-      </Paper>
-      <Modal
-        opened={resetConfirmOpen}
-        onClose={() => setResetConfirmOpen(false)}
-        title="Reset ALL Factory Options"
-        closeButtonProps={{ 'aria-label': 'Close' }}
-      >
-        <Text>Are you sure? This will clear all production goals, inputs, and recipe settings.</Text>
-        <Group justify='flex-end' style={{ marginTop: '20px' }}>
-          <Button
-            variant='default'
-            onClick={() => setResetConfirmOpen(false)}
-            // The global Button theme forces white labels (for filled colored
-            // buttons); the default variant needs the readable theme text color
-            // so it isn't white-on-light. See WCAG contrast scan in a11y.spec.ts.
-            styles={{ root: { color: 'var(--mantine-color-text)' } }}
-          >
-            Cancel
-          </Button>
-          <Button
-            color='danger.8'
-            onClick={() => {
-              ctx.dispatch({ type: 'RESET_FACTORY', gameData: ctx.gameData });
-              setResetConfirmOpen(false);
-            }}
-          >
-            Reset
-          </Button>
-        </Group>
-      </Modal>
+      <WelcomeCard />
       <Tabs defaultValue="production" variant='pills' className='segmented-tabs segmented-tabs-grow'>
         <Tabs.List grow>
           <Tabs.Tab value="production" leftSection={<TrendingUp size={16} />}>Production</Tabs.Tab>
@@ -131,22 +37,22 @@ const PlannerOptions = () => {
           <Tabs.Tab value="buildings" leftSection={<Tool size={16} />}>Buildings</Tabs.Tab>
         </Tabs.List>
         <Tabs.Panel value="production">
-          <TabContainer fluid>
+          <TabContainer fluid $flush={flush}>
             <ProductionTab />
           </TabContainer>
         </Tabs.Panel>
         <Tabs.Panel value="inputs">
-          <TabContainer fluid>
+          <TabContainer fluid $flush={flush}>
             <InputsTab />
           </TabContainer>
         </Tabs.Panel>
         <Tabs.Panel value="recipes">
-          <TabContainer fluid>
+          <TabContainer fluid $flush={flush}>
             <RecipesTab />
           </TabContainer>
         </Tabs.Panel>
         <Tabs.Panel value="buildings">
-          <TabContainer fluid>
+          <TabContainer fluid $flush={flush}>
             <BuildingsTab />
           </TabContainer>
         </Tabs.Panel>
@@ -157,7 +63,15 @@ const PlannerOptions = () => {
 
 export default PlannerOptions;
 
-const TabContainer = styled(Container)`
-  padding: 15px 15px;
-  background: var(--yafp-container-bg);
+const TabContainer = styled(Container)<{ $flush?: boolean }>`
+  padding: ${({ $flush }) => ($flush ? '0' : '15px 15px')};
+  background: ${({ $flush }) => ($flush ? 'transparent' : 'var(--yafp-container-bg)')};
+
+  /* Flatten the section cards' drop-shadow so they read as aligned with the flat
+     greeting card above, instead of floating/inset. */
+  ${({ $flush }) =>
+    $flush &&
+    `
+    & .mantine-Paper-root { box-shadow: none; }
+  `}
 `;

--- a/client/src/containers/ProductionPlanner/index.tsx
+++ b/client/src/containers/ProductionPlanner/index.tsx
@@ -1,21 +1,20 @@
 import React, { useEffect, useState } from 'react';
-import { Loader, Divider, Text, Title, Button } from '@mantine/core';
+import { Loader, Title, Button } from '@mantine/core';
 import { AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
 import bgImage from '../../assets/stripe-bg.png';
 import { useGameDataContext } from '../../contexts/gameData';
-import { useGlobalContext } from '../../contexts/global';
 import { ProductionProvider } from '../../contexts/production';
-import Card from '../../components/Card';
 import ExternalLink from '../../components/ExternalLink';
 import Drawer, { TOGGLE_TAB_CLEARANCE } from '../Drawer';
 import PlannerOptions from './PlannerOptions';
 import PlannerResults from './PlannerResults';
+// The factory switcher renders as native segmented tabs at the top of the main body.
+import FactorySwitcher from './PlannerOptions/FactorySwitcher';
 import Portal from '../../components/Portal';
 import { useSessionStorage } from '../../hooks/useSessionStorage';
 
 const ProductionPlanner = () => {
-  const globalCtx = useGlobalContext();
   const gdCtx = useGameDataContext();
   const [slowLoad, setSlowLoad] = useState(false);
   const [drawerOpen, setDrawerOpen] = useSessionStorage<'false' | 'true'>({ key: 'drawer-open', defaultValue: 'true' });
@@ -92,21 +91,16 @@ const ProductionPlanner = () => {
           gameVersion={gdCtx.gameVersion}
           initializer={gdCtx.initializer}
           triggerInitialize={gdCtx.completedThisFrame}
+          reinitToken={gdCtx.reinitToken}
         >
           <PlannerLayout>
             <Drawer open={drawerOpen === 'true'} onToggle={(value) => { setDrawerOpen(value ? 'true' : 'false'); }}>
               <PlannerOptions />
             </Drawer>
             <MainContent>
-              <WelcomeCard style={{ marginBottom: '20px' }}>
-                <Title order={2}>Welcome back &lt;Engineer ID #{globalCtx.engineerId}&gt;</Title>
-                <Text>
-                  This tool has been created to increase the efficiency of your work towards Project Assembly.<br />
-                  We hope that you will continue to be effective.
-                </Text>
-                <Divider style={{ marginTop: '10px', marginBottom: '10px' }} />
-                <Text style={{ fontSize: '13px' }}>{globalCtx.ficsitTip}</Text>
-              </WelcomeCard>
+              {/* The Welcome card is relocated into the drawer (WelcomeCard); the
+                  factory switcher takes the top of the body. */}
+              <FactorySwitcher />
               <PlannerResults />
               <FooterContent>
                 <FooterText>
@@ -143,11 +137,6 @@ const MainContent = styled.div`
   height: 100%;
   overflow-y: auto;
   padding: 0 12px 0 ${TOGGLE_TAB_CLEARANCE};
-`;
-
-const WelcomeCard = styled(Card)`
-  flex-shrink: 0;
-  margin-top: 12px;
 `;
 
 // Fills exactly the space the graph reserves below itself (GRAPH_BOTTOM_RESERVE

--- a/client/src/contexts/gameData/index.tsx
+++ b/client/src/contexts/gameData/index.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useMemo, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useGetInitialize } from '../../api/modules/initialize/useGetInitialize';
 import { GameData } from './types';
 import { DEFAULT_GAME_VERSION, SHARE_QUERY_PARAM } from './consts';
@@ -6,14 +6,17 @@ import { toDisplay } from '../../utilities/shared-factory/codec';
 import { usePrevious } from '../../hooks/usePrevious';
 import { FactoryOptions } from '../production/types';
 import { usePageTitle } from '../../hooks/usePageTitle';
+import { useLibraryContext } from '../library';
 
 
 // TYPE
 export type FactoryInitializer = {
+  // Raw share payload (decoded by the reducer) for URL share loads.
   factoryConfig: any | null,
   shareKey: string | null,
   legacyEncoding: string | null,
-  sessionState: FactoryOptions | null,
+  // A stored library config loaded straight into the reducer. Null => reset.
+  libraryConfig: FactoryOptions | null,
 };
 
 export type GameDataContextType = {
@@ -22,6 +25,9 @@ export type GameDataContextType = {
   loading: boolean,
   loadingError: boolean,
   completedThisFrame: boolean,
+  // Bumped to reload the active factory into the reducer WITHOUT refetching game
+  // data (a same-version factory switch). Different-version switches refetch instead.
+  reinitToken: number,
   gameVersion: string,
   setGameVersion: (version: string) => void,
 };
@@ -45,24 +51,26 @@ export function useGameDataContext() {
 // PROVIDER
 type PropTypes = { children: React.ReactNode };
 export const GameDataProvider = ({ children }: PropTypes) => {
+  const lib = useLibraryContext();
   const [gameData, setGameData] = useState<GameData | null>(null);
   const [gameVersion, setGameVersion] = useState('');
   const [initializer, setInitializer] = useState<FactoryInitializer | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadingError, setLoadingError] = useState(false);
+  const [reinitToken, setReinitToken] = useState(0);
   const prevLoading = usePrevious(loading);
   const [needToFetchGameData, setNeedToFetchGameData] = useState(true);
   const completedThisFrame = useMemo(() => !loading && loading !== prevLoading, [loading, prevLoading]);
+
+  // The active factory id whose content is already reflected in the reducer. The
+  // switch observer below only fires when the active id drifts from this.
+  const handledActiveIdRef = useRef<string>(lib.activeId);
 
   const getInitialize = useGetInitialize();
 
   const pageTitle = useMemo(() => {
     const base = 'Another... Yet Another Factory Planner';
-    let versionPart = '';
-    if (gameVersion) {
-      versionPart = `[${gameVersion}] `;
-    }
-    return versionPart + base;
+    return (gameVersion ? `[${gameVersion}] ` : '') + base;
   }, [gameVersion]);
 
   usePageTitle(pageTitle);
@@ -77,17 +85,15 @@ export const GameDataProvider = ({ children }: PropTypes) => {
       const params = new URLSearchParams(window.location.search);
       const shareKey = params.get(SHARE_QUERY_PARAM);
       const legacyEncoding = params.get('f');
-      const sessionVersion = window.sessionStorage?.getItem('game-version');
-      const sessionState = window.sessionStorage?.getItem('state');
 
       if (shareKey) {
         getInitialize.request({ factoryKey: shareKey });
       } else if (legacyEncoding) {
         getInitialize.request({ gameVersion: DEFAULT_GAME_VERSION });
-      } else if (sessionVersion && sessionState) {
-        getInitialize.request({ gameVersion: sessionVersion });
       } else {
-        getInitialize.request({ gameVersion: gameVersion || DEFAULT_GAME_VERSION });
+        // Library-driven: fetch the active factory's game version.
+        const version = lib.activeFactory?.gameVersion || gameVersion || DEFAULT_GAME_VERSION;
+        getInitialize.request({ gameVersion: version });
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -98,57 +104,72 @@ export const GameDataProvider = ({ children }: PropTypes) => {
       if (getInitialize.error) {
         setLoadingError(true);
       }
-      const gameData = getInitialize.data?.game_data || null;
+      const newGameData = getInitialize.data?.game_data || null;
       const factoryConfig = getInitialize.data?.factory_config || null;
 
       const params = new URLSearchParams(window.location.search);
       const shareKey = params.get(SHARE_QUERY_PARAM);
       const legacyEncoding = params.get('f');
-      const sessionVersion = window.sessionStorage?.getItem('game-version');
-      let sessionState: FactoryOptions | null = null;
-      try {
-        const sessionStateJSON = window.sessionStorage?.getItem('state');
-        if (sessionVersion && sessionStateJSON) {
-          sessionState = JSON.parse(sessionStateJSON);
-        }
-      } catch (e) {
-        console.error(e);
-      }
-
       window.history.replaceState(null, '', `${window.location.pathname}`);
-      window.sessionStorage?.removeItem('game-version');
-      window.sessionStorage?.removeItem('state');
 
+      // Resolve the version this load landed on.
+      let version: string;
       if (factoryConfig?.gameVersion) {
-        setGameVersion(toDisplay(factoryConfig.gameVersion));
+        version = toDisplay(factoryConfig.gameVersion);
       } else if (legacyEncoding) {
-        setGameVersion(DEFAULT_GAME_VERSION);
-      } else if (sessionVersion && sessionState) {
-        setGameVersion(sessionVersion);
+        version = DEFAULT_GAME_VERSION;
       } else {
-        setGameVersion(gameVersion || DEFAULT_GAME_VERSION);
+        version = lib.activeFactory?.gameVersion || gameVersion || DEFAULT_GAME_VERSION;
       }
 
-      setGameData(gameData);
+      let libraryConfig: FactoryOptions | null = null;
+      if (shareKey || legacyEncoding) {
+        // Import the incoming URL factory as a new library slot (no dedupe). Its
+        // config is filled in by autosave once the reducer loads the share payload.
+        const imported = lib.importFactory({ gameVersion: version, sourceKey: shareKey ?? undefined });
+        handledActiveIdRef.current = imported.id;
+      } else {
+        libraryConfig = lib.activeFactory?.config ?? null;
+        handledActiveIdRef.current = lib.activeId;
+      }
+
+      setGameVersion(version);
+      setGameData(newGameData);
       setInitializer({
-        factoryConfig,
+        factoryConfig: (shareKey || legacyEncoding) ? factoryConfig : null,
         shareKey,
         legacyEncoding,
-        sessionState,
+        libraryConfig,
       });
       setLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getInitialize]);
 
+  // Observe active-factory switches that don't go through a refetch. Same version
+  // => reload the config into the reducer (instant); different version => refetch.
+  useEffect(() => {
+    if (loading) return;
+    if (lib.activeId === handledActiveIdRef.current) return;
+    const factory = lib.activeFactory;
+    if (!factory) return;
+    if (factory.gameVersion !== gameVersion) {
+      setNeedToFetchGameData(true);
+    } else {
+      setInitializer({ factoryConfig: null, shareKey: null, legacyEncoding: null, libraryConfig: factory.config ?? null });
+      handledActiveIdRef.current = lib.activeId;
+      setReinitToken((t) => t + 1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lib.activeId, loading]);
+
+  // Version selector: retarget the active factory and refetch game data for it.
   const handleSetGameVersion = useCallback((version: string) => {
     if (version !== gameVersion) {
-      setGameVersion(version);
+      lib.setActiveVersion(version);
       setNeedToFetchGameData(true);
-      window.sessionStorage?.removeItem('game-version');
-      window.sessionStorage?.removeItem('state');
     }
-  }, [gameVersion]);
+  }, [gameVersion, lib]);
 
   const ctxValue = useMemo(() => {
     return {
@@ -157,10 +178,11 @@ export const GameDataProvider = ({ children }: PropTypes) => {
       loading,
       loadingError,
       completedThisFrame,
+      reinitToken,
       gameVersion,
       setGameVersion: handleSetGameVersion,
     }
-  }, [completedThisFrame, gameData, gameVersion, handleSetGameVersion, initializer, loading, loadingError]);
+  }, [completedThisFrame, gameData, gameVersion, handleSetGameVersion, initializer, loading, loadingError, reinitToken]);
 
   return (
     <GameDataContext.Provider value={ctxValue}>

--- a/client/src/contexts/library/index.test.tsx
+++ b/client/src/contexts/library/index.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { LibraryProvider, useLibraryContext } from './index';
+import { loadLibrary, getActiveId } from './storage';
+import { FactoryOptions } from '../production/types';
+
+// Drive the provider through its public hook. Fake timers give every mutation a
+// distinct, monotonic timestamp so createdAt ordering and updatedAt bumps are
+// deterministic instead of racing on the wall clock.
+function setup() {
+  return renderHook(() => useLibraryContext(), { wrapper: LibraryProvider });
+}
+
+const tick = () => act(() => { vi.advanceTimersByTime(10); });
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-06-28T00:00:00Z'));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('LibraryProvider initial mount', () => {
+  it('auto-creates one factory, sets it active, and persists it', () => {
+    const { result } = setup();
+    expect(result.current.factories).toHaveLength(1);
+    expect(result.current.activeId).toBe(result.current.factories[0].id);
+    expect(result.current.activeFactory).toBeDefined();
+
+    // Persisted to localStorage + the session pointer.
+    const stored = loadLibrary();
+    expect(Object.keys(stored)).toHaveLength(1);
+    expect(getActiveId()).toBe(result.current.activeId);
+  });
+});
+
+describe('create', () => {
+  it('adds a slot inheriting the active version, makes it active, keeps createdAt order', () => {
+    const { result } = setup();
+    const firstId = result.current.activeId;
+
+    tick();
+    act(() => { result.current.create(); });
+
+    expect(result.current.factories).toHaveLength(2);
+    // Sorted by createdAt asc → the original stays first, the new one is last/active.
+    expect(result.current.factories[0].id).toBe(firstId);
+    const newId = result.current.factories[1].id;
+    expect(result.current.activeId).toBe(newId);
+    expect(result.current.activeFactory!.gameVersion).toBe('1.2');
+    expect(Object.keys(loadLibrary())).toHaveLength(2);
+  });
+
+  it('inherits a non-default active version', () => {
+    const { result } = setup();
+    tick();
+    act(() => { result.current.setActiveVersion('1.1'); });
+    tick();
+    act(() => { result.current.create(); });
+    expect(result.current.activeFactory!.gameVersion).toBe('1.1');
+  });
+});
+
+describe('duplicate', () => {
+  it('copies the config and appends " (copy)" to a nicknamed source', () => {
+    const { result } = setup();
+    const config = { key: 'cfg' } as unknown as FactoryOptions;
+
+    act(() => { result.current.saveActiveConfig(config); });
+    act(() => { result.current.rename(result.current.activeId, 'Base'); });
+    const srcId = result.current.activeId;
+
+    tick();
+    act(() => { result.current.duplicate(srcId); });
+
+    expect(result.current.factories).toHaveLength(2);
+    const copy = result.current.activeFactory!;
+    expect(copy.id).not.toBe(srcId);
+    expect(copy.nickname).toBe('Base (copy)');
+    expect(copy.config).toEqual(config);
+  });
+
+  it('does nothing for an unknown id', () => {
+    const { result } = setup();
+    act(() => { result.current.duplicate('does-not-exist'); });
+    expect(result.current.factories).toHaveLength(1);
+  });
+});
+
+describe('rename', () => {
+  it('trims whitespace', () => {
+    const { result } = setup();
+    act(() => { result.current.rename(result.current.activeId, '  Steel  '); });
+    expect(result.current.activeFactory!.nickname).toBe('Steel');
+  });
+
+  it('clears the nickname when given an empty string', () => {
+    const { result } = setup();
+    act(() => { result.current.rename(result.current.activeId, 'Temp'); });
+    act(() => { result.current.rename(result.current.activeId, '   '); });
+    expect(result.current.activeFactory!.nickname).toBeUndefined();
+  });
+});
+
+describe('remove', () => {
+  it('selects the most-recent remaining factory when the active one is removed', () => {
+    const { result } = setup();
+    const firstId = result.current.activeId;
+    tick();
+    act(() => { result.current.create(); });
+    const secondId = result.current.activeId;
+
+    // Re-select the first, then remove it → the (newer) second should become active.
+    act(() => { result.current.select(firstId); });
+    act(() => { result.current.remove(firstId); });
+
+    expect(result.current.factories).toHaveLength(1);
+    expect(result.current.activeId).toBe(secondId);
+  });
+
+  it('creates a fresh factory when the last one is removed', () => {
+    const { result } = setup();
+    const onlyId = result.current.activeId;
+    act(() => { result.current.remove(onlyId); });
+
+    expect(result.current.factories).toHaveLength(1);
+    expect(result.current.activeId).not.toBe(onlyId);
+    expect(Object.keys(loadLibrary())).toHaveLength(1);
+  });
+});
+
+describe('saveActiveConfig', () => {
+  it('writes config and bumps updatedAt on the active slot only', () => {
+    const { result } = setup();
+    tick();
+    act(() => { result.current.create(); });
+    const otherId = result.current.factories[0].id;
+    const otherBefore = result.current.factories[0].updatedAt;
+
+    const config = { key: 'live' } as unknown as FactoryOptions;
+    tick();
+    act(() => { result.current.saveActiveConfig(config); });
+
+    expect(result.current.activeFactory!.config).toEqual(config);
+    expect(result.current.activeFactory!.updatedAt).toBeGreaterThan(result.current.activeFactory!.createdAt);
+    // The non-active factory is untouched.
+    const other = result.current.factories.find((f) => f.id === otherId)!;
+    expect(other.updatedAt).toBe(otherBefore);
+    // Persisted.
+    expect(loadLibrary()[result.current.activeId].config).toEqual(config);
+  });
+});
+
+describe('setActiveVersion', () => {
+  it('retargets the version and clears the config', () => {
+    const { result } = setup();
+    act(() => { result.current.saveActiveConfig({ key: 'x' } as unknown as FactoryOptions); });
+    act(() => { result.current.setActiveVersion('1.1'); });
+
+    expect(result.current.activeFactory!.gameVersion).toBe('1.1');
+    expect(result.current.activeFactory!.config).toBeUndefined();
+  });
+
+  it('is a no-op when the version is unchanged', () => {
+    const { result } = setup();
+    const config = { key: 'keep' } as unknown as FactoryOptions;
+    act(() => { result.current.saveActiveConfig(config); });
+    act(() => { result.current.setActiveVersion('1.2'); }); // already 1.2
+
+    expect(result.current.activeFactory!.config).toEqual(config);
+  });
+});
+
+describe('importFactory', () => {
+  it('adds a slot carrying the sourceKey and makes it active', () => {
+    const { result } = setup();
+    const config = { key: 'imported' } as unknown as FactoryOptions;
+
+    tick();
+    act(() => { result.current.importFactory({ config, gameVersion: '1.1', sourceKey: 'shareKey1' }); });
+
+    expect(result.current.factories).toHaveLength(2);
+    const imported = result.current.activeFactory!;
+    expect(imported.config).toEqual(config);
+    expect(imported.gameVersion).toBe('1.1');
+    expect(imported.sourceKey).toBe('shareKey1');
+    expect(loadLibrary()[imported.id].sourceKey).toBe('shareKey1');
+  });
+});

--- a/client/src/contexts/library/index.tsx
+++ b/client/src/contexts/library/index.tsx
@@ -99,34 +99,32 @@ export const LibraryProvider = ({ children }: PropTypes) => {
     if (id !== activeId) selectId(id);
   }, [activeId, selectId]);
 
-  const create = useCallback((): LibraryFactory => {
-    const gameVersion = library[activeId]?.gameVersion ?? DEFAULT_GAME_VERSION;
-    const factory = makeFactory(gameVersion);
+  // Add a freshly-built factory to the library and make it active.
+  const addFactory = useCallback((factory: LibraryFactory): LibraryFactory => {
     commit({ ...library, [factory.id]: factory });
     selectId(factory.id);
     return factory;
-  }, [activeId, commit, library, selectId]);
+  }, [commit, library, selectId]);
+
+  const create = useCallback((): LibraryFactory => {
+    const gameVersion = library[activeId]?.gameVersion ?? DEFAULT_GAME_VERSION;
+    return addFactory(makeFactory(gameVersion));
+  }, [activeId, addFactory, library]);
 
   const importFactory = useCallback(
-    (input: { config?: FactoryOptions; gameVersion: string; sourceKey?: string }): LibraryFactory => {
-      const factory = makeFactory(input.gameVersion, { config: input.config, sourceKey: input.sourceKey });
-      commit({ ...library, [factory.id]: factory });
-      selectId(factory.id);
-      return factory;
-    },
-    [commit, library, selectId],
+    (input: { config?: FactoryOptions; gameVersion: string; sourceKey?: string }): LibraryFactory =>
+      addFactory(makeFactory(input.gameVersion, { config: input.config, sourceKey: input.sourceKey })),
+    [addFactory],
   );
 
   const duplicate = useCallback((id: string) => {
     const src = library[id];
     if (!src) return;
-    const copy = makeFactory(src.gameVersion, {
+    addFactory(makeFactory(src.gameVersion, {
       config: src.config,
       nickname: src.nickname ? `${src.nickname} (copy)` : undefined,
-    });
-    commit({ ...library, [copy.id]: copy });
-    selectId(copy.id);
-  }, [commit, library, selectId]);
+    }));
+  }, [addFactory, library]);
 
   const rename = useCallback((id: string, nickname: string) => {
     const src = library[id];

--- a/client/src/contexts/library/index.tsx
+++ b/client/src/contexts/library/index.tsx
@@ -1,0 +1,198 @@
+import React, { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { FactoryOptions } from '../production/types';
+import { DEFAULT_GAME_VERSION, SHARE_QUERY_PARAM } from '../gameData/consts';
+import { LibraryFactory, LibraryMap } from './types';
+import {
+  getActiveId,
+  loadLibrary,
+  makeFactory,
+  migrateFromSession,
+  mostRecent,
+  setActiveId as persistActiveId,
+  writeLibrary,
+} from './storage';
+
+
+// TYPE
+export type LibraryContextType = {
+  factories: LibraryFactory[]; // stable display order (createdAt asc)
+  activeId: string;
+  activeFactory: LibraryFactory | undefined;
+  select: (id: string) => void;
+  create: () => LibraryFactory;
+  duplicate: (id: string) => void;
+  rename: (id: string, nickname: string) => void;
+  remove: (id: string) => void;
+  saveActiveConfig: (config: FactoryOptions) => void;
+  setActiveVersion: (gameVersion: string) => void;
+  importFactory: (input: { config?: FactoryOptions; gameVersion: string; sourceKey?: string }) => LibraryFactory;
+};
+
+
+// CONTEXT
+export const LibraryContext = createContext<LibraryContextType | null>(null);
+LibraryContext.displayName = 'LibraryContext';
+
+
+// HELPER HOOK
+export function useLibraryContext() {
+  const ctx = useContext(LibraryContext);
+  if (!ctx) {
+    throw new Error('LibraryContext is null');
+  }
+  return ctx;
+}
+
+
+// Resolve the library + this tab's active factory on first mount, before the
+// game-data layer reads it. Migrates legacy sessionStorage state, honours the
+// per-tab active pointer, falls back to the most-recently-edited factory, and
+// creates an empty factory when the library is empty and no URL factory is present
+// (a URL share/legacy link is imported by the game-data layer instead).
+function resolveInitial(): { library: LibraryMap; activeId: string } {
+  let library = loadLibrary();
+  if (migrateFromSession(library)) {
+    library = loadLibrary();
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const hasUrlFactory = !!(params.get(SHARE_QUERY_PARAM) || params.get('f'));
+
+  let activeId = getActiveId() ?? '';
+  if (!activeId || !library[activeId]) {
+    activeId = mostRecent(library)?.id ?? '';
+  }
+
+  if (!hasUrlFactory && !activeId) {
+    const factory = makeFactory(DEFAULT_GAME_VERSION);
+    library = { ...library, [factory.id]: factory };
+    writeLibrary(library);
+    activeId = factory.id;
+  }
+
+  if (activeId) persistActiveId(activeId);
+  return { library, activeId };
+}
+
+
+// PROVIDER
+type PropTypes = { children: React.ReactNode };
+export const LibraryProvider = ({ children }: PropTypes) => {
+  const initial = useRef<{ library: LibraryMap; activeId: string } | null>(null);
+  if (!initial.current) initial.current = resolveInitial();
+
+  const [library, setLibrary] = useState<LibraryMap>(initial.current.library);
+  const [activeId, setActiveId] = useState<string>(initial.current.activeId);
+
+  // Persist a mutated map and update React state in one step.
+  const commit = useCallback((next: LibraryMap) => {
+    writeLibrary(next);
+    setLibrary(next);
+  }, []);
+
+  const selectId = useCallback((id: string) => {
+    persistActiveId(id);
+    setActiveId(id);
+  }, []);
+
+  const select = useCallback((id: string) => {
+    if (id !== activeId) selectId(id);
+  }, [activeId, selectId]);
+
+  const create = useCallback((): LibraryFactory => {
+    const gameVersion = library[activeId]?.gameVersion ?? DEFAULT_GAME_VERSION;
+    const factory = makeFactory(gameVersion);
+    commit({ ...library, [factory.id]: factory });
+    selectId(factory.id);
+    return factory;
+  }, [activeId, commit, library, selectId]);
+
+  const importFactory = useCallback(
+    (input: { config?: FactoryOptions; gameVersion: string; sourceKey?: string }): LibraryFactory => {
+      const factory = makeFactory(input.gameVersion, { config: input.config, sourceKey: input.sourceKey });
+      commit({ ...library, [factory.id]: factory });
+      selectId(factory.id);
+      return factory;
+    },
+    [commit, library, selectId],
+  );
+
+  const duplicate = useCallback((id: string) => {
+    const src = library[id];
+    if (!src) return;
+    const copy = makeFactory(src.gameVersion, {
+      config: src.config,
+      nickname: src.nickname ? `${src.nickname} (copy)` : undefined,
+    });
+    commit({ ...library, [copy.id]: copy });
+    selectId(copy.id);
+  }, [commit, library, selectId]);
+
+  const rename = useCallback((id: string, nickname: string) => {
+    const src = library[id];
+    if (!src) return;
+    const trimmed = nickname.trim();
+    commit({ ...library, [id]: { ...src, nickname: trimmed || undefined, updatedAt: Date.now() } });
+  }, [commit, library]);
+
+  const remove = useCallback((id: string) => {
+    const next = { ...library };
+    delete next[id];
+    commit(next);
+    if (id === activeId) {
+      const fallback = mostRecent(next) ?? makeFactory(library[id]?.gameVersion ?? DEFAULT_GAME_VERSION);
+      if (!next[fallback.id]) commit({ ...next, [fallback.id]: fallback });
+      selectId(fallback.id);
+    }
+  }, [activeId, commit, library, selectId]);
+
+  // Autosave: write the live reducer state into the active slot. Called on every
+  // production state change, so this is the hot path.
+  const saveActiveConfig = useCallback((config: FactoryOptions) => {
+    setLibrary((prev) => {
+      const src = prev[activeId];
+      if (!src) return prev;
+      const next = { ...prev, [activeId]: { ...src, config, updatedAt: Date.now() } };
+      writeLibrary(next);
+      return next;
+    });
+  }, [activeId]);
+
+  // Version selector: retarget the active factory to a new game version and drop
+  // its config (recipes/items differ across versions, so it resets on reload).
+  const setActiveVersion = useCallback((gameVersion: string) => {
+    setLibrary((prev) => {
+      const src = prev[activeId];
+      if (!src || src.gameVersion === gameVersion) return prev;
+      const next = { ...prev, [activeId]: { ...src, gameVersion, config: undefined, updatedAt: Date.now() } };
+      writeLibrary(next);
+      return next;
+    });
+  }, [activeId]);
+
+  const factories = useMemo(
+    () => Object.values(library).sort((a, b) => a.createdAt - b.createdAt),
+    [library],
+  );
+  const activeFactory = library[activeId];
+
+  const ctxValue = useMemo<LibraryContextType>(() => ({
+    factories,
+    activeId,
+    activeFactory,
+    select,
+    create,
+    duplicate,
+    rename,
+    remove,
+    saveActiveConfig,
+    setActiveVersion,
+    importFactory,
+  }), [factories, activeId, activeFactory, select, create, duplicate, rename, remove, saveActiveConfig, setActiveVersion, importFactory]);
+
+  return (
+    <LibraryContext.Provider value={ctxValue}>
+      {children}
+    </LibraryContext.Provider>
+  );
+};

--- a/client/src/contexts/library/storage.test.ts
+++ b/client/src/contexts/library/storage.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getActiveId,
+  loadLibrary,
+  makeFactory,
+  migrateFromSession,
+  mostRecent,
+  setActiveId,
+  writeLibrary,
+} from './storage';
+import { LibraryMap } from './types';
+import { FactoryOptions } from '../production/types';
+
+const LIBRARY_KEY = 'factory-library';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('loadLibrary / writeLibrary', () => {
+  it('returns an empty map when nothing is stored', () => {
+    expect(loadLibrary()).toEqual({});
+  });
+
+  it('round-trips a written map', () => {
+    const factory = makeFactory('1.2');
+    const map: LibraryMap = { [factory.id]: factory };
+    writeLibrary(map);
+    expect(loadLibrary()).toEqual(map);
+  });
+
+  it('returns an empty map on malformed JSON', () => {
+    window.localStorage.setItem(LIBRARY_KEY, '{ not json');
+    expect(loadLibrary()).toEqual({});
+  });
+
+  it('surfaces a quota error via window.alert instead of throwing', () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('full', 'QuotaExceededError');
+    });
+
+    expect(() => writeLibrary({ a: makeFactory('1.2') })).not.toThrow();
+    expect(alertSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('active-id pointer', () => {
+  it('returns null when unset', () => {
+    expect(getActiveId()).toBeNull();
+  });
+
+  it('round-trips through sessionStorage', () => {
+    setActiveId('abc');
+    expect(getActiveId()).toBe('abc');
+  });
+});
+
+describe('makeFactory', () => {
+  it('produces a unique id with equal created/updated timestamps', () => {
+    const a = makeFactory('1.2');
+    const b = makeFactory('1.2');
+    expect(a.id).not.toBe(b.id);
+    expect(a.createdAt).toBe(a.updatedAt);
+  });
+
+  it('leaves config undefined and carries the game version by default', () => {
+    const f = makeFactory('1.1');
+    expect(f.gameVersion).toBe('1.1');
+    expect(f.config).toBeUndefined();
+    expect(f.nickname).toBeUndefined();
+    expect(f.sourceKey).toBeUndefined();
+  });
+
+  it('passes through nickname, config, and sourceKey', () => {
+    const config = { key: 'c' } as unknown as FactoryOptions;
+    const f = makeFactory('1.2', { config, nickname: 'Base', sourceKey: 'key123' });
+    expect(f.config).toBe(config);
+    expect(f.nickname).toBe('Base');
+    expect(f.sourceKey).toBe('key123');
+  });
+});
+
+describe('migrateFromSession', () => {
+  const legacyConfig = { key: 'legacy' } as unknown as FactoryOptions;
+
+  function seedLegacySession() {
+    window.sessionStorage.setItem('game-version', '1.1');
+    window.sessionStorage.setItem('state', JSON.stringify(legacyConfig));
+  }
+
+  it('adopts legacy session state into an empty library and clears the legacy keys', () => {
+    seedLegacySession();
+    const seeded = migrateFromSession({});
+
+    expect(seeded).not.toBeNull();
+    expect(seeded!.gameVersion).toBe('1.1');
+    expect(seeded!.config).toEqual(legacyConfig);
+    // Written to the library...
+    expect(loadLibrary()[seeded!.id]).toEqual(seeded);
+    // ...and the legacy keys are gone.
+    expect(window.sessionStorage.getItem('state')).toBeNull();
+    expect(window.sessionStorage.getItem('game-version')).toBeNull();
+  });
+
+  it('is a no-op when the library is already populated', () => {
+    seedLegacySession();
+    const existing = makeFactory('1.2');
+    expect(migrateFromSession({ [existing.id]: existing })).toBeNull();
+    // Legacy keys are left untouched in this case.
+    expect(window.sessionStorage.getItem('state')).not.toBeNull();
+  });
+
+  it('returns null when there is no legacy state to migrate', () => {
+    expect(migrateFromSession({})).toBeNull();
+  });
+});
+
+describe('mostRecent', () => {
+  it('returns null for an empty library', () => {
+    expect(mostRecent({})).toBeNull();
+  });
+
+  it('returns the factory with the greatest updatedAt', () => {
+    const older = { ...makeFactory('1.2'), updatedAt: 100 };
+    const newer = { ...makeFactory('1.2'), updatedAt: 200 };
+    const map: LibraryMap = { [older.id]: older, [newer.id]: newer };
+    expect(mostRecent(map)).toBe(newer);
+  });
+});

--- a/client/src/contexts/library/storage.ts
+++ b/client/src/contexts/library/storage.ts
@@ -1,0 +1,98 @@
+import { nanoid } from 'nanoid';
+import { LibraryFactory, LibraryMap } from './types';
+import { FactoryOptions } from '../production/types';
+
+// localStorage holds the shared library (the data); sessionStorage holds this
+// tab's active-factory pointer, so two tabs can edit two factories independently.
+const LIBRARY_KEY = 'factory-library';
+const ACTIVE_ID_KEY = 'active-factory-id';
+
+// Legacy single-factory persistence we migrate away from on first load.
+const LEGACY_STATE_KEY = 'state';
+const LEGACY_VERSION_KEY = 'game-version';
+
+export function loadLibrary(): LibraryMap {
+  try {
+    const raw = window.localStorage.getItem(LIBRARY_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch (e) {
+    console.error(e);
+    return {};
+  }
+}
+
+export function writeLibrary(library: LibraryMap): void {
+  try {
+    window.localStorage.setItem(LIBRARY_KEY, JSON.stringify(library));
+  } catch (e) {
+    console.error(e);
+    // Quota is the only expected failure; surface it rather than losing work silently.
+    if (e instanceof DOMException && e.name === 'QuotaExceededError') {
+      window.alert('Factory storage is full — delete some factories to keep saving.');
+    }
+  }
+}
+
+export function getActiveId(): string | null {
+  try {
+    return window.sessionStorage.getItem(ACTIVE_ID_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setActiveId(id: string): void {
+  try {
+    window.sessionStorage.setItem(ACTIVE_ID_KEY, id);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+// Build a fresh library record. `config` is left undefined for brand-new/imported
+// slots; the reducer initializes them and autosave fills `config` in on first edit.
+export function makeFactory(
+  gameVersion: string,
+  opts: { config?: FactoryOptions; nickname?: string; sourceKey?: string } = {},
+): LibraryFactory {
+  const now = Date.now();
+  return {
+    id: nanoid(),
+    nickname: opts.nickname,
+    gameVersion,
+    config: opts.config,
+    sourceKey: opts.sourceKey,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// One-time adoption of the old single-factory sessionStorage state so existing
+// in-progress work isn't lost on the first load after this feature ships. Returns
+// the seeded factory (already written to the library) or null if nothing to migrate.
+export function migrateFromSession(library: LibraryMap): LibraryFactory | null {
+  if (Object.keys(library).length > 0) return null;
+  try {
+    const version = window.sessionStorage.getItem(LEGACY_VERSION_KEY);
+    const stateJSON = window.sessionStorage.getItem(LEGACY_STATE_KEY);
+    if (!version || !stateJSON) return null;
+    const config = JSON.parse(stateJSON) as FactoryOptions;
+    const factory = makeFactory(version, { config });
+    writeLibrary({ [factory.id]: factory });
+    window.sessionStorage.removeItem(LEGACY_STATE_KEY);
+    window.sessionStorage.removeItem(LEGACY_VERSION_KEY);
+    return factory;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
+// Most-recently-edited factory, used when a fresh tab has no active pointer.
+export function mostRecent(library: LibraryMap): LibraryFactory | null {
+  const all = Object.values(library);
+  if (all.length === 0) return null;
+  return all.reduce((a, b) => (b.updatedAt > a.updatedAt ? b : a));
+}

--- a/client/src/contexts/library/types.ts
+++ b/client/src/contexts/library/types.ts
@@ -1,0 +1,20 @@
+import { FactoryOptions } from '../production/types';
+
+// A single saved factory in the localStorage library.
+export type LibraryFactory = {
+  id: string;
+  nickname?: string;
+  gameVersion: string;
+  // Undefined for a freshly-created/just-imported slot: the production reducer
+  // initializes it and autosave writes the real config back on first edit.
+  config?: FactoryOptions;
+  // The share key this factory was imported from, if any (no dedupe in v1).
+  sourceKey?: string;
+  createdAt: number; // epoch ms
+  updatedAt: number; // epoch ms
+};
+
+// The library is a map keyed by factory id.
+export type LibraryMap = {
+  [id: string]: LibraryFactory;
+};

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -92,21 +92,15 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
     }
   };
 
-  // Initial load (and after a different-version refetch remounts this provider).
+  // Load the active factory whenever game data tells us to: on the initial load /
+  // different-version refetch (triggerInitialize), or a same-version switch that
+  // reloads without a refetch (reinitToken).
   useEffect(() => {
-    if (triggerInitialize) {
+    if (triggerInitialize || reinitToken > 0) {
       loadFromInitializer();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [triggerInitialize]);
-
-  // Same-version factory switch: reload the new active config without a refetch.
-  useEffect(() => {
-    if (reinitToken > 0) {
-      loadFromInitializer();
-    }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [reinitToken]);
+  }, [triggerInitialize, reinitToken]);
 
   // Performance is good enough to always auto-solve on any state change. The initial
   // state (prevState === undefined) is skipped; the load dispatch above produces the

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -1,6 +1,5 @@
-import React, { createContext, useContext, useReducer, useEffect, useMemo, useRef } from 'react';
+import React, { createContext, useContext, useReducer, useEffect, useMemo } from 'react';
 import { usePrevious } from '../../hooks/usePrevious';
-import { useSessionStorage } from '../../hooks/useSessionStorage';
 import { usePostSharedFactory } from '../../api/modules/shared-factories/usePostSharedFactory';
 import { reducer, FactoryAction, getInitialState } from './reducer';
 import { FactoryOptions } from './types';
@@ -9,6 +8,7 @@ import { GameData } from '../gameData/types';
 import { SHARE_QUERY_PARAM } from '../gameData/consts';
 import { SolverResults } from '../../utilities/production-solver/models';
 import { useSolverRun } from './useSolverRun';
+import { useLibraryContext } from '../library';
 
 
 export type ShareLinkProps = { link: string, copyToClipboard: boolean, loading: boolean };
@@ -21,8 +21,6 @@ export type ProductionContextType = {
   calculating: boolean,
   solverResults: SolverResults | null,
   calculate: () => void,
-  autoCalculate: boolean,
-  setAutoCalculate: (value: boolean) => void,
   generateShareLink: () => void,
   shareLink: ShareLinkProps,
 };
@@ -49,14 +47,13 @@ type PropTypes = {
   gameVersion: string,
   initializer: FactoryInitializer | null,
   triggerInitialize: boolean,
+  reinitToken: number,
   children: React.ReactNode,
 };
-export const ProductionProvider = ({ gameData, gameVersion, initializer, triggerInitialize, children }: PropTypes) => {
+export const ProductionProvider = ({ gameData, gameVersion, initializer, triggerInitialize, reinitToken, children }: PropTypes) => {
+  const lib = useLibraryContext();
   const [state, dispatch] = useReducer(reducer, getInitialState(gameData));
   const prevState = usePrevious(state);
-
-  const [autoCalculate, setAutoCalculate] = useSessionStorage<'false' | 'true'>({ key: 'auto-calculate', defaultValue: 'true' });
-  const autoCalculateBool = autoCalculate === 'true' ? true : false;
 
   const postSharedFactory = usePostSharedFactory();
 
@@ -64,23 +61,13 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
   // and the calculating flag) lives in useSolverRun. The provider only decides WHEN to solve.
   const { solverResults, calculating, calculate: handleCalculateFactory } = useSolverRun(state, gameData);
 
-  // Set to true in triggerInitialize effect so the state-change effect runs the solve after dispatch applies.
-  const forceCalculateRef = useRef(false);
-
-  const handleSetAutoCalculate = (checked: boolean) => {
-    setAutoCalculate(checked ? 'true' : 'false');
-    if (checked) {
-      handleCalculateFactory();
-    }
-  };
-
   const handleGenerateShareLink = () => {
     postSharedFactory.request({ factoryConfig: state, gameVersion });
   };
 
   const shareLink: ShareLinkProps = useMemo(() => {
     let link = '';
-    const key = postSharedFactory.data?.key || initializer?.shareKey;
+    const key = postSharedFactory.data?.key;
     if (key) {
       link = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${SHARE_QUERY_PARAM}=${key}`;
     }
@@ -89,40 +76,53 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
       copyToClipboard: !!postSharedFactory.data?.key,
       loading: postSharedFactory.loading,
     }
-  }, [initializer?.shareKey, postSharedFactory.data?.key, postSharedFactory.loading]);
-  
+  }, [postSharedFactory.data?.key, postSharedFactory.loading]);
+
+  // Load the active factory's content into the reducer. Shared/legacy take priority
+  // (URL imports), then a stored library config, else a fresh/empty factory.
+  const loadFromInitializer = () => {
+    if (initializer?.factoryConfig) {
+      dispatch({ type: 'LOAD_FROM_SHARED_FACTORY', config: initializer.factoryConfig, gameData });
+    } else if (initializer?.legacyEncoding) {
+      dispatch({ type: 'LOAD_FROM_LEGACY_ENCODING', encoding: initializer.legacyEncoding, gameData });
+    } else if (initializer?.libraryConfig) {
+      dispatch({ type: 'LOAD_FROM_LIBRARY', config: initializer.libraryConfig, gameData });
+    } else {
+      dispatch({ type: 'RESET_FACTORY', gameData });
+    }
+  };
+
+  // Initial load (and after a different-version refetch remounts this provider).
   useEffect(() => {
     if (triggerInitialize) {
-      if (initializer?.factoryConfig) {
-        dispatch({ type: 'LOAD_FROM_SHARED_FACTORY', config: initializer.factoryConfig, gameData });
-      } else if (initializer?.legacyEncoding) {
-        dispatch({ type: 'LOAD_FROM_LEGACY_ENCODING', encoding: initializer.legacyEncoding, gameData });
-      } else if (initializer?.sessionState) {
-        dispatch({ type: 'LOAD_FROM_SESSION_STORAGE', sessionState: initializer?.sessionState, gameData });
-      } else {
-        dispatch({ type: 'RESET_FACTORY', gameData });
-      }
-      // Don't call handleCalculateFactory() here — state hasn't updated yet (dispatch is async).
-      // Set the flag so the state-change effect below runs the solve after the new state is applied.
-      forceCalculateRef.current = true;
+      loadFromInitializer();
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [triggerInitialize]);
 
+  // Same-version factory switch: reload the new active config without a refetch.
   useEffect(() => {
-    if (prevState !== undefined && prevState !== state && (autoCalculateBool || forceCalculateRef.current)) {
-      forceCalculateRef.current = false;
+    if (reinitToken > 0) {
+      loadFromInitializer();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reinitToken]);
+
+  // Performance is good enough to always auto-solve on any state change. The initial
+  // state (prevState === undefined) is skipped; the load dispatch above produces the
+  // first real state change, which triggers the initial solve.
+  useEffect(() => {
+    if (prevState !== undefined && prevState !== state) {
       handleCalculateFactory();
     }
-  }, [autoCalculateBool, handleCalculateFactory, prevState, state]);
+  }, [handleCalculateFactory, prevState, state]);
 
+  // Autosave the live reducer state into the active library slot. Skipped on the
+  // initial (pre-load) state so it never clobbers a stored config before it loads.
   useEffect(() => {
-      try {
-        window.sessionStorage.setItem('game-version', gameVersion);
-        window.sessionStorage.setItem('state', JSON.stringify(state));
-      } catch (e) {
-        console.error(e);
-      }
+    if (prevState !== undefined) {
+      lib.saveActiveConfig(state);
+    }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state]);
 
@@ -134,8 +134,6 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
       calculating,
       solverResults,
       calculate: handleCalculateFactory,
-      autoCalculate: autoCalculateBool,
-      setAutoCalculate: handleSetAutoCalculate,
       generateShareLink: handleGenerateShareLink,
       shareLink,
     };
@@ -146,7 +144,6 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
     calculating,
     solverResults,
     handleCalculateFactory,
-    autoCalculateBool,
     shareLink,
   ]);
 

--- a/client/src/contexts/production/reducer.test.ts
+++ b/client/src/contexts/production/reducer.test.ts
@@ -579,12 +579,12 @@ describe('reducer', () => {
     });
   });
 
-  describe('LOAD_FROM_SESSION_STORAGE', () => {
-    it('loads state from session storage', () => {
+  describe('LOAD_FROM_LIBRARY', () => {
+    it('loads a stored library config', () => {
       const savedState = createStateWithProductionItem();
       const result = reducer(createInitialState(), {
-        type: 'LOAD_FROM_SESSION_STORAGE',
-        sessionState: savedState,
+        type: 'LOAD_FROM_LIBRARY',
+        config: savedState,
         gameData: mockGameData,
       });
       expect(result).toEqual(savedState);

--- a/client/src/contexts/production/reducer.tsx
+++ b/client/src/contexts/production/reducer.tsx
@@ -153,7 +153,7 @@ export type FactoryAction =
   | { type: 'MASS_SET_BUILDINGS_ACTIVE', buildings: string[], active: boolean }
   | { type: 'LOAD_FROM_SHARED_FACTORY', config: any, gameData: GameData }
   | { type: 'LOAD_FROM_LEGACY_ENCODING', encoding: string, gameData: GameData }
-  | { type: 'LOAD_FROM_SESSION_STORAGE', sessionState: FactoryOptions, gameData: GameData }
+  | { type: 'LOAD_FROM_LIBRARY', config: FactoryOptions, gameData: GameData }
   | { type: 'UPDATE_NODES_POSTIONS', nodesPositions: NodeInfo[] }
   | { type: 'SET_MAXIMIZE_BALANCE_MODE', mode: MaximizeBalanceMode }
   | { type: 'UPDATE_TRANSPORT_OPTIONS', data: TransportOptions };
@@ -373,15 +373,15 @@ export function reducer(state: FactoryOptions, action: FactoryAction): FactoryOp
         return getInitialState(action.gameData);
       }
     }
-    case 'LOAD_FROM_SESSION_STORAGE': {
+    case 'LOAD_FROM_LIBRARY': {
       try {
         // TODO: some validation
         return {
-          ...action.sessionState,
-          maximizeBalanceMode: action.sessionState.maximizeBalanceMode ?? DEFAULT_MAXIMIZE_BALANCE_MODE,
-          transportOptions: action.sessionState.transportOptions ?? getInitialTransportOptions(),
-          gameModeOptions: action.sessionState.gameModeOptions ?? getInitialGameModeOptions(),
-          allowedBuildings: action.sessionState.allowedBuildings ?? getInitialAllowedBuildings(action.gameData.recipes),
+          ...action.config,
+          maximizeBalanceMode: action.config.maximizeBalanceMode ?? DEFAULT_MAXIMIZE_BALANCE_MODE,
+          transportOptions: action.config.transportOptions ?? getInitialTransportOptions(),
+          gameModeOptions: action.config.gameModeOptions ?? getInitialGameModeOptions(),
+          allowedBuildings: action.config.allowedBuildings ?? getInitialAllowedBuildings(action.gameData.recipes),
         };
       } catch (e) {
         console.error(e);

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -157,6 +157,36 @@ export const theme: MantineThemeOverride = {
         },
       },
     },
+    Modal: {
+      // The factory Rename/Delete dialogs are the app's only modals. Dress them to
+      // match the rest of the UI: the same steel Paper surface, squared corners, and
+      // the FICSIT-orange left accent the Card component uses — instead of the plain
+      // generic Mantine modal with its faint two-tone header.
+      defaultProps: { radius: 'sm', centered: true },
+      styles: {
+        content: {
+          background: 'light-dark(#ffffff, #373b40)',
+          borderLeft: '5px solid var(--mantine-color-primary-6)',
+        },
+        header: {
+          background: 'light-dark(#ffffff, #373b40)',
+          borderBottom: '1px solid light-dark(#dee2e6, #50565e)',
+          paddingBottom: '12px',
+        },
+        title: {
+          fontWeight: 700,
+          fontSize: '18px',
+          color: 'light-dark(#212529, #eee)',
+        },
+        body: {
+          paddingTop: '16px',
+          color: 'light-dark(#212529, #eee)',
+        },
+        close: {
+          color: 'light-dark(#212529, #eee)',
+        },
+      },
+    },
   },
 };
 

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -162,7 +162,9 @@ export const theme: MantineThemeOverride = {
       // match the rest of the UI: the same steel Paper surface, squared corners, and
       // the FICSIT-orange left accent the Card component uses — instead of the plain
       // generic Mantine modal with its faint two-tone header.
-      defaultProps: { radius: 'sm', centered: true },
+      // Mantine v9 doesn't give the auto close button an accessible name; set one
+      // so the dialogs satisfy the WCAG button-name rule.
+      defaultProps: { radius: 'sm', centered: true, closeButtonProps: { 'aria-label': 'Close' } },
       styles: {
         content: {
           background: 'light-dark(#ffffff, #373b40)',

--- a/client/src/utilities/factory-label.test.ts
+++ b/client/src/utilities/factory-label.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { deriveAutoLabel, labelOf, relativeTime } from './factory-label';
+import { FactoryOptions, ProductionItemOptions } from '../contexts/production/types';
+import { GameData } from '../contexts/gameData/types';
+import { LibraryFactory } from '../contexts/library/types';
+
+// deriveAutoLabel/labelOf only read gameData.items[key]?.name, so a partial
+// items map is enough — the rest of GameData is irrelevant here.
+const gameData = {
+  items: {
+    Desc_IronPlate_C: { name: 'Iron Plate' },
+    Desc_Rotor_C: { name: 'Rotor' },
+  },
+} as unknown as GameData;
+
+function product(over: Partial<ProductionItemOptions>): ProductionItemOptions {
+  return { key: 'k', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '30', ...over };
+}
+
+function config(productionItems: ProductionItemOptions[]): FactoryOptions {
+  return { productionItems } as FactoryOptions;
+}
+
+describe('deriveAutoLabel', () => {
+  it('returns "Empty factory" for an undefined config', () => {
+    expect(deriveAutoLabel(undefined, gameData)).toBe('Empty factory');
+  });
+
+  it('returns "Empty factory" when there are no production items', () => {
+    expect(deriveAutoLabel(config([]), gameData)).toBe('Empty factory');
+  });
+
+  it('formats a per-minute goal as "Name ×N"', () => {
+    expect(deriveAutoLabel(config([product({ mode: 'per-minute', value: '30' })]), gameData))
+      .toBe('Iron Plate ×30');
+  });
+
+  it('formats a non-per-minute goal as "Name (max)"', () => {
+    expect(deriveAutoLabel(config([product({ mode: 'maximize', value: '0' })]), gameData))
+      .toBe('Iron Plate (max)');
+  });
+
+  it('joins multiple goals with ", "', () => {
+    const label = deriveAutoLabel(
+      config([
+        product({ itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '30' }),
+        product({ itemKey: 'Desc_Rotor_C', mode: 'maximize', value: '0' }),
+      ]),
+      gameData,
+    );
+    expect(label).toBe('Iron Plate ×30, Rotor (max)');
+  });
+
+  it('falls back to the raw itemKey when the item is unknown', () => {
+    expect(deriveAutoLabel(config([product({ itemKey: 'Desc_Unknown_C' })]), gameData))
+      .toBe('Desc_Unknown_C ×30');
+  });
+
+  it('ignores placeholder rows with an empty itemKey', () => {
+    const label = deriveAutoLabel(
+      config([
+        product({ itemKey: '' }),
+        product({ itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '12' }),
+      ]),
+      gameData,
+    );
+    expect(label).toBe('Iron Plate ×12');
+  });
+
+  it('shows ×0 when a per-minute value is empty', () => {
+    expect(deriveAutoLabel(config([product({ mode: 'per-minute', value: '' })]), gameData))
+      .toBe('Iron Plate ×0');
+  });
+});
+
+describe('labelOf', () => {
+  const base: LibraryFactory = {
+    id: '1',
+    gameVersion: '1.2',
+    config: config([product({ mode: 'per-minute', value: '30' })]),
+    createdAt: 0,
+    updatedAt: 0,
+  };
+
+  it('uses the nickname when set', () => {
+    expect(labelOf({ ...base, nickname: 'My Base' }, gameData)).toBe('My Base');
+  });
+
+  it('derives from outputs when there is no nickname', () => {
+    expect(labelOf(base, gameData)).toBe('Iron Plate ×30');
+  });
+
+  it('derives from outputs when the nickname is an empty string', () => {
+    expect(labelOf({ ...base, nickname: '' }, gameData)).toBe('Iron Plate ×30');
+  });
+});
+
+describe('relativeTime', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-28T12:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const now = () => Date.now();
+
+  it('returns "just now" under a minute', () => {
+    expect(relativeTime(now() - 30_000)).toBe('just now');
+  });
+
+  it('returns minutes within the hour', () => {
+    expect(relativeTime(now() - 5 * 60_000)).toBe('5m ago');
+  });
+
+  it('returns hours within the day', () => {
+    expect(relativeTime(now() - 3 * 60 * 60_000)).toBe('3h ago');
+  });
+
+  it('returns days beyond a day', () => {
+    expect(relativeTime(now() - 2 * 24 * 60 * 60_000)).toBe('2d ago');
+  });
+});

--- a/client/src/utilities/factory-label.ts
+++ b/client/src/utilities/factory-label.ts
@@ -1,0 +1,34 @@
+import { FactoryOptions } from '../contexts/production/types';
+import { GameData } from '../contexts/gameData/types';
+import { LibraryFactory } from '../contexts/library/types';
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+// Auto-label a factory from its production outputs, e.g.
+// "Reinforced Iron Plate ×30, Rotor (max)". Empty factory => "Empty factory".
+export function deriveAutoLabel(config: FactoryOptions | undefined, gameData: GameData): string {
+  const parts = (config?.productionItems ?? [])
+    .filter((p) => p.itemKey)
+    .map((p) => {
+      const name = gameData.items[p.itemKey]?.name ?? p.itemKey;
+      if (p.mode === 'per-minute') return `${name} ×${p.value || '0'}`;
+      return `${name} (max)`;
+    });
+  if (parts.length === 0) return 'Empty factory';
+  return parts.join(', ');
+}
+
+// A nickname overrides the auto-label; otherwise derive from outputs.
+export function labelOf(factory: LibraryFactory, gameData: GameData): string {
+  return factory.nickname || deriveAutoLabel(factory.config, gameData);
+}
+
+export function relativeTime(ms: number): string {
+  const diff = Date.now() - ms;
+  if (diff < MINUTE) return 'just now';
+  if (diff < HOUR) return `${Math.floor(diff / MINUTE)}m ago`;
+  if (diff < DAY) return `${Math.floor(diff / HOUR)}h ago`;
+  return `${Math.floor(diff / DAY)}d ago`;
+}

--- a/client/src/utilities/shared-factory/codec.ts
+++ b/client/src/utilities/shared-factory/codec.ts
@@ -116,6 +116,13 @@ export type DecodedFactory = {
 
 // ---- Encode: client FactoryOptions -> wire shape ----
 
+// A factory is shareable only if it has at least one selected product; the API
+// rejects an empty production list. encode() drops unselected placeholder rows, so
+// this mirrors what would actually be sent.
+export function canShareFactory(config: FactoryOptions): boolean {
+  return config.productionItems.some((i) => i.itemKey);
+}
+
 export function encode(config: FactoryOptions, gameVersion: string): WireFactory {
   // Drop placeholder rows that have no item selected yet: they carry no information,
   // the solver ignores them, and the API rejects them (ItemKey must not be empty).

--- a/client/src/utilities/shared-factory/codec.ts
+++ b/client/src/utilities/shared-factory/codec.ts
@@ -117,19 +117,25 @@ export type DecodedFactory = {
 // ---- Encode: client FactoryOptions -> wire shape ----
 
 export function encode(config: FactoryOptions, gameVersion: string): WireFactory {
+  // Drop placeholder rows that have no item selected yet: they carry no information,
+  // the solver ignores them, and the API rejects them (ItemKey must not be empty).
   return {
     gameVersion: toEnumName(gameVersion),
-    productionItems: config.productionItems.map((i) => ({
-      itemKey: i.itemKey,
-      mode: i.mode,
-      value: Number(i.value),
-    })),
-    inputItems: config.inputItems.map((i) => ({
-      itemKey: i.itemKey,
-      value: Number(i.value),
-      weight: Number(i.weight),
-      unlimited: i.unlimited,
-    })),
+    productionItems: config.productionItems
+      .filter((i) => i.itemKey)
+      .map((i) => ({
+        itemKey: i.itemKey,
+        mode: i.mode,
+        value: Number(i.value),
+      })),
+    inputItems: config.inputItems
+      .filter((i) => i.itemKey)
+      .map((i) => ({
+        itemKey: i.itemKey,
+        value: Number(i.value),
+        weight: Number(i.weight),
+        unlimited: i.unlimited,
+      })),
     inputResources: config.inputResources.map((i) => ({
       itemKey: i.itemKey,
       value: Number(i.value),

--- a/client/tests/a11y.spec.ts
+++ b/client/tests/a11y.spec.ts
@@ -105,18 +105,16 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
     expect(results.violations).toEqual([]);
   });
 
-  test('Reset-confirmation modal has no WCAG A/AA violations', async ({ page }) => {
+  test('Delete-factory modal has no WCAG A/AA violations', async ({ page }) => {
     await page.goto('/');
 
-    // Open the control panel drawer
-    const openPanelBtn = page.getByRole('button', { name: 'Open Control Panel' });
-    await openPanelBtn.click();
-
-    // Open the reset-confirmation modal
-    await page.getByRole('button', { name: 'Reset ALL Factory Options' }).click();
+    // Open the Delete dialog from the factory switcher's actions menu (the body
+    // switcher is always visible; the drawer stays closed).
+    await page.getByRole('button', { name: 'Factory actions' }).click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
 
     // Wait for the modal dialog to be present before scanning
-    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.getByRole('dialog', { name: 'Delete factory' })).toBeVisible();
 
     // Scope the scan to the dialog itself: the open Modal renders a translucent
     // overlay that dims the (inert, aria-hidden) page behind it, which would
@@ -128,16 +126,26 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
   });
 
   test('Share-link "copied" popover has no WCAG A/AA violations', async ({ page }) => {
+    // Stub the share endpoint so the popover opens without a live backend.
+    await page.route(/\/share-factory$/, async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { key: 'a11ysharekey00001' } }),
+      });
+    });
+
     await page.goto('/');
 
-    // Open the control panel drawer
-    const openPanelBtn = page.getByRole('button', { name: 'Open Control Panel' });
-    await openPanelBtn.click();
+    // Share is gated until the factory has a product, so add one first.
+    await page.getByRole('button', { name: 'Open Control Panel' }).click();
+    await page.getByRole('button', { name: '+ Add Product' }).click();
+    await page.getByPlaceholder('Select an item').click();
+    await page.getByRole('option', { name: 'Iron Plate', exact: true }).click();
+    await page.getByRole('button', { name: 'Close Control Panel' }).click();
 
-    // Clicking the share input opens the "Link copied!" popover directly,
-    // avoiding the backend round-trip the "Save & Share" button performs.
-    await page.getByPlaceholder('Save factory to generate a link').click();
-
+    // Clicking Share posts the factory and opens the "Link copied!" popover.
+    await page.getByRole('button', { name: 'Share' }).click();
     await expect(page.getByText('Link copied!')).toBeVisible();
 
     const results = await buildScan(page).analyze();

--- a/client/tests/factory-library.spec.ts
+++ b/client/tests/factory-library.spec.ts
@@ -1,0 +1,245 @@
+import { test, expect, Page } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Reuse the same canned /initialize payload the main e2e suite uses, so these
+// tests run against the dev server with no Aspire backend.
+const fixtureResponse = readFileSync(join(__dirname, 'fixtures/initialize-response.json'), 'utf-8');
+
+// Factory tabs share the app's `segmented-tabs` look with the drawer/view tabs, so
+// they're disambiguated by their title attribute ("<label> · edited <time>"), set in
+// FactorySwitcher.tsx.
+const FACTORY_TAB = '[role="tab"][title*="edited"]';
+const LOADING = 'Loading game data...';
+
+async function mockInitialize(page: Page, opts: { delayMs?: number } = {}) {
+  await page.route(/\/initialize(\?.*)?$/, async (route) => {
+    if (opts.delayMs) await new Promise((r) => setTimeout(r, opts.delayMs));
+    await route.fulfill({ status: 200, contentType: 'application/json', body: fixtureResponse });
+  });
+}
+
+async function gotoApp(page: Page, url = '/') {
+  await page.goto(url);
+  await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible({ timeout: 30_000 });
+}
+
+async function openControlPanel(page: Page) {
+  await page.getByRole('button', { name: 'Open Control Panel' }).click();
+  await page.getByRole('tab', { name: 'Production', exact: true }).click();
+}
+
+async function closeControlPanel(page: Page) {
+  await page.getByRole('button', { name: 'Close Control Panel' }).click();
+}
+
+async function addProduct(page: Page, name: string) {
+  await page.getByRole('button', { name: '+ Add Product' }).click();
+  await page.getByPlaceholder('Select an item').last().click();
+  await page.getByRole('option', { name, exact: true }).click();
+}
+
+test.describe('Multi-factory library', () => {
+  test.beforeEach(async ({ page }) => {
+    // Drawer starts closed so the FactorySwitcher controls in the main body are
+    // reachable without the drawer overlapping them.
+    await page.addInitScript(() => {
+      sessionStorage.setItem('drawer-open', '"false"');
+    });
+    await mockInitialize(page);
+  });
+
+  test('persists a factory across reloads via localStorage', async ({ page }) => {
+    await gotoApp(page);
+    await openControlPanel(page);
+    await addProduct(page, 'Iron Plate');
+    await closeControlPanel(page);
+
+    // The active tab's auto-label reflects the product, and the library is in localStorage.
+    await expect(page.locator(FACTORY_TAB).first()).toContainText('Iron Plate');
+    const stored = await page.evaluate(() => localStorage.getItem('factory-library'));
+    expect(stored).toContain('Desc_IronPlate_C');
+
+    // Reload: the factory comes back from localStorage (previously this work was lost).
+    await page.reload();
+    await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(FACTORY_TAB).first()).toContainText('Iron Plate');
+  });
+
+  test('supports create / rename / duplicate / delete, persisted across reload', async ({ page }) => {
+    await gotoApp(page);
+    const tabs = page.locator(FACTORY_TAB);
+    await expect(tabs).toHaveCount(1);
+
+    // New
+    await page.getByRole('button', { name: 'New factory' }).click();
+    await expect(tabs).toHaveCount(2);
+
+    // Rename the active factory
+    await page.getByRole('button', { name: 'Factory actions' }).click();
+    await page.getByRole('menuitem', { name: 'Rename' }).click();
+    const renameDialog = page.getByRole('dialog', { name: 'Rename factory' });
+    await renameDialog.getByLabel('Nickname').fill('My Steel Base');
+    await renameDialog.getByRole('button', { name: 'Save' }).click();
+    await expect(tabs.filter({ hasText: 'My Steel Base' })).toHaveCount(1);
+
+    // Duplicate → "<name> (copy)"
+    await page.getByRole('button', { name: 'Factory actions' }).click();
+    await page.getByRole('menuitem', { name: 'Duplicate' }).click();
+    await expect(tabs).toHaveCount(3);
+    await expect(tabs.filter({ hasText: 'My Steel Base (copy)' })).toHaveCount(1);
+
+    // Delete the active (the copy)
+    await page.getByRole('button', { name: 'Factory actions' }).click();
+    await page.getByRole('menuitem', { name: 'Delete' }).click();
+    const deleteDialog = page.getByRole('dialog', { name: 'Delete factory' });
+    await deleteDialog.getByRole('button', { name: 'Delete' }).click();
+    await expect(tabs).toHaveCount(2);
+    await expect(tabs.filter({ hasText: 'My Steel Base (copy)' })).toHaveCount(0);
+
+    // Persisted across reload
+    await page.reload();
+    await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible({ timeout: 30_000 });
+    await expect(tabs).toHaveCount(2);
+    await expect(tabs.filter({ hasText: 'My Steel Base' })).toHaveCount(1);
+  });
+
+  test('reset-to-empty clears the active factory', async ({ page }) => {
+    await gotoApp(page);
+    await openControlPanel(page);
+    await addProduct(page, 'Iron Plate');
+    await closeControlPanel(page);
+    await expect(page.locator(FACTORY_TAB).first()).toContainText('Iron Plate');
+
+    await page.getByRole('button', { name: 'Factory actions' }).click();
+    await page.getByRole('menuitem', { name: 'Reset to empty' }).click();
+
+    await expect(page.locator(FACTORY_TAB).first()).toContainText('Empty factory');
+  });
+
+  test('switching between same-version factories is instant (no loading overlay)', async ({ page }) => {
+    await gotoApp(page);
+
+    // Factory A: Iron Plate
+    await openControlPanel(page);
+    await addProduct(page, 'Iron Plate');
+    await closeControlPanel(page);
+
+    // Factory B: Iron Rod
+    await page.getByRole('button', { name: 'New factory' }).click();
+    await openControlPanel(page);
+    await addProduct(page, 'Iron Rod');
+    await closeControlPanel(page);
+
+    const tabs = page.locator(FACTORY_TAB);
+    const ironPlateTab = tabs.filter({ hasText: 'Iron Plate' });
+
+    // Switch back to A. The overlay (which only renders on a game-data refetch) must
+    // never appear, and the target tab must be selected immediately with its real
+    // label — no "Empty factory" flash.
+    await ironPlateTab.click();
+    await expect(page.getByText(LOADING)).toHaveCount(0);
+    await expect(ironPlateTab).toHaveAttribute('aria-selected', 'true');
+    await expect(tabs.filter({ hasText: 'Empty factory' })).toHaveCount(0);
+  });
+
+  test('switching to a different-version factory shows the loading overlay', async ({ page }) => {
+    // Add latency so the refetch overlay is observable.
+    await mockInitialize(page, { delayMs: 600 });
+    await gotoApp(page);
+
+    const tabs = page.locator(FACTORY_TAB);
+    const versionSelect = page.getByRole('combobox', { name: 'Game version' });
+
+    // Factory A stays on 1.2. Create B and retarget it to 1.1 (this itself refetches).
+    await page.getByRole('button', { name: 'New factory' }).click();
+    await expect(tabs).toHaveCount(2);
+    await versionSelect.click();
+    await page.getByRole('option', { name: '1.1', exact: true }).click();
+    await expect(page.getByText(LOADING)).toBeVisible();
+    await expect(page.getByText(LOADING)).toBeHidden({ timeout: 15_000 });
+    await expect(versionSelect).toHaveValue(/1\.1/);
+
+    // Switch to A (1.2): a different-version switch must refetch → overlay appears.
+    await tabs.first().click();
+    await expect(page.getByText(LOADING)).toBeVisible();
+    await expect(page.getByText(LOADING)).toBeHidden({ timeout: 15_000 });
+    await expect(versionSelect).toHaveValue(/1\.2/);
+  });
+
+  test('imports a ?factory= share link as a new slot and strips the URL', async ({ page }) => {
+    // Return a saved config when the share key is present (mirrors the API).
+    await page.route(/\/initialize(\?.*)?$/, async (route) => {
+      const body = JSON.parse(fixtureResponse);
+      if (route.request().url().includes('factoryKey=')) {
+        body.data.factory_config = {
+          gameVersion: 'V1_2',
+          productionItems: [{ itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: 10 }],
+          inputItems: [],
+          inputResources: [],
+          allowHandGatheredItems: false,
+          weightingOptions: { resources: 1000, power: 1, complexity: 0, buildings: 0 },
+          gameModeOptions: { recipePartsCost: 1, powerConsumption: 1 },
+          allowedRecipes: [],
+          nodesPositions: [],
+        };
+      }
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    });
+
+    await gotoApp(page, '/?factory=e2eimportkey0001');
+
+    // URL is stripped of the query string after import.
+    await expect(page).toHaveURL(/^[^?]*$/);
+
+    // The imported factory is a slot labelled from its config, and persists on reload.
+    const imported = page.locator(FACTORY_TAB).filter({ hasText: 'Iron Plate' });
+    await expect(imported).toHaveCount(1);
+
+    await page.reload();
+    await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(FACTORY_TAB).filter({ hasText: 'Iron Plate' })).toHaveCount(1);
+  });
+
+  test('Share is gated until a product exists, then posts and confirms', async ({ page }) => {
+    // Stub the share endpoint so no real backend is needed.
+    await page.route(/\/share-factory$/, async (route) => {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { key: 'e2esharekey00001' } }),
+      });
+    });
+
+    await gotoApp(page);
+
+    // Empty factory → Share disabled (firing it would 400).
+    const shareBtn = page.getByRole('button', { name: 'Share' });
+    await expect(shareBtn).toBeDisabled();
+
+    // Add a product → Share becomes enabled.
+    await openControlPanel(page);
+    await addProduct(page, 'Iron Plate');
+    await closeControlPanel(page);
+    await expect(shareBtn).toBeEnabled();
+
+    // Click → the share request fires and the copied-confirmation popover appears.
+    const sharePost = page.waitForResponse(
+      (r) => r.url().includes('/share-factory') && r.status() === 201,
+      { timeout: 15_000 },
+    );
+    await shareBtn.click();
+    await sharePost;
+    await expect(page.getByText('Link copied!')).toBeVisible();
+  });
+
+  test('exposes no Calculate, Auto-calculate, or Save & Share controls', async ({ page }) => {
+    await gotoApp(page);
+    await openControlPanel(page);
+
+    await expect(page.getByRole('button', { name: /calculate/i })).toHaveCount(0);
+    await expect(page.getByRole('switch', { name: /auto-calculate/i })).toHaveCount(0);
+    await expect(page.getByText(/auto-calculate/i)).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /save & share/i })).toHaveCount(0);
+  });
+});

--- a/client/tests/main.spec.ts
+++ b/client/tests/main.spec.ts
@@ -291,10 +291,12 @@ test.describe('Factory Planner Application', () => {
     // Wait for calculation
     await page.waitForTimeout(500);
 
-    // Verify the Save & Share button exists and is clickable
-    const saveShareBtn = page.getByRole('button', { name: 'Save & Share' });
-    await expect(saveShareBtn).toBeVisible();
-    await expect(saveShareBtn).toBeEnabled();
+    // The Share control now lives in the body FactorySwitcher; close the drawer so
+    // it isn't overlapped. With a product selected it must be enabled.
+    await page.getByRole('button', { name: 'Close Control Panel' }).click();
+    const shareBtn = page.getByRole('button', { name: 'Share' });
+    await expect(shareBtn).toBeVisible();
+    await expect(shareBtn).toBeEnabled();
   });
 
   test('should send game mode multipliers in the save & share request', async ({ page }) => {
@@ -323,7 +325,9 @@ test.describe('Factory Planner Application', () => {
     await page.getByRole('combobox', { name: 'Power Multiplier' }).click();
     await page.getByRole('option', { name: '2x', exact: true }).click();
 
-    await page.getByRole('button', { name: 'Save & Share' }).click();
+    // Share moved to the body FactorySwitcher; close the drawer so it isn't overlapped.
+    await page.getByRole('button', { name: 'Close Control Panel' }).click();
+    await page.getByRole('button', { name: 'Share' }).click();
 
     await expect.poll(() => sharedBody).not.toBeNull();
     expect(sharedBody.factoryConfig.gameModeOptions).toEqual({

--- a/docs/multi-factory-library.md
+++ b/docs/multi-factory-library.md
@@ -1,0 +1,112 @@
+# Multi-Factory Library (design)
+
+- Status: Proposed
+- Date: 2026-06-26
+
+## Problem
+
+Factory configuration is lost when the browser is closed. The active factory lives
+in the `production` reducer and is persisted only to **`sessionStorage`**
+(`client/src/contexts/production/index.tsx`, keys `state` + `game-version`).
+`sessionStorage` survives a refresh within a tab but is wiped on tab/browser close —
+hence the lost work. There is also no concept of keeping **multiple** designs around or
+switching between them.
+
+## Goal
+
+A named library of factories persisted in `localStorage`, with a switcher/manager in the
+UI, such that no work is ever silently lost and multiple designs coexist.
+
+## Decisions
+
+### Core model — autosave, no Save button
+
+- A library of factories stored in `localStorage`. Every edit **autosaves** to the active
+  factory's slot. Eliminating "lost my work" is the whole point, so there is no explicit
+  Save button.
+- Per-factory shape:
+  `{ id, nickname?, gameVersion, config: FactoryOptions, sourceKey?, createdAt, updatedAt }`.
+
+### Identity — derived, not typed
+
+- A switcher entry shows an **auto-label derived from production outputs**
+  (e.g. "Reinforced Iron Plate ×30, Rotor ×10", from `state.productionItems` joined with
+  `gameData.items[].name`), a **"last edited"** line (`updatedAt`), and an **optional
+  nickname** that overrides the auto-label. Empty factory → "Empty factory".
+- No forced naming. Naming is opt-in polish for the few factories worth labelling.
+- Item **icons/thumbnails were rejected** for v1: the client renders items as text names
+  and ships no item art, so an icon/graph-thumbnail identity is disproportionately more
+  work. Revisit as a possible v2.
+
+### Multi-tab — reuse the existing storage split
+
+- `localStorage` = the **shared library** (the data).
+- `sessionStorage` = **this tab's active factory id** (the pointer).
+- Two tabs can edit two different factories independently. The same factory open in two
+  tabs is **last-write-wins** (rare, accepted).
+
+### Fresh-tab / first-load resolution order
+
+For a tab with no active pointer yet:
+
+1. `?factory=` / `?f=` URL → **import as a new library slot**, make active, strip the URL,
+   autosave onward. Re-opening the same link creates a **duplicate** (no dedupe by
+   `sourceKey` in v1 — accepted for simplicity).
+2. Library non-empty → open the factory with **max(`updatedAt`)**.
+3. Library empty → create **"Untitled Factory 1"**.
+
+Migration: on first load after shipping, adopt any existing `sessionStorage` `state` as
+the first library factory so current users don't lose in-progress work.
+
+### Control Panel header redesign
+
+- **Remove the Calculate button and the Auto-calculate toggle entirely.** Performance is
+  good enough to always auto-solve. Concretely: drop the `auto-calculate` `sessionStorage`
+  key; the solve effect (`production/index.tsx`) always runs on state change; keep the
+  internal `calculate()` for the forced initial solve.
+- The redesigned header hosts: the **factory switcher + "New"**, **Share** (relabeled from
+  "Save & Share" — saving is now automatic; the button only POSTs to get a shareable key),
+  and factory actions (**Rename, Duplicate, Delete, Reset-to-empty**).
+- The **exact visual layout is deferred to a prototyping phase.**
+
+### Durability
+
+- `localStorage` + **Export / Import the library as JSON** (manual backup, and to move
+  between browsers/devices). Per-factory share links remain the server-side copy.
+- **Server-sync keyed by `engineerId`** (the app already has an `engineerId` in
+  `localStorage` and a Cosmos-backed API) is **deferred** as a separate, larger project:
+  new endpoints, Cosmos schema, conflict handling, and `engineerId` becoming a losable
+  identity.
+
+### Safety net
+
+- **Duplicate** ("clone before you experiment") is the primary answer to autosave
+  overwrite fear.
+- **Delete** = confirm dialog + a brief "Deleted — Undo" toast.
+- **No version/undo history** in v1.
+
+## Implementation notes (no decision required)
+
+- Switching to a factory on a different `gameVersion` reuses the existing
+  `/initialize?gameVersion=` reload path (same mechanism as loading a shared factory or
+  changing the version selector).
+- `localStorage` quota: hundreds of factories fit comfortably; on `QuotaExceededError`,
+  surface a toast ("storage full — delete some factories or export the library").
+
+## Open items
+
+- The concrete Control Panel header visual layout (settle during prototyping).
+
+## Alternatives considered
+
+- **Explicit Save + dirty working copy** (document-editor model). Rejected: reintroduces a
+  way to lose work and adds an "unsaved changes" concept; autosave is a better fit for the
+  stated pain.
+- **Icon / graph-thumbnail identity.** Rejected for v1 (no item art shipped; thumbnailing
+  the graph is its own project).
+- **Ephemeral share-link loading with "Add to library".** Rejected: editing then
+  refreshing without adding would lose work — the original problem.
+- **Global active-factory pointer in `localStorage`.** Rejected: tabs fight over the active
+  factory and autosaves clobber each other.
+- **Server-sync to `engineerId`.** Deferred (see Durability) — much larger scope than a
+  local-storage feature.


### PR DESCRIPTION
## What & why

Factory config previously lived only in `sessionStorage`, so work was silently lost on tab/browser close and there was no way to keep or switch between multiple designs. This PR adds a **named library of factories in `localStorage` with autosave** (no Save button), a per-tab active pointer, a body factory switcher, and removes the old Calculate/Auto-calculate controls.

Implements the agreed v1 "core" scope from `docs/multi-factory-library.md`.

## What's included

- **Library + autosave** — a new `LibraryProvider` (above `GameDataProvider`) owns the reactive factories list + active id, backed by `localStorage`; every production edit autosaves into the active slot.
- **Factory switcher** (`FactorySwitcher`) in the main body — segmented-tabs header band with New / ⋯ (Rename, Duplicate, Delete, Reset-to-empty) / Share.
- **Derived identity** — auto-label from production outputs (e.g. "Iron Plate ×30"), with optional nickname override.
- **Switch UX** — same game-version switches load instantly (no overlay); only different-version switches show the existing loading overlay.
- **URL import-as-slot** — opening a `?factory=` share / legacy `?f=` link imports it as a new library slot and strips the URL.
- **sessionStorage migration** — existing in-progress work is adopted into the library on first load.
- **Removed** Calculate / Auto-calculate (always auto-solves) and the throwaway `_prototype/`.

## Polish

- Themed the Rename/Delete dialogs to match the app (steel surface, FICSIT-orange Card accent, clean header divider, squared corners) in both light & dark.
- Fixed a tab-label flash and a share-link 400 (empty-product guard + encode filtering) during development.

## Testing

- **Vitest (+42):** `factory-label`, `library/storage`, and `LibraryProvider` CRUD. Full suite **163 pass**.
- **Playwright (+8):** `factory-library.spec.ts` — persistence across reload, switcher CRUD, instant same-version switch vs. version-change overlay, `?factory=` import, and the share guard. Updated two `main.spec.ts` tests that referenced the removed "Save & Share" button.
- Lint clean, production build passes.

## Deferred (follow-up)

Export/Import library as JSON, and Delete→Undo toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Yipzei2SC5x22NmhHDmzq