### PR TITLE
chore(deps): resolve @lhci/cli transitive vulns via npm overrides

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5042,19 +5042,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/external-editor/node_modules/tmp": {
-            "version": "0.0.33",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "os-tmpdir": "~1.0.2"
-            },
-            "engines": {
-                "node": ">=0.6.0"
-            }
-        },
         "node_modules/extract-zip": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -6610,9 +6597,9 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7811,16 +7798,6 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/own-keys": {
@@ -9540,30 +9517,13 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-            "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "rimraf": "^2.6.3"
-            },
             "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tmp/node_modules/rimraf": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
+                "node": ">=14.14"
             }
         },
         "node_modules/toidentifier": {
@@ -9916,14 +9876,17 @@
             }
         },
         "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
             "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/vary": {
@@ -11308,8 +11271,8 @@
                 "lighthouse-logger": "1.2.0",
                 "open": "^7.1.0",
                 "proxy-agent": "^6.4.0",
-                "tmp": "^0.1.0",
-                "uuid": "^8.3.1",
+                "tmp": "^0.2.7",
+                "uuid": "^11.1.1",
                 "yargs": "^15.4.1",
                 "yargs-parser": "^13.1.2"
             }
@@ -11322,7 +11285,7 @@
             "requires": {
                 "debug": "^4.3.1",
                 "isomorphic-fetch": "^3.0.0",
-                "js-yaml": "^3.13.1",
+                "js-yaml": "^3.15.0",
                 "lighthouse": "12.6.1",
                 "tree-kill": "^1.2.1"
             }
@@ -13746,7 +13709,7 @@
             "requires": {
                 "chardet": "^0.7.0",
                 "iconv-lite": "^0.4.24",
-                "tmp": "^0.0.33"
+                "tmp": "^0.2.7"
             },
             "dependencies": {
                 "iconv-lite": {
@@ -13756,15 +13719,6 @@
                     "dev": true,
                     "requires": {
                         "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "tmp": {
-                    "version": "0.0.33",
-                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-                    "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-                    "dev": true,
-                    "requires": {
-                        "os-tmpdir": "~1.0.2"
                     }
                 }
             }
@@ -14792,9 +14746,9 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -15550,12 +15504,6 @@
                 "type-check": "^0.4.0",
                 "word-wrap": "^1.2.5"
             }
-        },
-        "os-tmpdir": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-            "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-            "dev": true
         },
         "own-keys": {
             "version": "1.0.1",
@@ -16751,24 +16699,10 @@
             }
         },
         "tmp": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-            "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-            "dev": true,
-            "requires": {
-                "rimraf": "^2.6.3"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.1.3"
-                    }
-                }
-            }
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+            "dev": true
         },
         "toidentifier": {
             "version": "1.0.1",
@@ -16989,9 +16923,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "dev": true
         },
         "vary": {

--- a/client/package.json
+++ b/client/package.json
@@ -101,5 +101,12 @@
         "typescript-eslint": "^8.61.0",
         "vite": "^8.1.0",
         "vitest": "^4.1.0"
+    },
+    "overrides": {
+        "@lhci/cli": {
+            "js-yaml": "^3.15.0",
+            "tmp": "^0.2.7",
+            "uuid": "^11.1.1"
+        }
     }
 }


### PR DESCRIPTION
Clears the 6 pre-existing `npm audit` findings (1 high, 3 moderate, 2 low) that the dependabot batch (#153) left behind.

## Background
All 6 advisories are **transitive under `@lhci/cli`** (dev-only Lighthouse CI, behind the `a11y:lhci` script). `@lhci/cli@0.15.1` is already the **latest** release — there's no upstream fix, and it pins old majors of three deps below their patched versions. The only `npm audit fix --force` path was a breaking downgrade to `@lhci/cli@0.1.0`, so that was a non-starter.

## Fix
A `package.json` `overrides` block **scoped to lhci's subtree only** (nothing else in the app is touched) forces the patched versions:

| Package | Was | Now | Advisory |
|---|---|---|---|
| js-yaml | 3.14.2 | 3.15.0 | GHSA-h67p-54hq-rp68 (same-major patch) |
| tmp | 0.0.33 / 0.1.0 | 0.2.7 | GHSA-52f5-9888-hmc6, GHSA-ph9p-34f9-6g65 |
| uuid | 8.3.2 | 11.1.1 | GHSA-w5hq-g745-h8pq |

Fixing `tmp` also clears the `inquirer` / `external-editor` transitive flags.

## Verification
- `npm audit` → **0 vulnerabilities** (was 6)
- `lhci autorun` → runs end-to-end and passes accessibility assertions (exercises js-yaml config parse, tmp dirs, uuid run IDs — i.e. all three overridden packages)
- `npm test` (vitest) → 171/171
- `npm run test:e2e` (chromium + firefox + webkit) → 87/87
- `npm run test:responsive` (7 viewports) → 9 passed, 5 intentionally skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)