### PR TITLE
feat(mobile): searchable factory list in the bottom sheet

### DIFF
--- a/client/src/containers/ProductionPlanner/MobileShell/FactoryPicker.tsx
+++ b/client/src/containers/ProductionPlanner/MobileShell/FactoryPicker.tsx
@@ -1,0 +1,172 @@
+// The mobile factory picker: a search-first vertical list of saved factories, shown
+// inside the factory bottom sheet (FactorySheet). It replaces the horizontal tab
+// strip the sheet used to borrow from the desktop FactorySwitcher — on a phone those
+// tabs overflow and scroll sideways, so a filterable list reads far better.
+//
+// Tapping a factory switches to it AND dismisses the sheet (picking one is the whole
+// reason the sheet is open). The per-row "⋮" handles rename/duplicate/delete, plus
+// "Reset to empty" on the active row (it acts on the live reducer state). New + Share
+// sit in the footer; Share targets the active factory, as on desktop.
+import React, { useMemo, useState } from 'react';
+import styled from 'styled-components';
+import { Menu, ActionIcon, Button, Group, Text, TextInput, Tooltip, Popover } from '@mantine/core';
+import { Search, Plus, Share2, Check, MoreVertical, Edit2, Copy, Trash2, RotateCcw } from 'react-feather';
+import { useProductionContext } from '../../../contexts/production';
+import { useLibraryContext } from '../../../contexts/library';
+import { labelOf, relativeTime } from '../../../utilities/factory-label';
+import { canShareFactory } from '../../../utilities/shared-factory/codec';
+import { RenameDialog, DeleteDialog } from '../PlannerOptions/factory-dialogs';
+
+type Props = { onClose: () => void };
+
+const FactoryPicker = ({ onClose }: Props) => {
+  const ctx = useProductionContext();
+  const lib = useLibraryContext();
+  const [query, setQuery] = useState('');
+  const [renameId, setRenameId] = useState<string | null>(null);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const byId = (id: string | null) => (id ? lib.factories.find((f) => f.id === id) : undefined);
+
+  const filtered = useMemo(
+    () => lib.factories.filter((f) => labelOf(f, ctx.gameData).toLowerCase().includes(query.trim().toLowerCase())),
+    [lib.factories, ctx.gameData, query],
+  );
+
+  const pick = (id: string) => { lib.select(id); onClose(); };
+
+  // Guard the Share button rather than firing a POST that 400s with no feedback.
+  const canShare = canShareFactory(ctx.state);
+  const onShare = () => { ctx.generateShareLink(); setCopied(true); setTimeout(() => setCopied(false), 2500); };
+
+  return (
+    <>
+      <TextInput
+        value={query}
+        onChange={(e) => setQuery(e.currentTarget.value)}
+        placeholder="Search factories…"
+        aria-label="Search factories"
+        leftSection={<Search size={16} />}
+        mb="sm"
+      />
+
+      <List className="custom-scrollbar">
+        {filtered.length === 0 ? (
+          <Text size="sm" c="dimmed" ta="center" py="md">No matching factories</Text>
+        ) : (
+          filtered.map((f) => {
+            const isActive = f.id === lib.activeId;
+            return (
+              <Row key={f.id} $active={isActive}>
+                <RowSelect type="button" onClick={() => pick(f.id)} aria-current={isActive}>
+                  <CheckSlot>{isActive && <Check size={16} />}</CheckSlot>
+                  <RowText>
+                    <Text size="sm" fw={isActive ? 600 : 400} truncate>{labelOf(f, ctx.gameData)}</Text>
+                    <Text size="xs" c="dimmed">edited {relativeTime(f.updatedAt)}</Text>
+                  </RowText>
+                </RowSelect>
+                <Menu position="bottom-end" withArrow shadow="md">
+                  <Menu.Target>
+                    <ActionIcon variant="subtle" size="lg" aria-label={`Actions for ${labelOf(f, ctx.gameData)}`} styles={{ root: { color: 'var(--mantine-color-text)' } }}>
+                      <MoreVertical size={18} />
+                    </ActionIcon>
+                  </Menu.Target>
+                  <Menu.Dropdown>
+                    <Menu.Item leftSection={<Edit2 size={14} />} onClick={() => setRenameId(f.id)}>Rename</Menu.Item>
+                    <Menu.Item leftSection={<Copy size={14} />} onClick={() => lib.duplicate(f.id)}>Duplicate</Menu.Item>
+                    <Menu.Item color="red" leftSection={<Trash2 size={14} />} onClick={() => setDeleteId(f.id)}>Delete</Menu.Item>
+                    {isActive && (
+                      <>
+                        <Menu.Divider />
+                        <Menu.Item leftSection={<RotateCcw size={14} />} onClick={() => ctx.dispatch({ type: 'RESET_FACTORY', gameData: ctx.gameData })}>Reset to empty</Menu.Item>
+                      </>
+                    )}
+                  </Menu.Dropdown>
+                </Menu>
+              </Row>
+            );
+          })
+        )}
+      </List>
+
+      <Group gap="xs" mt="md" wrap="nowrap">
+        <Button variant="default" leftSection={<Plus size={16} />} onClick={() => lib.create()} styles={{ root: { color: 'var(--mantine-color-text)' } }}>
+          New factory
+        </Button>
+        <Tooltip label="Add a product to share this factory" withArrow disabled={canShare}>
+          {/* The span keeps the Tooltip alive while the Button is disabled (a disabled
+              control emits no pointer events). The Popover targets the Button so its
+              aria-haspopup/expanded land on an element that supports them. */}
+          <span style={{ marginLeft: 'auto' }}>
+            <Popover opened={copied && canShare} position="top-end" withArrow>
+              <Popover.Target>
+                <Button color="positive.8" leftSection={<Share2 size={16} />} loading={ctx.shareLink.loading} disabled={!canShare} onClick={onShare}>Share</Button>
+              </Popover.Target>
+              <Popover.Dropdown><Text size="sm">{ctx.shareLink.link ? 'Link copied!' : 'Generating…'}</Text></Popover.Dropdown>
+            </Popover>
+          </span>
+        </Tooltip>
+      </Group>
+
+      <RenameDialog opened={!!renameId} initial={byId(renameId)?.nickname ?? ''} onClose={() => setRenameId(null)} onSubmit={(v) => renameId && lib.rename(renameId, v)} />
+      <DeleteDialog opened={!!deleteId} label={byId(deleteId) ? labelOf(byId(deleteId)!, ctx.gameData) : ''} onClose={() => setDeleteId(null)} onConfirm={() => deleteId && lib.remove(deleteId)} />
+    </>
+  );
+};
+
+export default FactoryPicker;
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  /* Cap the list so the New/Share footer stays in view inside the 60%-tall sheet. */
+  max-height: 45vh;
+  /* Breathing room so the cards' accent + focus ring aren't clipped while scrolling. */
+  padding: 2px;
+`;
+
+// Each factory is its own card — steel surface, squared corners, and (when active)
+// the FICSIT-orange left accent the app's Card/Modal use. Inactive cards keep a
+// transparent 5px left edge so switching active doesn't shift the text.
+const Row = styled.div<{ $active?: boolean }>`
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--yafp-graph-border);
+  border-left: 5px solid ${({ $active }) => ($active ? 'var(--mantine-color-primary-6)' : 'transparent')};
+  border-radius: 4px;
+  background: ${({ $active }) => ($active ? 'light-dark(#ffffff, #474c54)' : 'light-dark(#e9ecef, #3f434a)')};
+  transition: background 0.12s ease;
+
+  &:hover {
+    background: light-dark(#ffffff, #474c54);
+  }
+`;
+
+const RowSelect = styled.button`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 12px;
+  cursor: pointer;
+  color: inherit;
+`;
+
+const CheckSlot = styled.span`
+  flex: 0 0 16px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--mantine-color-primary-6);
+`;
+
+const RowText = styled.span`
+  min-width: 0;
+  flex: 1;
+`;

--- a/client/src/containers/ProductionPlanner/MobileShell/FactorySheet.tsx
+++ b/client/src/containers/ProductionPlanner/MobileShell/FactorySheet.tsx
@@ -1,9 +1,14 @@
-// The factory bottom sheet: a bottom-anchored Drawer wrapping the existing
-// FactorySwitcher so switching/creating/renaming factories on mobile reuses the
-// exact desktop control (presentation only — no library logic changes).
+// The factory bottom sheet: a bottom-anchored Drawer wrapping the mobile factory
+// picker — a search-first list of factories. Tapping one switches to it and closes
+// the sheet (see FactoryPicker).
+//
+// Dressed to match the app's Rename/Delete modals (see the Modal theme in theme.ts):
+// the same steel surface, an underlined header, and the FICSIT-orange accent stripe —
+// placed on the TOP edge here since the sheet rises from the bottom — instead of the
+// plain default Drawer chrome.
 import React from 'react';
-import { Drawer, Text } from '@mantine/core';
-import FactorySwitcher from '../PlannerOptions/FactorySwitcher';
+import { Drawer } from '@mantine/core';
+import FactoryPicker from './FactoryPicker';
 
 type Props = {
   opened: boolean;
@@ -16,9 +21,25 @@ const FactorySheet = ({ opened, onClose }: Props) => (
     onClose={onClose}
     position="bottom"
     size="60%"
-    title={<Text fw={700}>Factories</Text>}
+    radius={0}
+    title="Factories"
+    closeButtonProps={{ 'aria-label': 'Close' }}
+    styles={{
+      content: {
+        background: 'light-dark(#ffffff, #373b40)',
+        borderTop: '4px solid var(--mantine-color-primary-6)',
+      },
+      header: {
+        background: 'light-dark(#ffffff, #373b40)',
+        borderBottom: '1px solid light-dark(#dee2e6, #50565e)',
+        paddingBottom: '12px',
+      },
+      title: { fontWeight: 700, fontSize: '18px', color: 'light-dark(#212529, #eee)' },
+      body: { paddingTop: '16px', color: 'light-dark(#212529, #eee)' },
+      close: { color: 'light-dark(#212529, #eee)' },
+    }}
   >
-    <FactorySwitcher layout="stacked" />
+    <FactoryPicker onClose={onClose} />
   </Drawer>
 );
 

--- a/client/src/contexts/gameData/index.tsx
+++ b/client/src/contexts/gameData/index.tsx
@@ -110,7 +110,13 @@ export const GameDataProvider = ({ children }: PropTypes) => {
       const params = new URLSearchParams(window.location.search);
       const shareKey = params.get(SHARE_QUERY_PARAM);
       const legacyEncoding = params.get('f');
-      window.history.replaceState(null, '', `${window.location.pathname}`);
+      // Clear only the share keys we just imported — leave any other query params
+      // (e.g. the prototype's ?variant=) intact so a refresh doesn't re-import the
+      // shared factory while still preserving the rest of the URL.
+      params.delete(SHARE_QUERY_PARAM);
+      params.delete('f');
+      const rest = params.toString();
+      window.history.replaceState(null, '', rest ? `${window.location.pathname}?${rest}` : window.location.pathname);
 
       // Resolve the version this load landed on.
       let version: string;


### PR DESCRIPTION
## What & why

On mobile the factory selector was a stacked horizontal tab strip (borrowed from the desktop `FactorySwitcher`) that overflowed and scrolled sideways once you had more than a few factories — and every unnamed one just read "EMPTY FACTORY". This replaces it with **`FactoryPicker`**: a search-first vertical list inside the factory bottom sheet.

Desktop keeps its tabs — unchanged.

## Changes

- **`FactoryPicker.tsx`** (new) — searchable list in the mobile sheet:
  - Tapping a factory switches to it **and dismisses the sheet**.
  - Per-row `⋮` menu: Rename / Duplicate / Delete, plus **Reset to empty** on the active row (preserved from the old sheet). New + Share in the footer.
  - Rows are real `<button>`s with `aria-label` / `aria-current` for accessibility.
- **`FactorySheet.tsx`** — renders `FactoryPicker`; styled to match the app's Rename/Delete modals (steel surface, FICSIT-orange accent stripe, underlined header). Active row carries the 5px orange left accent the `Card`/`Modal` use.
- **`gameData/index.tsx`** — the URL clean-up after a share import now strips only the share keys (`shared=` / `f=`) instead of the whole query string, preserving any other params.

## Verification

- Light + dark mode checked via Playwright (mobile viewport).
- **171 unit tests pass.**
- **Responsive Playwright suite: 9 pass / 0 fail.**
- Mocked desktop suite: 86 pass, 1 fail — `Delete-factory modal has no WCAG A/AA violations`, **proven pre-existing** (fails identically on a clean tree; it's a contrast issue on the desktop danger button, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)