### PR TITLE
fix(mobile): make info-icon tooltips open on tap

### DIFF
--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -163,6 +163,11 @@ export const theme: MantineThemeOverride = {
       },
     },
     Tooltip: {
+      defaultProps: {
+        // Mantine defaults to hover-only; touch devices never hover, so the info
+        // icons were dead on mobile. Enable touch (tap to open) and focus (keyboard).
+        events: { hover: true, focus: true, touch: true },
+      },
       styles: {
         tooltip: {
           background: 'light-dark(#fff, #3f434a)',


### PR DESCRIPTION
## What happened

On the mobile UI, tapping any info ("i") icon did nothing — no tooltip appeared. This affected **every** info icon across the app.

## Root cause

Every info icon is a Mantine `<Tooltip>`, which defaults to `events: { hover: true, focus: false, touch: false }`. Touch devices never fire a hover event, so with `touch: false` the tooltip could never open on a tap. Nothing overrode this, so tooltips worked on desktop (mouse hover) but were dead on mobile.

## Fix

Add `defaultProps: { events: { hover: true, focus: true, touch: true } }` to the existing `Tooltip` entry in `client/src/theme.ts`. One central change — matches the `defaultProps` pattern already used for `Modal` — so every tooltip (current and future) opens on tap and on keyboard focus. Desktop hover is unchanged.

## Testing

- Unit + accessibility (vitest): **171 passed**
- Playwright e2e: **87 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)