### PR TITLE
fix(solver): enforce belt/pipe capacity on total node output (#130)

### DIFF
--- a/client/src/utilities/production-solver/index.test.ts
+++ b/client/src/utilities/production-solver/index.test.ts
@@ -493,3 +493,57 @@ describe('ProductionSolver game mode multipliers (recipe cost)', () => {
     expect(oreNode.multiplier).toBeCloseTo(60, 2);
   });
 });
+
+describe('ProductionSolver belt/pipe capacity (issue #130)', () => {
+  // Iron Ingot recipe produces 30 ingots/min per building, so the recipe node's total
+  // output for iron ingot is `multiplier * 30`. A rate target (rate pass) plus a maximize
+  // target for the same item (a second, summed pass) both touch Recipe_IronIngot_C — the bug
+  // was that each pass capped independently and the per-pass results were summed, letting the
+  // node's total output exceed one belt.
+
+  it('enforces the belt cap on a recipe node total output across the rate + maximize passes', async () => {
+    const options = createValidOptions({
+      productionItems: [
+        { key: 'prod-1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '10' },
+        { key: 'prod-2', itemKey: 'Desc_IronIngot_C', mode: 'maximize', value: '1' },
+      ],
+      transportOptions: { beltCapacity: '60', pipeCapacity: null },
+    });
+    const { productionGraph, error } = await new ProductionSolver(options, mockGameData).exec();
+
+    expect(error).toBeNull();
+    const ingotRecipeNode = productionGraph!.nodes['Recipe_IronIngot_C'];
+    // Total iron-ingot output of the node must fit on a single 60/min belt.
+    expect(ingotRecipeNode.multiplier * 30).toBeLessThanOrEqual(60 + 1e-6);
+  });
+
+  it('does not cap output when no belt capacity is configured', async () => {
+    const options = createValidOptions({
+      productionItems: [
+        { key: 'prod-1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '10' },
+        { key: 'prod-2', itemKey: 'Desc_IronIngot_C', mode: 'maximize', value: '1' },
+      ],
+      transportOptions: { beltCapacity: null, pipeCapacity: null },
+    });
+    const { productionGraph, error } = await new ProductionSolver(options, mockGameData).exec();
+
+    expect(error).toBeNull();
+    const ingotRecipeNode = productionGraph!.nodes['Recipe_IronIngot_C'];
+    // Uncapped: maximize pushes iron ingot well past what one 60/min belt could carry.
+    expect(ingotRecipeNode.multiplier * 30).toBeGreaterThan(60);
+  });
+
+  it('reports a belt/pipe-capacity error when a target needs more than one belt', async () => {
+    const options = createValidOptions({
+      productionItems: [
+        { key: 'prod-1', itemKey: 'Desc_IronIngot_C', mode: 'per-minute', value: '100' },
+      ],
+      transportOptions: { beltCapacity: '60', pipeCapacity: null },
+    });
+    const { error } = await new ProductionSolver(options, mockGameData).exec();
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toBe('BELT/PIPE CAPACITY TOO LOW');
+    expect(error!.helpText).toMatch(/belt 60\/min/);
+  });
+});

--- a/client/src/utilities/production-solver/index.ts
+++ b/client/src/utilities/production-solver/index.ts
@@ -385,11 +385,11 @@ export class ProductionSolver {
         }
         let solution: ProductionSolution;
         if (groupTargetKeys.length === 1) {
-          solution = await this.productionSolverPass(groupTargetKeys, remainingInputs, glpk);
+          solution = await this.productionSolverPass(groupTargetKeys, remainingInputs, glpk, undefined, productionSolution);
         } else {
           const maxima = new Map<string, number>();
           for (const targetKey of groupTargetKeys) {
-            const individualSol = await this.productionSolverPass([targetKey], remainingInputs, glpk);
+            const individualSol = await this.productionSolverPass([targetKey], remainingInputs, glpk, undefined, productionSolution);
             const tempGraph = assembleGraph(individualSol, this.graphContext());
             const node = Object.values(tempGraph.nodes).find(n => n.key === targetKey && n.type === NODE_TYPE.FINAL_PRODUCT);
             maxima.set(targetKey, node?.multiplier ?? 0);
@@ -397,7 +397,7 @@ export class ProductionSolver {
           const balancedMaxima = this.maximizeBalanceMode === 'equal'
             ? new Map([...maxima.entries()].map(([k, v]) => [k, v > EPSILON ? 1 : 0]))
             : maxima;
-          solution = await this.productionSolverPass(groupTargetKeys, remainingInputs, glpk, balancedMaxima);
+          solution = await this.productionSolverPass(groupTargetKeys, remainingInputs, glpk, balancedMaxima, productionSolution);
         }
         for (const [key, multiplier] of Object.entries(solution)) {
           if (productionSolution[key]) {
@@ -442,7 +442,7 @@ export class ProductionSolver {
     };
   }
 
-  private async productionSolverPass(targetKeys: string[], remainingInputs: Inputs, glpk: GLPK, maxima?: Map<string, number>): Promise<ProductionSolution> {
+  private async productionSolverPass(targetKeys: string[], remainingInputs: Inputs, glpk: GLPK, maxima?: Map<string, number>, priorSolution?: ProductionSolution): Promise<ProductionSolution> {
     const isRateTargetPass = targetKeys.length === 1 && targetKeys[0] === RATE_TARGET_KEY;
     const targetItemVars = new Map<string, Var[]>();
     const model: LP = {
@@ -488,10 +488,14 @@ export class ProductionSolver {
           const isFluid = this.gameData.items[product.itemClass]?.isFluid ?? false;
           const capacity = isFluid ? this.pipeCapacity : this.beltCapacity;
           if (capacity !== null) {
+            // Tighten the cap by output already allocated to this recipe in prior passes, so the
+            // cumulative total across all summed passes stays within a single belt/pipe (issue #130).
+            const priorMultiplier = priorSolution?.[recipeKey] ?? 0;
+            const ub = Math.max(0, capacity - priorMultiplier * product.perMinute);
             model.subjectTo.push({
               name: `${recipeKey}_${product.itemClass}_capacity`,
               vars: [{ name: recipeKey, coef: product.perMinute }],
-              bnds: { type: glpk.GLP_UP, ub: capacity, lb: NaN },
+              bnds: { type: glpk.GLP_UP, ub, lb: NaN },
             });
           }
         }
@@ -698,6 +702,22 @@ export class ProductionSolver {
       throw new GraphError('TIMED OUT', 'Try setting the complexity weight to 0. Unfortunately it is currently very slow for large factories. For complex factories, you might try the Buildings optimizer instead.');
     }
     if (solution.result.status !== glpk.GLP_OPT && solution.result.status !== glpk.GLP_FEAS) {
+      // If a belt/pipe capacity limit is set, check whether it is what made the solve infeasible by
+      // re-solving without the capacity constraints. If that succeeds, the cap is the culprit and we
+      // can explain exactly why instead of throwing a generic error (issue #130).
+      if (this.beltCapacity !== null || this.pipeCapacity !== null) {
+        const probe = { ...model, subjectTo: model.subjectTo.filter((c) => !c.name.endsWith('_capacity')) };
+        const probeSolution = await glpk.solve(probe, { msglev: glpk.GLP_MSG_OFF, tmlim: TIME_LIMIT });
+        if (probeSolution.result.status === glpk.GLP_OPT || probeSolution.result.status === glpk.GLP_FEAS) {
+          const limits: string[] = [];
+          if (this.beltCapacity !== null) limits.push(`belt ${this.beltCapacity}/min`);
+          if (this.pipeCapacity !== null) limits.push(`pipe ${this.pipeCapacity}/min`);
+          throw new GraphError(
+            'BELT/PIPE CAPACITY TOO LOW',
+            `Your transport capacity limit (${limits.join(', ')}) is too low to satisfy this factory. A single recipe's output for one item cannot exceed one belt/pipe, so a target needs more throughput than one belt can carry. Raise or clear the belt/pipe capacity in the Production tab.`,
+          );
+        }
+      }
       if (isRateTargetPass) {
         throw new GraphError('NO SOLUTION', 'This could be due to missing recipes, impossible demands, or any number of reasons. Double check your factory settings.');
       } else {


### PR DESCRIPTION
## Summary

Fixes #130 — belt/pipe capacity was not enforced on a recipe node's **total** output.

The capacity constraint (`perMinute × multiplier ≤ capacity`) is correct *within a single LP pass*, but `exec()` runs multiple passes (a rate-target pass plus one per maximize-priority group) and **sums** their solutions. Nothing bounded the running total, so a recipe used across passes could accumulate output exceeding a single belt/pipe — exactly the "aggregate output not enforced / appears split across consumers" symptom in the issue.

## Changes

All in `client/src/utilities/production-solver/`.

- **Aggregate enforcement** — thread the accumulated solution into each pass and tighten the capacity upper bound to `max(0, capacity − priorMultiplier × perMinute)`, so the cumulative total across all summed passes stays within one belt/pipe.
- **Explanatory error** — when a solve is infeasible and a capacity limit is set, re-solve a probe model with the `_capacity` constraints stripped; if that's feasible, the cap is the culprit, so throw `BELT/PIPE CAPACITY TOO LOW` naming the configured limits instead of the generic "NO SOLUTION". (Per maintainer decision: keep a hard cap, but explain why.)
- **Regression tests** — aggregate enforcement across rate + maximize passes, the uncapped (opt-in) case, and the capacity-specific error message.

## Testing

- `npm test` (vitest): **174 passed** — includes the `.a11y.test.tsx` accessibility tests.
- `npm run test:e2e` (Playwright): **87 passed**.
- Verified the new aggregate test genuinely catches the bug: with the fix reverted it fails `expected 75 to be less than or equal to 60`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)