### PR TITLE
feat(client): experimental feature-flag system + gated balancer view

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import Main from './containers/Main';
 import { theme } from './theme';
 import GlobalStylesheet from './global-stylesheet';
 import { GlobalContextProvider } from './contexts/global';
+import { ExperimentalProvider } from './contexts/experimental';
 import { LibraryProvider } from './contexts/library';
 import { GameDataProvider } from './contexts/gameData';
 
@@ -27,11 +28,13 @@ const ThemeTransfer = () => {
     <ThemeProvider theme={mergedTheme}>
       <GlobalStylesheet />
       <GlobalContextProvider>
-        <LibraryProvider>
-          <GameDataProvider>
-            <Main />
-          </GameDataProvider>
-        </LibraryProvider>
+        <ExperimentalProvider>
+          <LibraryProvider>
+            <GameDataProvider>
+              <Main />
+            </GameDataProvider>
+          </LibraryProvider>
+        </ExperimentalProvider>
       </GlobalContextProvider>
     </ThemeProvider>
   );

--- a/client/src/containers/Main/SiteHeader/ExperimentalModal.a11y.test.tsx
+++ b/client/src/containers/Main/SiteHeader/ExperimentalModal.a11y.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MantineProvider } from '@mantine/core';
+import ExperimentalModal from './ExperimentalModal';
+import { theme } from '../../../theme';
+import { ExperimentalProvider } from '../../../contexts/experimental';
+
+// Renders the modal OPEN so the flag switches are actually in the DOM and get
+// scanned (the SiteHeader a11y test only covers the closed trigger). Note: axe
+// under jsdom cannot evaluate colour-contrast — that needs a real browser — so
+// this guards structure/roles/labels/aria, not visual contrast.
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <MantineProvider theme={theme}>
+      <ExperimentalProvider>{children}</ExperimentalProvider>
+    </MantineProvider>
+  );
+}
+
+describe('ExperimentalModal — accessibility', () => {
+  it('renders the open dialog without axe violations', async () => {
+    render(
+      <Wrapper>
+        <ExperimentalModal opened onClose={() => {}} />
+      </Wrapper>
+    );
+
+    // Mantine renders the Modal in a portal on document.body, so scan the body.
+    const results = await axe(document.body);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/client/src/containers/Main/SiteHeader/ExperimentalModal.test.tsx
+++ b/client/src/containers/Main/SiteHeader/ExperimentalModal.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MantineProvider } from '@mantine/core';
+import ExperimentalModal from './ExperimentalModal';
+import { theme } from '../../../theme';
+import { ExperimentalProvider } from '../../../contexts/experimental';
+import { EXPERIMENTAL_FLAGS } from '../../../contexts/experimental/consts';
+
+function renderModal(onClose = vi.fn()) {
+  const utils = render(
+    <MantineProvider theme={theme}>
+      <ExperimentalProvider>
+        <ExperimentalModal opened onClose={onClose} />
+      </ExperimentalProvider>
+    </MantineProvider>
+  );
+  return { ...utils, onClose };
+}
+
+describe('ExperimentalModal', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('renders one switch per manifest flag, off by default', () => {
+    renderModal();
+    const switches = screen.getAllByRole('switch');
+    expect(switches).toHaveLength(EXPERIMENTAL_FLAGS.length);
+    switches.forEach((s) => expect(s).not.toBeChecked());
+    // The single current flag is "Balancer view".
+    expect(screen.getByRole('switch', { name: /Balancer view/ })).toBeInTheDocument();
+  });
+
+  it('persists an enabled flag across a remount', async () => {
+    const user = userEvent.setup();
+    const { unmount } = renderModal();
+
+    const toggle = screen.getByRole('switch', { name: /Balancer view/ });
+    await user.click(toggle);
+    expect(toggle).toBeChecked();
+
+    // A fresh render reads the persisted state back as enabled.
+    unmount();
+    renderModal();
+    expect(screen.getByRole('switch', { name: /Balancer view/ })).toBeChecked();
+  });
+});

--- a/client/src/containers/Main/SiteHeader/ExperimentalModal.tsx
+++ b/client/src/containers/Main/SiteHeader/ExperimentalModal.tsx
@@ -1,0 +1,61 @@
+// The Experimental features dialog: one Switch per manifest flag, backed by the
+// experimental-flags context (persisted to localStorage). Presentational — the
+// caller owns open/close. Dressed by the global Modal theme (see theme.ts).
+//
+// react-feather has no flask/beaker and free-solid-svg-icons isn't a dependency
+// (only free-brands is), so the flask is an inline SVG in react-feather's stroke
+// style — the same approach SiteHeader already uses for its Sun/Moon icons.
+import React from 'react';
+import { Modal, Switch, Stack, Text, Group } from '@mantine/core';
+import { useExperimentalContext } from '../../../contexts/experimental';
+
+export const FlaskIcon = ({ size = 18 }: { size?: number }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M9 3h6" />
+    <path d="M10 3v6.5L4.5 18a2 2 0 0 0 1.7 3h11.6a2 2 0 0 0 1.7-3L14 9.5V3" />
+    <path d="M7 15h10" />
+  </svg>
+);
+
+type Props = {
+  opened: boolean;
+  onClose: () => void;
+};
+
+const ExperimentalModal = ({ opened, onClose }: Props) => {
+  const { flags, isEnabled, setEnabled } = useExperimentalContext();
+  return (
+    <Modal
+      opened={opened}
+      onClose={onClose}
+      title={<Group gap="xs"><FlaskIcon /> Experimental features</Group>}
+    >
+      <Text size="sm" c="dimmed" mb="md">
+        These features are unfinished and may change or break.
+      </Text>
+      <Stack gap="md">
+        {flags.map((flag) => (
+          <Switch
+            key={flag.key}
+            label={flag.label}
+            description={flag.description}
+            checked={isEnabled(flag.key)}
+            onChange={(e) => setEnabled(flag.key, e.currentTarget.checked)}
+          />
+        ))}
+      </Stack>
+    </Modal>
+  );
+};
+
+export default ExperimentalModal;

--- a/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
+++ b/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from 'styled-components';
 import SiteHeader from './index';
 import { theme } from '../../../theme';
 import { GameDataContext, GameDataContextType } from '../../../contexts/gameData';
+import { ExperimentalProvider } from '../../../contexts/experimental';
 import { DEFAULT_GAME_VERSION } from '../../../contexts/gameData/consts';
 
 // Minimal styled-components theme matching the shape SiteHeader's CSS expects
@@ -33,9 +34,11 @@ function Wrapper({ children }: { children: React.ReactNode }) {
   return (
     <MantineProvider theme={theme}>
       <ThemeProvider theme={scTheme}>
-        <GameDataContext.Provider value={gameDataValue}>
-          {children}
-        </GameDataContext.Provider>
+        <ExperimentalProvider>
+          <GameDataContext.Provider value={gameDataValue}>
+            {children}
+          </GameDataContext.Provider>
+        </ExperimentalProvider>
       </ThemeProvider>
     </MantineProvider>
   );

--- a/client/src/containers/Main/SiteHeader/index.tsx
+++ b/client/src/containers/Main/SiteHeader/index.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Title, Container, Group, Select, ActionIcon, useComputedColorScheme, useMantineColorScheme } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import logo from '../../../assets/satisfactory_logo_full_color_small.png';
 import SocialIcon from '../../../components/SocialIcon';
 import { DEFAULT_GAME_VERSION, GAME_VERSION_OPTIONS } from '../../../contexts/gameData/consts';
 import { useGameDataContext } from '../../../contexts/gameData';
+import ExperimentalModal, { FlaskIcon } from './ExperimentalModal';
 
 const SunIcon = () => (
   <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
@@ -26,6 +28,8 @@ const SiteHeader = () => {
   const { setColorScheme } = useMantineColorScheme();
   const computedColorScheme = useComputedColorScheme('dark');
 
+  const [experimentalOpened, { open: openExperimental, close: closeExperimental }] = useDisclosure(false);
+
   const toggleColorScheme = () => {
     setColorScheme(computedColorScheme === 'dark' ? 'light' : 'dark');
   };
@@ -44,6 +48,15 @@ const SiteHeader = () => {
           style={{ width: '200px' }}
         />
         <ActionIcon
+          onClick={openExperimental}
+          variant="transparent"
+          size="lg"
+          aria-label="Experimental features"
+          color="white"
+        >
+          <FlaskIcon />
+        </ActionIcon>
+        <ActionIcon
           onClick={toggleColorScheme}
           variant="transparent"
           size="lg"
@@ -54,6 +67,7 @@ const SiteHeader = () => {
         </ActionIcon>
         <SocialIcon href='https://github.com/greven145/yet-another-factory-planner' label='View source on GitHub' icon={<FontAwesomeIcon icon={faGithub} fontSize={32} />} />
       </RightAlign>
+      <ExperimentalModal opened={experimentalOpened} onClose={closeExperimental} />
     </HeaderContainer>
   );
 };

--- a/client/src/containers/ProductionPlanner/MobileShell/MobileTopBar.test.tsx
+++ b/client/src/containers/ProductionPlanner/MobileShell/MobileTopBar.test.tsx
@@ -8,6 +8,7 @@ import { theme } from '../../../theme';
 import { GameDataContext, GameDataContextType } from '../../../contexts/gameData';
 import { LibraryContext, LibraryContextType } from '../../../contexts/library';
 import { ProductionContext, ProductionContextType } from '../../../contexts/production';
+import { ExperimentalProvider } from '../../../contexts/experimental';
 import { DEFAULT_GAME_VERSION } from '../../../contexts/gameData/consts';
 
 // Minimal context values: MobileTopBar reads the active factory label
@@ -36,13 +37,15 @@ const productionValue = { gameData } as unknown as ProductionContextType;
 function renderBar(onOpenFactories = vi.fn()) {
   const utils = render(
     <MantineProvider theme={theme}>
-      <GameDataContext.Provider value={gameDataValue}>
-        <LibraryContext.Provider value={libraryValue}>
-          <ProductionContext.Provider value={productionValue}>
-            <MobileTopBar onOpenFactories={onOpenFactories} />
-          </ProductionContext.Provider>
-        </LibraryContext.Provider>
-      </GameDataContext.Provider>
+      <ExperimentalProvider>
+        <GameDataContext.Provider value={gameDataValue}>
+          <LibraryContext.Provider value={libraryValue}>
+            <ProductionContext.Provider value={productionValue}>
+              <MobileTopBar onOpenFactories={onOpenFactories} />
+            </ProductionContext.Provider>
+          </LibraryContext.Provider>
+        </GameDataContext.Provider>
+      </ExperimentalProvider>
     </MantineProvider>
   );
   return { ...utils, onOpenFactories };
@@ -71,5 +74,17 @@ describe('MobileTopBar', () => {
     expect(screen.getByText(/(Dark|Light) theme/)).toBeInTheDocument();
     const source = screen.getByText('View source').closest('a');
     expect(source).toHaveAttribute('href', 'https://github.com/greven145/yet-another-factory-planner');
+  });
+
+  it('opens the experimental features modal from the overflow menu', async () => {
+    const user = userEvent.setup();
+    renderBar();
+
+    await user.click(screen.getByRole('button', { name: 'More options' }));
+    const item = await screen.findByText('Experimental features…');
+    await user.click(item);
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: /Balancer view/ })).toBeInTheDocument();
   });
 });

--- a/client/src/containers/ProductionPlanner/MobileShell/MobileTopBar.tsx
+++ b/client/src/containers/ProductionPlanner/MobileShell/MobileTopBar.tsx
@@ -7,8 +7,10 @@ import {
   Menu, ActionIcon, Select, Group,
   useMantineColorScheme, useComputedColorScheme,
 } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import { MoreVertical, Sun, Moon, GitHub, ChevronDown } from 'react-feather';
 import logo from '../../../assets/satisfactory_logo_full_color_small.png';
+import ExperimentalModal, { FlaskIcon } from '../../Main/SiteHeader/ExperimentalModal';
 import { useGameDataContext } from '../../../contexts/gameData';
 import { useLibraryContext } from '../../../contexts/library';
 import { useProductionContext } from '../../../contexts/production';
@@ -30,7 +32,9 @@ const OverflowMenu = () => {
   const gd = useGameDataContext();
   const { setColorScheme } = useMantineColorScheme();
   const scheme = useComputedColorScheme('dark');
+  const [experimentalOpened, { open: openExperimental, close: closeExperimental }] = useDisclosure(false);
   return (
+    <>
     <Menu position="bottom-end" withArrow shadow="md" closeOnItemClick={false}>
       <Menu.Target>
         <ActionIcon variant="transparent" color="white" size="lg" aria-label="More options">
@@ -64,8 +68,14 @@ const OverflowMenu = () => {
         >
           View source
         </Menu.Item>
+        <Menu.Divider />
+        <Menu.Item leftSection={<FlaskIcon size={16} />} onClick={openExperimental}>
+          Experimental features…
+        </Menu.Item>
       </Menu.Dropdown>
     </Menu>
+    <ExperimentalModal opened={experimentalOpened} onClose={closeExperimental} />
+    </>
   );
 };
 

--- a/client/src/containers/ProductionPlanner/PlannerResults/FlowTab/FlowCards.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/FlowTab/FlowCards.tsx
@@ -13,7 +13,10 @@ function renderConnections(connections: FlowConnection[]) {
   return (
     <List spacing={2} size="sm" withPadding>
       {connections.map((c, i) => (
-        <List.Item key={`${c.itemKey}-${i}`}>{c.itemName} — {formatRate(c.rate)}</List.Item>
+        <List.Item key={`${c.itemKey}-${i}`}>
+          {c.itemName} — {formatRate(c.rate)}
+          {c.transport && <Text span c="dimmed"> · {c.transport}</Text>}
+        </List.Item>
       ))}
     </List>
   );

--- a/client/src/containers/ProductionPlanner/PlannerResults/FlowTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/FlowTab/index.tsx
@@ -5,6 +5,7 @@ import { AlertCircle } from 'react-feather';
 import { useProductionContext } from '../../../../contexts/production';
 import { buildFlowModel } from '../../../../utilities/production-solver/flow-model';
 import { decomposeGraph } from '../../../../utilities/production-solver/decompose-graph';
+import { resolveTransportCaps } from '../../../../utilities/production-solver/transport';
 import FlowCards from './FlowCards';
 
 type FlowTabProps = {
@@ -13,12 +14,6 @@ type FlowTabProps = {
   // When true, annotate each flow with its belt/pipe requirement (see transport.ts).
   showTransport?: boolean,
 };
-
-function parseCapacity(value: string | null): number | null {
-  if (value == null) return null;
-  const n = Number(value);
-  return Number.isFinite(n) && n > 0 ? n : null;
-}
 
 // Accessible, non-canvas equivalent of the production graph (issue #92, ADR 0002).
 // Renders the solved plan as a semantic table and announces recomputes via an ARIA
@@ -36,12 +31,7 @@ const FlowTab = ({ dedicatedLines = false, showTransport = false }: FlowTabProps
   );
 
   const transportCaps = useMemo(
-    () => (showTransport
-      ? {
-        beltCapacity: parseCapacity(transportOptions.beltCapacity),
-        pipeCapacity: parseCapacity(transportOptions.pipeCapacity),
-      }
-      : undefined),
+    () => resolveTransportCaps(showTransport, transportOptions.beltCapacity, transportOptions.pipeCapacity),
     [showTransport, transportOptions.beltCapacity, transportOptions.pipeCapacity],
   );
 

--- a/client/src/containers/ProductionPlanner/PlannerResults/FlowTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/FlowTab/index.tsx
@@ -4,20 +4,50 @@ import { Container, Group, Text, VisuallyHidden } from '@mantine/core';
 import { AlertCircle } from 'react-feather';
 import { useProductionContext } from '../../../../contexts/production';
 import { buildFlowModel } from '../../../../utilities/production-solver/flow-model';
+import { decomposeGraph } from '../../../../utilities/production-solver/decompose-graph';
 import FlowCards from './FlowCards';
+
+type FlowTabProps = {
+  // When true, show dedicated lines: each step feeds a single consumer (see decompose-graph.ts).
+  dedicatedLines?: boolean,
+  // When true, annotate each flow with its belt/pipe requirement (see transport.ts).
+  showTransport?: boolean,
+};
+
+function parseCapacity(value: string | null): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
 
 // Accessible, non-canvas equivalent of the production graph (issue #92, ADR 0002).
 // Renders the solved plan as a semantic table and announces recomputes via an ARIA
 // live region so screen-reader and keyboard users can read the plan without the canvas.
-const FlowTab = () => {
+const FlowTab = ({ dedicatedLines = false, showTransport = false }: FlowTabProps) => {
   const ctx = useProductionContext();
-  const graph = ctx.solverResults?.productionGraph ?? null;
+  const rawGraph = ctx.solverResults?.productionGraph ?? null;
   const timestamp = ctx.solverResults?.timestamp ?? null;
   const loopWarning = ctx.solverResults?.report?.loopWarning ?? false;
+  const transportOptions = ctx.state.transportOptions;
+
+  const graph = useMemo(
+    () => (rawGraph && dedicatedLines ? decomposeGraph(rawGraph, ctx.gameData) : rawGraph),
+    [rawGraph, dedicatedLines, ctx.gameData],
+  );
+
+  const transportCaps = useMemo(
+    () => (showTransport
+      ? {
+        beltCapacity: parseCapacity(transportOptions.beltCapacity),
+        pipeCapacity: parseCapacity(transportOptions.pipeCapacity),
+      }
+      : undefined),
+    [showTransport, transportOptions.beltCapacity, transportOptions.pipeCapacity],
+  );
 
   const model = useMemo(
-    () => (graph ? buildFlowModel(graph, ctx.gameData) : null),
-    [graph, ctx.gameData],
+    () => (graph ? buildFlowModel(graph, ctx.gameData, transportCaps) : null),
+    [graph, ctx.gameData, transportCaps],
   );
 
   // Announce each recompute (new solver timestamp) once the plan has data.

--- a/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
@@ -6,6 +6,8 @@ import GraphVisualizer from 'react-cytoscapejs';
 import { Text, Container, Center, Group, Stack, Loader, Button, ButtonProps } from '@mantine/core';
 import { AlertCircle } from 'react-feather';
 import { GraphNode, GraphEdge, NODE_TYPE, ProductionGraph } from '../../../../utilities/production-solver/models';
+import { decomposeGraph } from '../../../../utilities/production-solver/decompose-graph';
+import { describeTransport, formatTransport, TransportCapacities } from '../../../../utilities/production-solver/transport';
 import { graphColors, MOBILE_MEDIA } from '../../../../theme';
 import GraphTooltip from '../../../../components/GraphTooltip';
 import GraphContextMenu, { ContextMenuState } from '../../../../components/GraphContextMenu';
@@ -321,11 +323,16 @@ function getNodeClasses(node: GraphNode, gameData: GameData) {
   return classes;
 }
 
-function getEdgeLabel(edge: GraphEdge, gameData: GameData) {
+function getEdgeLabel(edge: GraphEdge, gameData: GameData, transportCaps?: TransportCapacities) {
   const item = gameData.items[edge.key];
   const label = item.name;
   const amountText = `${truncateFloat(edge.productionRate)} / min`;
-  return `${label}\n${amountText}`;
+  let transportText = '';
+  if (transportCaps) {
+    const info = describeTransport(edge.productionRate, item.isFluid ?? false, transportCaps);
+    if (info) transportText = `\n${formatTransport(info)}`;
+  }
+  return `${label}\n${amountText}${transportText}`;
 }
 
 // Room left below the graph for the planner footer (FooterContent in
@@ -356,7 +363,20 @@ export interface EdgeData extends GraphEdge {
   label: string,
 }
 
-const ProductionGraphTab = () => {
+type ProductionGraphTabProps = {
+  // When true, show dedicated lines: each step feeds a single consumer (see decompose-graph.ts).
+  dedicatedLines?: boolean,
+  // When true, annotate each edge with its belt/pipe requirement (see transport.ts).
+  showTransport?: boolean,
+};
+
+function parseCapacity(value: string | null): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+const ProductionGraphTab = ({ dedicatedLines = false, showTransport = false }: ProductionGraphTabProps) => {
   const [doFirstRender, setDoFirstRender] = useState(false);
   const [pluginsReady, setPluginsReady] = useState(false);
   const graphRef = useRef<HTMLDivElement | null>(null);
@@ -370,7 +390,11 @@ const ProductionGraphTab = () => {
   const [popupNode, setPopupNode] = useState<NodeData | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const ctx = useProductionContext();
-  const resultsGraph = ctx.solverResults?.productionGraph || null;
+  const rawResultsGraph = ctx.solverResults?.productionGraph || null;
+  const resultsGraph = useMemo(
+    () => (rawResultsGraph && dedicatedLines ? decomposeGraph(rawResultsGraph, ctx.gameData) : rawResultsGraph),
+    [rawResultsGraph, dedicatedLines, ctx.gameData],
+  );
   const graphError = ctx.solverResults?.error || null;
   const isLoading = ctx.calculating;
   const nodesPositions = ctx.state.nodesPositions;
@@ -597,6 +621,17 @@ const ProductionGraphTab = () => {
     }
   }, [resultsGraph]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const transportOptions = ctx.state.transportOptions;
+  const transportCaps = useMemo<TransportCapacities | undefined>(
+    () => (showTransport
+      ? {
+        beltCapacity: parseCapacity(transportOptions.beltCapacity),
+        pipeCapacity: parseCapacity(transportOptions.pipeCapacity),
+      }
+      : undefined),
+    [showTransport, transportOptions.beltCapacity, transportOptions.pipeCapacity],
+  );
+
   const graphProps = useMemo<any>(() => {
     if (resultsGraph == null) {
       return null;
@@ -626,14 +661,14 @@ const ProductionGraphTab = () => {
           id: edgeId,
           source: edge.from,
           target: edge.to,
-          label: getEdgeLabel(edge, ctx.gameData),
+          label: getEdgeLabel(edge, ctx.gameData, transportCaps),
         },
         classes: edge.from === edge.to ? ['loop'] : undefined,
       });
     });
 
     return { key: graphKey, elements };
-  }, [resultsGraph, ctx.gameData, graphKey]);
+  }, [resultsGraph, ctx.gameData, graphKey, transportCaps]);
 
   return (
     <>

--- a/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
@@ -7,7 +7,7 @@ import { Text, Container, Center, Group, Stack, Loader, Button, ButtonProps } fr
 import { AlertCircle } from 'react-feather';
 import { GraphNode, GraphEdge, NODE_TYPE, ProductionGraph } from '../../../../utilities/production-solver/models';
 import { decomposeGraph } from '../../../../utilities/production-solver/decompose-graph';
-import { describeTransport, formatTransport, TransportCapacities } from '../../../../utilities/production-solver/transport';
+import { describeTransport, formatTransport, resolveTransportCaps, TransportCapacities } from '../../../../utilities/production-solver/transport';
 import { graphColors, MOBILE_MEDIA } from '../../../../theme';
 import GraphTooltip from '../../../../components/GraphTooltip';
 import GraphContextMenu, { ContextMenuState } from '../../../../components/GraphContextMenu';
@@ -370,12 +370,6 @@ type ProductionGraphTabProps = {
   showTransport?: boolean,
 };
 
-function parseCapacity(value: string | null): number | null {
-  if (value == null) return null;
-  const n = Number(value);
-  return Number.isFinite(n) && n > 0 ? n : null;
-}
-
 const ProductionGraphTab = ({ dedicatedLines = false, showTransport = false }: ProductionGraphTabProps) => {
   const [doFirstRender, setDoFirstRender] = useState(false);
   const [pluginsReady, setPluginsReady] = useState(false);
@@ -623,12 +617,7 @@ const ProductionGraphTab = ({ dedicatedLines = false, showTransport = false }: P
 
   const transportOptions = ctx.state.transportOptions;
   const transportCaps = useMemo<TransportCapacities | undefined>(
-    () => (showTransport
-      ? {
-        beltCapacity: parseCapacity(transportOptions.beltCapacity),
-        pipeCapacity: parseCapacity(transportOptions.pipeCapacity),
-      }
-      : undefined),
+    () => resolveTransportCaps(showTransport, transportOptions.beltCapacity, transportOptions.pipeCapacity),
     [showTransport, transportOptions.beltCapacity, transportOptions.pipeCapacity],
   );
 

--- a/client/src/containers/ProductionPlanner/PlannerResults/index.a11y.test.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/index.a11y.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { MantineProvider } from '@mantine/core';
+import { ThemeProvider, DefaultTheme } from 'styled-components';
+import { theme } from '../../../theme';
+import { ExperimentalProvider } from '../../../contexts/experimental';
+import { EXPERIMENTAL_FLAGS_STORAGE_KEY } from '../../../contexts/experimental/consts';
+
+// Card reads theme.colors.primary[6] from the styled-components theme; provide the
+// minimal shape (mirrors index.test.tsx).
+const scTheme = {
+  colors: {
+    background: ['#26282b', '#373b40', '#3f434a', '#50565e', '#6c7582'],
+    primary: ['#fcebde', '#f9d8be', '#f7c59f', '#f4b17f', '#f19e60', '#ef8b40', '#ec7821'],
+  },
+} as unknown as DefaultTheme;
+
+// Stub the heavy tabs (solver / react-flow) — irrelevant to the header switches.
+vi.mock('./ProductionGraphTab', () => ({ default: () => <div data-testid="graph-tab" /> }));
+vi.mock('./FlowTab', () => ({ default: () => <div data-testid="flow-tab" /> }));
+vi.mock('./ReportTab', () => ({ default: () => <div data-testid="report-tab" /> }));
+
+import PlannerResults from './index';
+
+function renderResults() {
+  return render(
+    <MantineProvider theme={theme}>
+      <ThemeProvider theme={scTheme}>
+        <ExperimentalProvider>
+          <PlannerResults />
+        </ExperimentalProvider>
+      </ThemeProvider>
+    </MantineProvider>
+  );
+}
+
+describe('PlannerResults balancer toggles — accessibility', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('renders the enabled toggle group without axe violations', async () => {
+    // Flag on so both switches are in the DOM and get scanned.
+    window.localStorage.setItem(EXPERIMENTAL_FLAGS_STORAGE_KEY, JSON.stringify({ 'balancer-view': true }));
+    const { container } = renderResults();
+    await screen.findByTestId('graph-tab');
+    expect(screen.getByLabelText('Dedicated lines')).toBeInTheDocument();
+
+    // `region` is a page-level rule (content must sit in a landmark); irrelevant to
+    // a tab panel rendered in isolation without the app's surrounding layout.
+    const results = await axe(container, { rules: { region: { enabled: false } } });
+    expect(results).toHaveNoViolations();
+  });
+
+  it('gives each switch an accessible description beyond its label', async () => {
+    window.localStorage.setItem(EXPERIMENTAL_FLAGS_STORAGE_KEY, JSON.stringify({ 'balancer-view': true }));
+    renderResults();
+    await screen.findByTestId('graph-tab');
+
+    // The explanatory text (also shown on hover via Tooltip) must be wired to the
+    // input via aria-describedby, not left as a sighted-only Tooltip.
+    expect(screen.getByLabelText('Dedicated lines')).toHaveAccessibleDescription(/dedicated lines that feed a single consumer/i);
+    expect(screen.getByLabelText('Belt/pipe needs')).toHaveAccessibleDescription(/belts\/pipes it needs/i);
+  });
+});

--- a/client/src/containers/ProductionPlanner/PlannerResults/index.test.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/index.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MantineProvider } from '@mantine/core';
+import { ThemeProvider, DefaultTheme } from 'styled-components';
+import { theme } from '../../../theme';
+import { ExperimentalProvider } from '../../../contexts/experimental';
+import { EXPERIMENTAL_FLAGS_STORAGE_KEY } from '../../../contexts/experimental/consts';
+
+// Card reads theme.colors.primary[6] from the styled-components theme for its
+// left border; provide the minimal shape it expects.
+const scTheme = {
+  colors: {
+    background: ['#26282b', '#373b40', '#3f434a', '#50565e', '#6c7582'],
+    primary: ['#fcebde', '#f9d8be', '#f7c59f', '#f4b17f', '#f19e60', '#ef8b40', '#ec7821'],
+  },
+} as unknown as DefaultTheme;
+
+// The real tabs pull in the solver, react-flow, and the production context. None
+// of that is relevant to gating, so stub them out with trivial components that
+// echo their props via data attributes.
+vi.mock('./ProductionGraphTab', () => ({
+  default: ({ dedicatedLines, showTransport }: { dedicatedLines: boolean; showTransport: boolean }) => (
+    <div data-testid="graph-tab" data-dedicated={String(dedicatedLines)} data-transport={String(showTransport)} />
+  ),
+}));
+vi.mock('./FlowTab', () => ({
+  default: ({ dedicatedLines, showTransport }: { dedicatedLines: boolean; showTransport: boolean }) => (
+    <div data-testid="flow-tab" data-dedicated={String(dedicatedLines)} data-transport={String(showTransport)} />
+  ),
+}));
+vi.mock('./ReportTab', () => ({
+  default: () => <div data-testid="report-tab" />,
+}));
+
+import PlannerResults from './index';
+
+function renderResults() {
+  return render(
+    <MantineProvider theme={theme}>
+      <ThemeProvider theme={scTheme}>
+        <ExperimentalProvider>
+          <PlannerResults />
+        </ExperimentalProvider>
+      </ThemeProvider>
+    </MantineProvider>
+  );
+}
+
+describe('PlannerResults balancer gating', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('hides the balancer switches when the flag is off (default)', async () => {
+    renderResults();
+    // Lazy tabs resolve asynchronously; wait for the mounted graph tab.
+    expect(await screen.findByTestId('graph-tab')).toBeInTheDocument();
+    expect(screen.queryByText('Dedicated lines')).toBeNull();
+    expect(screen.queryByText('Belt/pipe needs')).toBeNull();
+    expect(screen.queryByLabelText('Dedicated lines')).toBeNull();
+    expect(screen.queryByLabelText('Belt/pipe needs')).toBeNull();
+  });
+
+  it('forces the tab effect off when the flag is off', async () => {
+    renderResults();
+    const graph = await screen.findByTestId('graph-tab');
+    expect(graph).toHaveAttribute('data-dedicated', 'false');
+    expect(graph).toHaveAttribute('data-transport', 'false');
+  });
+
+  it('shows the balancer switches when the flag is on', async () => {
+    window.localStorage.setItem(
+      EXPERIMENTAL_FLAGS_STORAGE_KEY,
+      JSON.stringify({ 'balancer-view': true }),
+    );
+    renderResults();
+    expect(await screen.findByTestId('graph-tab')).toBeInTheDocument();
+    expect(screen.getByLabelText('Dedicated lines')).toBeInTheDocument();
+    expect(screen.getByLabelText('Belt/pipe needs')).toBeInTheDocument();
+  });
+
+  it('passes toggled switch state through to the tabs', async () => {
+    window.localStorage.setItem(
+      EXPERIMENTAL_FLAGS_STORAGE_KEY,
+      JSON.stringify({ 'balancer-view': true }),
+    );
+    const user = userEvent.setup();
+    renderResults();
+    const graph = await screen.findByTestId('graph-tab');
+    expect(graph).toHaveAttribute('data-dedicated', 'false');
+
+    await user.click(screen.getByLabelText('Dedicated lines'));
+    expect(screen.getByTestId('graph-tab')).toHaveAttribute('data-dedicated', 'true');
+
+    await user.click(screen.getByLabelText('Belt/pipe needs'));
+    expect(screen.getByTestId('graph-tab')).toHaveAttribute('data-transport', 'true');
+  });
+});

--- a/client/src/containers/ProductionPlanner/PlannerResults/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/index.tsx
@@ -1,5 +1,5 @@
-import React, { Suspense, lazy } from 'react';
-import { Center, Loader, Tabs } from '@mantine/core';
+import React, { Suspense, lazy, useState } from 'react';
+import { Center, Group, Loader, Switch, Tabs, Tooltip } from '@mantine/core';
 import { Share2, Edit, List } from 'react-feather';
 import Card from '../../../components/Card';
 
@@ -14,24 +14,59 @@ const TabLoader = () => (
 );
 
 const PlannerResults = () => {
+  // Balancer-mode view state. Both are pure view toggles, off by default, and do
+  // not affect the solve. Shared by the Graph and Flow tabs.
+  //  - Dedicated lines: decompose so each production node feeds a single consumer (decompose-graph.ts).
+  //  - Belt/pipe needs: annotate each flow with its transport requirement (transport.ts).
+  const [dedicatedLines, setDedicatedLines] = useState(false);
+  const [showTransport, setShowTransport] = useState(false);
+
   return (
     <Tabs defaultValue="graph" variant='pills' className='segmented-tabs'>
-      <Tabs.List>
-        <Tabs.Tab value="graph" leftSection={<Share2 size={16} />}>Graph</Tabs.Tab>
-        <Tabs.Tab value="flow" leftSection={<List size={16} />}>Flow</Tabs.Tab>
-        <Tabs.Tab value="report" leftSection={<Edit size={16} />}>Report</Tabs.Tab>
-      </Tabs.List>
+      <Group justify="space-between" align="center" wrap="nowrap" gap="sm">
+        <Tabs.List>
+          <Tabs.Tab value="graph" leftSection={<Share2 size={16} />}>Graph</Tabs.Tab>
+          <Tabs.Tab value="flow" leftSection={<List size={16} />}>Flow</Tabs.Tab>
+          <Tabs.Tab value="report" leftSection={<Edit size={16} />}>Report</Tabs.Tab>
+        </Tabs.List>
+        <Group align="center" wrap="nowrap" gap="md" style={{ flexShrink: 0 }}>
+          <Tooltip
+            multiline
+            w={260}
+            label="Split each production step into dedicated lines that feed a single consumer, duplicating shared intermediates. Affects the Graph and Flow tabs only."
+          >
+            <Switch
+              checked={dedicatedLines}
+              onChange={(e) => setDedicatedLines(e.currentTarget.checked)}
+              label="Dedicated lines"
+              size="sm"
+            />
+          </Tooltip>
+          <Tooltip
+            multiline
+            w={260}
+            label="Label each flow with the belts/pipes it needs, counted against the Belt/Pipe Capacity option (or the smallest tier that fits when it's disabled)."
+          >
+            <Switch
+              checked={showTransport}
+              onChange={(e) => setShowTransport(e.currentTarget.checked)}
+              label="Belt/pipe needs"
+              size="sm"
+            />
+          </Tooltip>
+        </Group>
+      </Group>
       <Tabs.Panel value="graph" keepMounted>
         <Card style={{ padding: '0px', marginBottom: '0px', background: 'var(--yafp-container-bg)' }}>
           <Suspense fallback={<TabLoader />}>
-            <ProductionGraphTab />
+            <ProductionGraphTab dedicatedLines={dedicatedLines} showTransport={showTransport} />
           </Suspense>
         </Card>
       </Tabs.Panel>
       <Tabs.Panel value="flow">
         <Card style={{ paddingLeft: '10px', background: 'var(--yafp-container-bg)' }}>
           <Suspense fallback={<TabLoader />}>
-            <FlowTab />
+            <FlowTab dedicatedLines={dedicatedLines} showTransport={showTransport} />
           </Suspense>
         </Card>
       </Tabs.Panel>

--- a/client/src/containers/ProductionPlanner/PlannerResults/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/index.tsx
@@ -2,6 +2,7 @@ import React, { Suspense, lazy, useState } from 'react';
 import { Center, Group, Loader, Switch, Tabs, Tooltip } from '@mantine/core';
 import { Share2, Edit, List } from 'react-feather';
 import Card from '../../../components/Card';
+import { useExperimentalFlag } from '../../../contexts/experimental';
 
 const ProductionGraphTab = lazy(() => import('./ProductionGraphTab'));
 const FlowTab = lazy(() => import('./FlowTab'));
@@ -21,6 +22,11 @@ const PlannerResults = () => {
   const [dedicatedLines, setDedicatedLines] = useState(false);
   const [showTransport, setShowTransport] = useState(false);
 
+  // The balancer-mode view toggles are gated behind an experimental flag. When
+  // the flag is off the switches are absent from the DOM and the effect is
+  // forced off, so a stale `true` state can't leak into the tabs.
+  const balancerView = useExperimentalFlag('balancer-view');
+
   return (
     <Tabs defaultValue="graph" variant='pills' className='segmented-tabs'>
       <Group justify="space-between" align="center" wrap="nowrap" gap="sm">
@@ -29,44 +35,46 @@ const PlannerResults = () => {
           <Tabs.Tab value="flow" leftSection={<List size={16} />}>Flow</Tabs.Tab>
           <Tabs.Tab value="report" leftSection={<Edit size={16} />}>Report</Tabs.Tab>
         </Tabs.List>
-        <Group align="center" wrap="nowrap" gap="md" style={{ flexShrink: 0 }}>
-          <Tooltip
-            multiline
-            w={260}
-            label="Split each production step into dedicated lines that feed a single consumer, duplicating shared intermediates. Affects the Graph and Flow tabs only."
-          >
-            <Switch
-              checked={dedicatedLines}
-              onChange={(e) => setDedicatedLines(e.currentTarget.checked)}
-              label="Dedicated lines"
-              size="sm"
-            />
-          </Tooltip>
-          <Tooltip
-            multiline
-            w={260}
-            label="Label each flow with the belts/pipes it needs, counted against the Belt/Pipe Capacity option (or the smallest tier that fits when it's disabled)."
-          >
-            <Switch
-              checked={showTransport}
-              onChange={(e) => setShowTransport(e.currentTarget.checked)}
-              label="Belt/pipe needs"
-              size="sm"
-            />
-          </Tooltip>
-        </Group>
+        {balancerView && (
+          <Group align="center" wrap="nowrap" gap="md" style={{ flexShrink: 0 }}>
+            <Tooltip
+              multiline
+              w={260}
+              label="Split each production step into dedicated lines that feed a single consumer, duplicating shared intermediates. Affects the Graph and Flow tabs only."
+            >
+              <Switch
+                checked={dedicatedLines}
+                onChange={(e) => setDedicatedLines(e.currentTarget.checked)}
+                label="Dedicated lines"
+                size="sm"
+              />
+            </Tooltip>
+            <Tooltip
+              multiline
+              w={260}
+              label="Label each flow with the belts/pipes it needs, counted against the Belt/Pipe Capacity option (or the smallest tier that fits when it's disabled)."
+            >
+              <Switch
+                checked={showTransport}
+                onChange={(e) => setShowTransport(e.currentTarget.checked)}
+                label="Belt/pipe needs"
+                size="sm"
+              />
+            </Tooltip>
+          </Group>
+        )}
       </Group>
       <Tabs.Panel value="graph" keepMounted>
         <Card style={{ padding: '0px', marginBottom: '0px', background: 'var(--yafp-container-bg)' }}>
           <Suspense fallback={<TabLoader />}>
-            <ProductionGraphTab dedicatedLines={dedicatedLines} showTransport={showTransport} />
+            <ProductionGraphTab dedicatedLines={balancerView && dedicatedLines} showTransport={balancerView && showTransport} />
           </Suspense>
         </Card>
       </Tabs.Panel>
       <Tabs.Panel value="flow">
         <Card style={{ paddingLeft: '10px', background: 'var(--yafp-container-bg)' }}>
           <Suspense fallback={<TabLoader />}>
-            <FlowTab dedicatedLines={dedicatedLines} showTransport={showTransport} />
+            <FlowTab dedicatedLines={balancerView && dedicatedLines} showTransport={balancerView && showTransport} />
           </Suspense>
         </Card>
       </Tabs.Panel>

--- a/client/src/containers/ProductionPlanner/PlannerResults/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/index.tsx
@@ -26,6 +26,8 @@ const PlannerResults = () => {
   // the flag is off the switches are absent from the DOM and the effect is
   // forced off, so a stale `true` state can't leak into the tabs.
   const balancerView = useExperimentalFlag('balancer-view');
+  const activeDedicatedLines = balancerView && dedicatedLines;
+  const activeShowTransport = balancerView && showTransport;
 
   return (
     <Tabs defaultValue="graph" variant='pills' className='segmented-tabs'>
@@ -67,14 +69,14 @@ const PlannerResults = () => {
       <Tabs.Panel value="graph" keepMounted>
         <Card style={{ padding: '0px', marginBottom: '0px', background: 'var(--yafp-container-bg)' }}>
           <Suspense fallback={<TabLoader />}>
-            <ProductionGraphTab dedicatedLines={balancerView && dedicatedLines} showTransport={balancerView && showTransport} />
+            <ProductionGraphTab dedicatedLines={activeDedicatedLines} showTransport={activeShowTransport} />
           </Suspense>
         </Card>
       </Tabs.Panel>
       <Tabs.Panel value="flow">
         <Card style={{ paddingLeft: '10px', background: 'var(--yafp-container-bg)' }}>
           <Suspense fallback={<TabLoader />}>
-            <FlowTab dedicatedLines={balancerView && dedicatedLines} showTransport={balancerView && showTransport} />
+            <FlowTab dedicatedLines={activeDedicatedLines} showTransport={activeShowTransport} />
           </Suspense>
         </Card>
       </Tabs.Panel>

--- a/client/src/containers/ProductionPlanner/PlannerResults/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/index.tsx
@@ -1,5 +1,5 @@
 import React, { Suspense, lazy, useState } from 'react';
-import { Center, Group, Loader, Switch, Tabs, Tooltip } from '@mantine/core';
+import { Center, Group, Loader, Switch, Tabs, Tooltip, VisuallyHidden } from '@mantine/core';
 import { Share2, Edit, List } from 'react-feather';
 import Card from '../../../components/Card';
 import { useExperimentalFlag } from '../../../contexts/experimental';
@@ -7,6 +7,13 @@ import { useExperimentalFlag } from '../../../contexts/experimental';
 const ProductionGraphTab = lazy(() => import('./ProductionGraphTab'));
 const FlowTab = lazy(() => import('./FlowTab'));
 const ReportTab = lazy(() => import('./ReportTab'));
+
+// Shared by each Switch's Tooltip (sighted hover) and a VisuallyHidden element wired
+// via aria-describedby (so assistive tech gets the same explanation, not just the label).
+const DEDICATED_LINES_DESC = 'Split each production step into dedicated lines that feed a single consumer, duplicating shared intermediates. Affects the Graph and Flow tabs only.';
+const DEDICATED_LINES_DESC_ID = 'balancer-dedicated-lines-desc';
+const BELT_PIPE_DESC = "Label each flow with the belts/pipes it needs, counted against the Belt/Pipe Capacity option (or the smallest tier that fits when it's disabled).";
+const BELT_PIPE_DESC_ID = 'balancer-belt-pipe-desc';
 
 const TabLoader = () => (
   <Center py="xl">
@@ -39,30 +46,26 @@ const PlannerResults = () => {
         </Tabs.List>
         {balancerView && (
           <Group align="center" wrap="nowrap" gap="md" style={{ flexShrink: 0 }}>
-            <Tooltip
-              multiline
-              w={260}
-              label="Split each production step into dedicated lines that feed a single consumer, duplicating shared intermediates. Affects the Graph and Flow tabs only."
-            >
+            <Tooltip multiline w={260} label={DEDICATED_LINES_DESC}>
               <Switch
                 checked={dedicatedLines}
                 onChange={(e) => setDedicatedLines(e.currentTarget.checked)}
                 label="Dedicated lines"
                 size="sm"
+                aria-describedby={DEDICATED_LINES_DESC_ID}
               />
             </Tooltip>
-            <Tooltip
-              multiline
-              w={260}
-              label="Label each flow with the belts/pipes it needs, counted against the Belt/Pipe Capacity option (or the smallest tier that fits when it's disabled)."
-            >
+            <Tooltip multiline w={260} label={BELT_PIPE_DESC}>
               <Switch
                 checked={showTransport}
                 onChange={(e) => setShowTransport(e.currentTarget.checked)}
                 label="Belt/pipe needs"
                 size="sm"
+                aria-describedby={BELT_PIPE_DESC_ID}
               />
             </Tooltip>
+            <VisuallyHidden id={DEDICATED_LINES_DESC_ID}>{DEDICATED_LINES_DESC}</VisuallyHidden>
+            <VisuallyHidden id={BELT_PIPE_DESC_ID}>{BELT_PIPE_DESC}</VisuallyHidden>
           </Group>
         )}
       </Group>

--- a/client/src/contexts/experimental/consts.test.ts
+++ b/client/src/contexts/experimental/consts.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { EXPERIMENTAL_FLAGS, defaultFlagState, mergeFlagState } from './consts';
+
+describe('defaultFlagState', () => {
+  it('returns all-false for every manifest key', () => {
+    const state = defaultFlagState();
+    expect(Object.keys(state).sort()).toEqual(EXPERIMENTAL_FLAGS.map((f) => f.key).sort());
+    for (const f of EXPERIMENTAL_FLAGS) {
+      expect(state[f.key]).toBe(false);
+    }
+  });
+});
+
+describe('mergeFlagState', () => {
+  it('overlays known booleans', () => {
+    const state = mergeFlagState({ 'balancer-view': true });
+    expect(state['balancer-view']).toBe(true);
+  });
+
+  it('drops unknown keys and defaults known ones to false', () => {
+    const state = mergeFlagState({ nope: true });
+    expect(state['balancer-view']).toBe(false);
+    expect((state as Record<string, unknown>).nope).toBeUndefined();
+  });
+
+  it('ignores non-boolean values for known keys', () => {
+    const state = mergeFlagState({ 'balancer-view': 'yes' });
+    expect(state['balancer-view']).toBe(false);
+  });
+
+  it('tolerates null / undefined / arrays / strings without throwing', () => {
+    expect(mergeFlagState(null)['balancer-view']).toBe(false);
+    expect(mergeFlagState(undefined)['balancer-view']).toBe(false);
+    expect(mergeFlagState([])['balancer-view']).toBe(false);
+    expect(mergeFlagState('nope')['balancer-view']).toBe(false);
+  });
+});

--- a/client/src/contexts/experimental/consts.ts
+++ b/client/src/contexts/experimental/consts.ts
@@ -1,0 +1,28 @@
+export const EXPERIMENTAL_FLAGS_STORAGE_KEY = 'experimental-flags';
+
+export const EXPERIMENTAL_FLAGS = [
+  {
+    key: 'balancer-view',
+    label: 'Balancer view',
+    description: 'Adds “Dedicated lines” and “Belt/pipe needs” view toggles to the results header.',
+  },
+] as const;
+
+export type ExperimentalFlagKey = (typeof EXPERIMENTAL_FLAGS)[number]['key'];
+
+export function defaultFlagState(): Record<ExperimentalFlagKey, boolean> {
+  return Object.fromEntries(EXPERIMENTAL_FLAGS.map((f) => [f.key, false])) as Record<ExperimentalFlagKey, boolean>;
+}
+
+// Overlay only KNOWN keys whose value is a boolean; drop unknown/removed keys;
+// missing keys stay false. Accepts unknown (raw parsed JSON) defensively.
+export function mergeFlagState(stored: unknown): Record<ExperimentalFlagKey, boolean> {
+  const next = defaultFlagState();
+  if (stored && typeof stored === 'object') {
+    for (const f of EXPERIMENTAL_FLAGS) {
+      const v = (stored as Record<string, unknown>)[f.key];
+      if (typeof v === 'boolean') next[f.key] = v;
+    }
+  }
+  return next;
+}

--- a/client/src/contexts/experimental/index.test.tsx
+++ b/client/src/contexts/experimental/index.test.tsx
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { ExperimentalProvider, useExperimentalContext, useExperimentalFlag } from './index';
+import { EXPERIMENTAL_FLAGS_STORAGE_KEY } from './consts';
+
+// Drive the provider through its public hooks. Read both the context (for
+// setEnabled) and the derived flag value from one render.
+function setup() {
+  return renderHook(
+    () => ({
+      ctx: useExperimentalContext(),
+      balancer: useExperimentalFlag('balancer-view'),
+    }),
+    { wrapper: ExperimentalProvider },
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe('ExperimentalProvider', () => {
+  it('reads a flag as false by default', () => {
+    const { result } = setup();
+    expect(result.current.balancer).toBe(false);
+  });
+
+  it('reflects setEnabled(true) in the flag value', () => {
+    const { result } = setup();
+    act(() => { result.current.ctx.setEnabled('balancer-view', true); });
+    expect(result.current.balancer).toBe(true);
+  });
+
+  it('persists an enabled flag across a remount', () => {
+    const first = setup();
+    act(() => { first.result.current.ctx.setEnabled('balancer-view', true); });
+    expect(first.result.current.balancer).toBe(true);
+
+    // The value is written to the shared localStorage key...
+    expect(window.localStorage.getItem(EXPERIMENTAL_FLAGS_STORAGE_KEY)).toBeTruthy();
+
+    first.unmount();
+
+    // ...and a fresh provider reads it back on mount.
+    const second = setup();
+    expect(second.result.current.balancer).toBe(true);
+  });
+});

--- a/client/src/contexts/experimental/index.tsx
+++ b/client/src/contexts/experimental/index.tsx
@@ -52,10 +52,9 @@ export const ExperimentalProvider = ({ children }: PropTypes) => {
 
   const ctxValue = useMemo<ExperimentalContextType>(() => ({
     flags: EXPERIMENTAL_FLAGS,
-    state,
     isEnabled,
     setEnabled,
-  }), [state, isEnabled, setEnabled]);
+  }), [isEnabled, setEnabled]);
 
   return (
     <ExperimentalContext.Provider value={ctxValue}>

--- a/client/src/contexts/experimental/index.tsx
+++ b/client/src/contexts/experimental/index.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useCallback, useContext, useMemo } from 'react';
+import { useLocalStorage } from '@mantine/hooks';
+import {
+  EXPERIMENTAL_FLAGS,
+  EXPERIMENTAL_FLAGS_STORAGE_KEY,
+  ExperimentalFlagKey,
+  defaultFlagState,
+  mergeFlagState,
+} from './consts';
+import { ExperimentalContextType, ExperimentalFlagState } from './types';
+
+
+// CONTEXT
+export const ExperimentalContext = createContext<ExperimentalContextType | null>(null);
+ExperimentalContext.displayName = 'ExperimentalContext';
+
+
+// HELPER HOOKS
+export function useExperimentalContext() {
+  const ctx = useContext(ExperimentalContext);
+  if (!ctx) {
+    throw new Error('ExperimentalContext is null');
+  }
+  return ctx;
+}
+
+export function useExperimentalFlag(key: ExperimentalFlagKey) {
+  return useExperimentalContext().isEnabled(key);
+}
+
+
+// PROVIDER
+type PropTypes = { children: React.ReactNode };
+export const ExperimentalProvider = ({ children }: PropTypes) => {
+  const [raw, setRaw] = useLocalStorage<ExperimentalFlagState>({
+    key: EXPERIMENTAL_FLAGS_STORAGE_KEY,
+    defaultValue: defaultFlagState(),
+    getInitialValueInEffect: false,
+  });
+
+  // Derive the live state from the RAW stored value so unknown/removed keys are
+  // dropped and missing keys stay false, regardless of what was persisted.
+  const state = useMemo(() => mergeFlagState(raw), [raw]);
+
+  const isEnabled = useCallback((key: ExperimentalFlagKey) => state[key], [state]);
+
+  const setEnabled = useCallback(
+    (key: ExperimentalFlagKey, value: boolean) =>
+      setRaw((prev) => ({ ...mergeFlagState(prev), [key]: value })),
+    [setRaw],
+  );
+
+  const ctxValue = useMemo<ExperimentalContextType>(() => ({
+    flags: EXPERIMENTAL_FLAGS,
+    state,
+    isEnabled,
+    setEnabled,
+  }), [state, isEnabled, setEnabled]);
+
+  return (
+    <ExperimentalContext.Provider value={ctxValue}>
+      {children}
+    </ExperimentalContext.Provider>
+  );
+};

--- a/client/src/contexts/experimental/types.ts
+++ b/client/src/contexts/experimental/types.ts
@@ -5,7 +5,6 @@ export type ExperimentalFlagState = Record<ExperimentalFlagKey, boolean>;
 
 export type ExperimentalContextType = {
   flags: readonly ExperimentalFlagDefinition[];
-  state: ExperimentalFlagState;
   isEnabled: (key: ExperimentalFlagKey) => boolean;
   setEnabled: (key: ExperimentalFlagKey, value: boolean) => void;
 };

--- a/client/src/contexts/experimental/types.ts
+++ b/client/src/contexts/experimental/types.ts
@@ -1,0 +1,11 @@
+import { EXPERIMENTAL_FLAGS, ExperimentalFlagKey } from './consts';
+
+export type ExperimentalFlagDefinition = (typeof EXPERIMENTAL_FLAGS)[number];
+export type ExperimentalFlagState = Record<ExperimentalFlagKey, boolean>;
+
+export type ExperimentalContextType = {
+  flags: readonly ExperimentalFlagDefinition[];
+  state: ExperimentalFlagState;
+  isEnabled: (key: ExperimentalFlagKey) => boolean;
+  setEnabled: (key: ExperimentalFlagKey, value: boolean) => void;
+};

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -119,6 +119,10 @@ export const theme: MantineThemeOverride = {
     },
     Switch: {
       styles: {
+        // The off-state track is otherwise near-identical to the dark Modal body
+        // (#373b40), making it invisible. A border defines the track in both
+        // states without overriding the checked accent colour.
+        track: { border: '1px solid light-dark(#adb5bd, #6c757d)' },
         label: { cursor: 'pointer', color: 'light-dark(#212529, #eee)' },
       },
     },

--- a/client/src/utilities/production-solver/decompose-graph.test.ts
+++ b/client/src/utilities/production-solver/decompose-graph.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { decomposeGraph } from './decompose-graph';
+import { NODE_TYPE, ProductionGraph } from './models';
+import { GameData } from '../../contexts/gameData/types';
+
+// Helpers for asserting over the decomposed graph.
+const recipeNodes = (g: ProductionGraph) =>
+  Object.values(g.nodes).filter((n) => n.type === NODE_TYPE.RECIPE);
+const outEdges = (g: ProductionGraph, id: string) => g.edges.filter((e) => e.from === id);
+const edgesByKey = (g: ProductionGraph, key: string) => g.edges.filter((e) => e.key === key);
+const nodesWithKey = (g: ProductionGraph, key: string) =>
+  Object.values(g.nodes).filter((n) => n.key === key);
+
+describe('decomposeGraph', () => {
+  it('leaves a graph unchanged when every recipe already feeds a single consumer', () => {
+    // ore -> ingot -> plate -> final. No shared producers.
+    const graph: ProductionGraph = {
+      nodes: {
+        ore: { id: 'ore', key: 'Desc_OreIron', type: NODE_TYPE.RESOURCE, multiplier: 30 },
+        ingot: { id: 'ingot', key: 'Recipe_IronIngot', type: NODE_TYPE.RECIPE, multiplier: 1 },
+        plate: { id: 'plate', key: 'Recipe_IronPlate', type: NODE_TYPE.RECIPE, multiplier: 2 },
+        final: { id: 'final', key: 'Desc_IronPlate', type: NODE_TYPE.FINAL_PRODUCT, multiplier: 20 },
+      },
+      edges: [
+        { key: 'Desc_OreIron', from: 'ore', to: 'ingot', productionRate: 30 },
+        { key: 'Desc_IronIngot', from: 'ingot', to: 'plate', productionRate: 30 },
+        { key: 'Desc_IronPlate', from: 'plate', to: 'final', productionRate: 20 },
+      ],
+    };
+    const out = decomposeGraph(graph);
+    expect(recipeNodes(out)).toHaveLength(2);
+    expect(out.edges).toHaveLength(3);
+  });
+
+  it('splits a recipe that feeds two consumers into one dedicated copy each', () => {
+    // ingot (3×, 90/min) feeds plate (60) and rod (30).
+    const graph: ProductionGraph = {
+      nodes: {
+        ingot: { id: 'ingot', key: 'Recipe_IronIngot', type: NODE_TYPE.RECIPE, multiplier: 3 },
+        plate: { id: 'plate', key: 'Recipe_IronPlate', type: NODE_TYPE.RECIPE, multiplier: 2 },
+        rod: { id: 'rod', key: 'Recipe_IronRod', type: NODE_TYPE.RECIPE, multiplier: 1 },
+      },
+      edges: [
+        { key: 'Desc_IronIngot', from: 'ingot', to: 'plate', productionRate: 60 },
+        { key: 'Desc_IronIngot', from: 'ingot', to: 'rod', productionRate: 30 },
+      ],
+    };
+    const out = decomposeGraph(graph);
+
+    const ingotCopies = nodesWithKey(out, 'Recipe_IronIngot');
+    expect(ingotCopies).toHaveLength(2);
+    // Multipliers split proportionally to output share: 3 × 60/90 and 3 × 30/90.
+    expect(ingotCopies.map((n) => n.multiplier).sort((a, b) => a - b)).toEqual([1, 2]);
+    // Every ingot copy now feeds exactly one consumer.
+    for (const copy of ingotCopies) {
+      expect(outEdges(out, copy.id)).toHaveLength(1);
+    }
+  });
+
+  it('cascades the split upstream so shared intermediates are duplicated per path', () => {
+    // ore -> ingot -> {plate, rod}. Splitting ingot must also duplicate ore's edge,
+    // and ore's ingredient flow to each ingot copy scales proportionally.
+    const graph: ProductionGraph = {
+      nodes: {
+        ore: { id: 'ore', key: 'Desc_OreIron', type: NODE_TYPE.RESOURCE, multiplier: 90 },
+        ingot: { id: 'ingot', key: 'Recipe_IronIngot', type: NODE_TYPE.RECIPE, multiplier: 3 },
+        plate: { id: 'plate', key: 'Recipe_IronPlate', type: NODE_TYPE.RECIPE, multiplier: 2 },
+        rod: { id: 'rod', key: 'Recipe_IronRod', type: NODE_TYPE.RECIPE, multiplier: 1 },
+      },
+      edges: [
+        { key: 'Desc_OreIron', from: 'ore', to: 'ingot', productionRate: 90 },
+        { key: 'Desc_IronIngot', from: 'ingot', to: 'plate', productionRate: 60 },
+        { key: 'Desc_IronIngot', from: 'ingot', to: 'rod', productionRate: 30 },
+      ],
+    };
+    const out = decomposeGraph(graph);
+
+    // ore is a resource terminal — never duplicated — but now feeds two ingot copies.
+    expect(nodesWithKey(out, 'Desc_OreIron')).toHaveLength(1);
+    const oreEdges = outEdges(out, 'ore');
+    expect(oreEdges).toHaveLength(2);
+    expect(oreEdges.map((e) => e.productionRate).sort((a, b) => a - b)).toEqual([30, 60]);
+  });
+
+  it('leaves a byproduct recipe whole when its primary product feeds a single consumer', () => {
+    // Main product (Fuel) → one consumer; byproduct (Resin) → another. The primary
+    // product isn't shared, so there's nothing to dedicate — the node stays whole.
+    const graph: ProductionGraph = {
+      nodes: {
+        refinery: { id: 'refinery', key: 'Recipe_Fuel', type: NODE_TYPE.RECIPE, multiplier: 1 },
+        a: { id: 'a', key: 'Recipe_A', type: NODE_TYPE.RECIPE, multiplier: 1 },
+        b: { id: 'b', key: 'Recipe_B', type: NODE_TYPE.RECIPE, multiplier: 1 },
+      },
+      edges: [
+        { key: 'Desc_Fuel', from: 'refinery', to: 'a', productionRate: 40 },
+        { key: 'Desc_PolymerResin', from: 'refinery', to: 'b', productionRate: 20 },
+      ],
+    };
+    const out = decomposeGraph(graph);
+    expect(nodesWithKey(out, 'Recipe_Fuel')).toHaveLength(1);
+    expect(outEdges(out, 'refinery')).toHaveLength(2);
+  });
+
+  it('splits a byproduct recipe by its primary product, carrying the byproduct proportionally', () => {
+    // Base-Rubber shape: Rubber (primary, 2 consumers) + Heavy Oil Residue (byproduct,
+    // 1 consumer). gameData lists Rubber first, so it's the split axis.
+    const gameData = {
+      recipes: {
+        Recipe_Rubber: { products: [{ itemClass: 'Desc_Rubber' }, { itemClass: 'Desc_HeavyOilResidue' }] },
+      },
+    } as unknown as GameData;
+    const graph: ProductionGraph = {
+      nodes: {
+        rubber: { id: 'rubber', key: 'Recipe_Rubber', type: NODE_TYPE.RECIPE, multiplier: 4 },
+        tire: { id: 'tire', key: 'Recipe_Tire', type: NODE_TYPE.RECIPE, multiplier: 1 },
+        plate: { id: 'plate', key: 'Recipe_Plate', type: NODE_TYPE.RECIPE, multiplier: 1 },
+        fuel: { id: 'fuel', key: 'Recipe_Fuel', type: NODE_TYPE.RECIPE, multiplier: 1 },
+      },
+      edges: [
+        { key: 'Desc_Rubber', from: 'rubber', to: 'tire', productionRate: 60 },
+        { key: 'Desc_Rubber', from: 'rubber', to: 'plate', productionRate: 20 },
+        { key: 'Desc_HeavyOilResidue', from: 'rubber', to: 'fuel', productionRate: 80 },
+      ],
+    };
+    const out = decomposeGraph(graph, gameData);
+
+    // Rubber node splits per primary (Rubber) consumer: 4 × 60/80 and 4 × 20/80.
+    const copies = nodesWithKey(out, 'Recipe_Rubber');
+    expect(copies).toHaveLength(2);
+    expect(copies.map((n) => n.multiplier).sort((a, b) => a - b)).toEqual([1, 3]);
+    // Each copy feeds exactly one Rubber consumer.
+    for (const copy of copies) {
+      expect(outEdges(out, copy.id).filter((e) => e.key === 'Desc_Rubber')).toHaveLength(1);
+    }
+    // The byproduct is carried by each copy, split proportionally, conserving the total.
+    const residueEdges = edgesByKey(out, 'Desc_HeavyOilResidue');
+    expect(residueEdges).toHaveLength(2);
+    expect(residueEdges.reduce((s, e) => s + e.productionRate, 0)).toBeCloseTo(80);
+  });
+
+  it('does not throw and returns every recipe when the graph contains a cycle', () => {
+    const graph: ProductionGraph = {
+      nodes: {
+        a: { id: 'a', key: 'Recipe_A', type: NODE_TYPE.RECIPE, multiplier: 1 },
+        b: { id: 'b', key: 'Recipe_B', type: NODE_TYPE.RECIPE, multiplier: 1 },
+      },
+      edges: [
+        { key: 'Desc_X', from: 'a', to: 'b', productionRate: 10 },
+        { key: 'Desc_Y', from: 'b', to: 'a', productionRate: 10 },
+      ],
+    };
+    const out = decomposeGraph(graph);
+    expect(nodesWithKey(out, 'Recipe_A')).toHaveLength(1);
+    expect(nodesWithKey(out, 'Recipe_B')).toHaveLength(1);
+  });
+
+  it('does not mutate the input graph', () => {
+    const graph: ProductionGraph = {
+      nodes: {
+        ingot: { id: 'ingot', key: 'Recipe_IronIngot', type: NODE_TYPE.RECIPE, multiplier: 3 },
+        plate: { id: 'plate', key: 'Recipe_IronPlate', type: NODE_TYPE.RECIPE, multiplier: 2 },
+        rod: { id: 'rod', key: 'Recipe_IronRod', type: NODE_TYPE.RECIPE, multiplier: 1 },
+      },
+      edges: [
+        { key: 'Desc_IronIngot', from: 'ingot', to: 'plate', productionRate: 60 },
+        { key: 'Desc_IronIngot', from: 'ingot', to: 'rod', productionRate: 30 },
+      ],
+    };
+    const edgeCountBefore = graph.edges.length;
+    const nodeCountBefore = Object.keys(graph.nodes).length;
+    decomposeGraph(graph);
+    expect(graph.edges).toHaveLength(edgeCountBefore);
+    expect(Object.keys(graph.nodes)).toHaveLength(nodeCountBefore);
+  });
+});

--- a/client/src/utilities/production-solver/decompose-graph.ts
+++ b/client/src/utilities/production-solver/decompose-graph.ts
@@ -1,0 +1,135 @@
+import { GameData } from '../../contexts/gameData/types';
+import { GraphEdge, GraphNode, NODE_TYPE, ProductionGraph } from './models';
+
+// "Dedicated lines" (balancer) view — issue TBD.
+//
+// The solved graph aggregates each recipe into a single node whose output can fan
+// out to several consumers (one recipe→consumer edge per consumer). This transform
+// decomposes that into dedicated production lines: every recipe node is duplicated
+// so it feeds exactly ONE consumer of its primary product, and its ingredient demand
+// is split proportionally across the copies. Because we process consumers before
+// producers, the split cascades all the way upstream — a shared intermediate like
+// iron ingot is duplicated per downstream path.
+//
+// Byproduct recipes (a node whose recipe emits a main product plus a byproduct, e.g.
+// base Rubber → Rubber + Heavy Oil Residue): a single machine physically produces
+// both outputs at once, so it cannot be dedicated to one consumer outright. We split
+// it by its PRIMARY product (the recipe's first-listed product) and carry each copy's
+// byproduct output onward, scaled to that copy's share. Each copy then feeds one
+// primary consumer plus a proportional slice of every byproduct — the honest best a
+// dedicated line can do for a co-product recipe.
+//
+// Purely a post-processing view over `ProductionGraph`; the LP solve is untouched.
+// Recipe copies carry fractional multipliers (e.g. 1.8× / 1.2×), shown as-is.
+
+export function decomposeGraph(graph: ProductionGraph, gameData?: GameData): ProductionGraph {
+  const nodes: { [id: string]: GraphNode } = {};
+  for (const node of Object.values(graph.nodes)) {
+    nodes[node.id] = { ...node };
+  }
+  let edges: GraphEdge[] = graph.edges.map((e) => ({ ...e }));
+
+  const recipeIds = Object.values(nodes)
+    .filter((n) => n.type === NODE_TYPE.RECIPE)
+    .map((n) => n.id);
+
+  let cloneCounter = 0;
+  for (const nodeId of consumersFirstOrder(recipeIds, edges)) {
+    const node = nodes[nodeId];
+    if (!node || node.type !== NODE_TYPE.RECIPE) continue;
+
+    const outEdges = edges.filter((e) => e.from === nodeId);
+    if (outEdges.length <= 1) continue;
+
+    // Split by the recipe's primary product; other products ride along as byproducts.
+    const primaryKey = primaryProduct(node.key, outEdges, gameData);
+    const primaryEdges = outEdges.filter((e) => e.key === primaryKey);
+    if (primaryEdges.length <= 1) continue; // primary already feeds a single consumer
+
+    const totalPrimary = primaryEdges.reduce((sum, e) => sum + e.productionRate, 0);
+    if (totalPrimary <= 0) continue;
+
+    const byproductEdges = outEdges.filter((e) => e.key !== primaryKey);
+    const inEdges = edges.filter((e) => e.to === nodeId);
+
+    // Drop the original node plus its in/out edges; re-emit a dedicated copy per
+    // primary-product consumer with proportionally scaled ingredients and byproducts.
+    const touched = new Set<GraphEdge>([...outEdges, ...inEdges]);
+    edges = edges.filter((e) => !touched.has(e));
+    delete nodes[nodeId];
+
+    for (const primaryEdge of primaryEdges) {
+      const fraction = primaryEdge.productionRate / totalPrimary;
+      const cloneId = `${nodeId}::c${cloneCounter++}`;
+      nodes[cloneId] = { ...node, id: cloneId, multiplier: node.multiplier * fraction };
+      edges.push({ ...primaryEdge, from: cloneId });
+      for (const inEdge of inEdges) {
+        edges.push({ ...inEdge, to: cloneId, productionRate: inEdge.productionRate * fraction });
+      }
+      for (const byproductEdge of byproductEdges) {
+        edges.push({ ...byproductEdge, from: cloneId, productionRate: byproductEdge.productionRate * fraction });
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+// Chooses the product to split a recipe node on. Prefers the recipe's first-listed
+// product (the game's convention for a recipe's main output, byproducts follow), and
+// falls back — when game data is unavailable or the listed product isn't present as an
+// edge — to the highest-throughput output, tie-broken by item key for determinism.
+function primaryProduct(recipeKey: string, outEdges: GraphEdge[], gameData?: GameData): string {
+  const presentKeys = new Set(outEdges.map((e) => e.key));
+
+  const listed = gameData?.recipes?.[recipeKey]?.products?.[0]?.itemClass;
+  if (listed && presentKeys.has(listed)) return listed;
+
+  const rateByKey = new Map<string, number>();
+  for (const edge of outEdges) {
+    rateByKey.set(edge.key, (rateByKey.get(edge.key) ?? 0) + edge.productionRate);
+  }
+  return [...rateByKey.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0][0];
+}
+
+// Orders recipe nodes so every recipe is processed AFTER all the recipes it feeds
+// (consumers first). Splitting a node then adds scaled edges to its upstream
+// producers, which are processed later and split in turn — cascading the
+// decomposition to the source. Kahn's algorithm over recipe→recipe edges, peeling
+// from the sink side (out-degree 0); nodes left in a cycle are appended in a stable
+// order so a looping plan still produces a deterministic result.
+function consumersFirstOrder(recipeIds: string[], edges: GraphEdge[]): string[] {
+  const recipeSet = new Set(recipeIds);
+  const recipeConsumers = new Map<string, Set<string>>(recipeIds.map((id) => [id, new Set<string>()]));
+  const recipeProducers = new Map<string, Set<string>>(recipeIds.map((id) => [id, new Set<string>()]));
+
+  for (const edge of edges) {
+    if (edge.from === edge.to) continue;
+    if (!recipeSet.has(edge.from) || !recipeSet.has(edge.to)) continue;
+    recipeConsumers.get(edge.from)!.add(edge.to);
+    recipeProducers.get(edge.to)!.add(edge.from);
+  }
+
+  const outDegree = new Map<string, number>(recipeIds.map((id) => [id, recipeConsumers.get(id)!.size]));
+  const ready = recipeIds.filter((id) => outDegree.get(id) === 0).sort();
+  const order: string[] = [];
+  const seen = new Set<string>();
+
+  while (ready.length > 0) {
+    const id = ready.shift()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    order.push(id);
+    for (const producer of recipeProducers.get(id)!) {
+      outDegree.set(producer, outDegree.get(producer)! - 1);
+      if (outDegree.get(producer) === 0) ready.push(producer);
+    }
+    ready.sort();
+  }
+
+  if (order.length < recipeIds.length) {
+    order.push(...recipeIds.filter((id) => !seen.has(id)).sort());
+  }
+  return order;
+}

--- a/client/src/utilities/production-solver/flow-model.test.ts
+++ b/client/src/utilities/production-solver/flow-model.test.ts
@@ -128,4 +128,19 @@ describe('buildFlowModel', () => {
     // the ghost edge is skipped, so the plate still has exactly its one real input
     expect(plate.inputs).toHaveLength(1);
   });
+
+  it('leaves connections without a transport label when no capacities are supplied', () => {
+    const model = buildFlowModel(graph, gameData);
+    const ingot = model.recipes.find((r) => r.recipeKey === 'Recipe_IronIngot')!;
+    expect(ingot.outputs[0].transport).toBeUndefined();
+  });
+
+  it('annotates connections with belt requirements when capacities are supplied', () => {
+    // Ingot flows 30/min; against Mk.4 (480) belts that's one line.
+    const model = buildFlowModel(graph, gameData, { beltCapacity: 480, pipeCapacity: null });
+    const ingot = model.recipes.find((r) => r.recipeKey === 'Recipe_IronIngot')!;
+    const plate = model.recipes.find((r) => r.recipeKey === 'Recipe_IronPlate')!;
+    expect(ingot.outputs[0].transport).toBe('1× Mk.4');
+    expect(plate.inputs[0].transport).toBe('1× Mk.4');
+  });
 });

--- a/client/src/utilities/production-solver/flow-model.ts
+++ b/client/src/utilities/production-solver/flow-model.ts
@@ -1,5 +1,6 @@
 import { GameData } from '../../contexts/gameData/types';
 import { GraphNode, NODE_TYPE, ProductionGraph } from './models';
+import { describeTransport, formatTransport, TransportCapacities } from './transport';
 
 // An accessible, DOM-friendly view-model of the production graph (issue #92, ADR 0002).
 // Derived purely from `ProductionGraph` (nodes + edges) so the Flow tab can render a
@@ -14,6 +15,9 @@ export type FlowConnection = {
   rate: number,
   endpointKind: FlowEndpointKind,
   endpointLabel: string,
+  // Belt/pipe requirement label (e.g. "1× Mk.4"), present only when transport
+  // capacities are supplied to buildFlowModel. See transport.ts (balancer mode B1).
+  transport?: string,
 };
 
 // One row of the Flow table: a recipe node, its building, and its item flows.
@@ -70,10 +74,22 @@ function itemName(itemKey: string, gameData: GameData): string {
 // recipe node is attached as an output of its source recipe and/or an input of its
 // target recipe. Terminal item nodes (raw inputs / final products) are summarised
 // separately so the table has clear "from raw" / "to final" anchors.
-export function buildFlowModel(graph: ProductionGraph, gameData: GameData): FlowModel {
+export function buildFlowModel(
+  graph: ProductionGraph,
+  gameData: GameData,
+  transportCaps?: TransportCapacities,
+): FlowModel {
   const rows = new Map<string, FlowRecipeRow>();
   const rawInputs: FlowTerminal[] = [];
   const finalProducts: FlowTerminal[] = [];
+
+  // When capacities are supplied, label each connection with its belt/pipe need.
+  const transportFor = (itemKey: string, rate: number): string | undefined => {
+    if (!transportCaps) return undefined;
+    const isFluid = gameData.items[itemKey]?.isFluid ?? false;
+    const info = describeTransport(rate, isFluid, transportCaps);
+    return info ? formatTransport(info) : undefined;
+  };
 
   for (const node of Object.values(graph.nodes)) {
     if (node.type === NODE_TYPE.RECIPE) {
@@ -103,6 +119,8 @@ export function buildFlowModel(graph: ProductionGraph, gameData: GameData): Flow
 
     const name = itemName(edge.key, gameData);
 
+    const transport = transportFor(edge.key, edge.productionRate);
+
     const sourceRow = rows.get(edge.from);
     if (sourceRow) {
       sourceRow.outputs.push({
@@ -111,6 +129,7 @@ export function buildFlowModel(graph: ProductionGraph, gameData: GameData): Flow
         rate: edge.productionRate,
         endpointKind: endpointKind(toNode),
         endpointLabel: endpointLabel(toNode, gameData),
+        transport,
       });
     }
 
@@ -122,6 +141,7 @@ export function buildFlowModel(graph: ProductionGraph, gameData: GameData): Flow
         rate: edge.productionRate,
         endpointKind: endpointKind(fromNode),
         endpointLabel: endpointLabel(fromNode, gameData),
+        transport,
       });
     }
   }

--- a/client/src/utilities/production-solver/transport.test.ts
+++ b/client/src/utilities/production-solver/transport.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { describeTransport, formatTransport } from './transport';
+
+const NO_CAPS = { beltCapacity: null, pipeCapacity: null };
+
+describe('describeTransport', () => {
+  it('counts belts against the selected tier', () => {
+    // 1400/min on Mk.6 (1200) belts → 2 lines.
+    const info = describeTransport(1400, false, { beltCapacity: 1200, pipeCapacity: null });
+    expect(info).toMatchObject({ medium: 'belt', tierLabel: 'Mk.6', tierRate: 1200, lineCount: 2, autoTier: false });
+  });
+
+  it('needs a single belt when the rate fits the selected tier exactly', () => {
+    const info = describeTransport(480, false, { beltCapacity: 480, pipeCapacity: null });
+    expect(info).toMatchObject({ lineCount: 1, tierLabel: 'Mk.4', autoTier: false });
+  });
+
+  it('auto-picks the smallest tier that carries the flow on one line when disabled', () => {
+    // 300/min, no belt tier selected → Mk.4 (480) is the smallest single-line tier.
+    const info = describeTransport(300, false, NO_CAPS);
+    expect(info).toMatchObject({ tierLabel: 'Mk.4', tierRate: 480, lineCount: 1, autoTier: true });
+  });
+
+  it('auto mode falls back to the top tier with multiple lines when the flow exceeds Mk.6', () => {
+    const info = describeTransport(2500, false, NO_CAPS);
+    expect(info).toMatchObject({ tierLabel: 'Mk.6', tierRate: 1200, lineCount: 3, autoTier: true });
+  });
+
+  it('routes fluids through pipe tiers', () => {
+    // 700 m³/min on Mk.2 (600) pipes → 2 lines.
+    const info = describeTransport(700, true, { beltCapacity: null, pipeCapacity: 600 });
+    expect(info).toMatchObject({ medium: 'pipe', tierLabel: 'Mk.2', lineCount: 2, autoTier: false });
+  });
+
+  it('auto-picks pipe tiers for fluids when disabled', () => {
+    const info = describeTransport(250, true, NO_CAPS);
+    expect(info).toMatchObject({ medium: 'pipe', tierLabel: 'Mk.1', tierRate: 300, lineCount: 1, autoTier: true });
+  });
+
+  it('returns null for a non-positive rate', () => {
+    expect(describeTransport(0, false, NO_CAPS)).toBeNull();
+    expect(describeTransport(-5, false, NO_CAPS)).toBeNull();
+  });
+
+  it('formats a compact line count and tier label', () => {
+    const info = describeTransport(1400, false, { beltCapacity: 1200, pipeCapacity: null })!;
+    expect(formatTransport(info)).toBe('2× Mk.6');
+  });
+});

--- a/client/src/utilities/production-solver/transport.ts
+++ b/client/src/utilities/production-solver/transport.ts
@@ -31,6 +31,28 @@ export type TransportCapacities = {
   pipeCapacity: number | null,
 };
 
+// Parses a raw capacity option (a string from state, or null when disabled) into a
+// positive number, or null when disabled/invalid.
+export function parseCapacity(value: string | null): number | null {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+// Resolves the raw belt/pipe capacity options into TransportCapacities, or undefined
+// when the "belt/pipe needs" view is off (so callers skip transport annotation).
+export function resolveTransportCaps(
+  showTransport: boolean,
+  beltCapacity: string | null,
+  pipeCapacity: string | null,
+): TransportCapacities | undefined {
+  if (!showTransport) return undefined;
+  return {
+    beltCapacity: parseCapacity(beltCapacity),
+    pipeCapacity: parseCapacity(pipeCapacity),
+  };
+}
+
 export type TransportInfo = {
   medium: 'belt' | 'pipe',
   tierLabel: string,   // e.g. 'Mk.4'

--- a/client/src/utilities/production-solver/transport.ts
+++ b/client/src/utilities/production-solver/transport.ts
@@ -1,0 +1,81 @@
+// Belt/pipe transport requirements (balancer mode, part B1).
+//
+// Given the rate of an item flowing along one edge of the production graph, works
+// out how it is physically carried: which conveyor/pipe tier and how many parallel
+// lines. Counts against the tier the user selected in the Belt/Pipe Capacity option
+// (the same value the solver constrains total node output against); when that option
+// is disabled, auto-picks the smallest tier that carries the flow on a single line.
+//
+// Pure and data-only so it can be unit-tested without the solver or React.
+
+// Conveyor and pipeline tiers, ascending. Mirrors the presets in
+// PlannerOptions/ProductionTab (belts items/min, pipes m³/min) — keep in sync.
+export const BELT_TIERS: ReadonlyArray<{ label: string, rate: number }> = [
+  { label: 'Mk.1', rate: 60 },
+  { label: 'Mk.2', rate: 120 },
+  { label: 'Mk.3', rate: 240 },
+  { label: 'Mk.4', rate: 480 },
+  { label: 'Mk.5', rate: 780 },
+  { label: 'Mk.6', rate: 1200 },
+];
+
+export const PIPE_TIERS: ReadonlyArray<{ label: string, rate: number }> = [
+  { label: 'Mk.1', rate: 300 },
+  { label: 'Mk.2', rate: 600 },
+];
+
+export type TransportCapacities = {
+  // Selected tier capacity, or null when the option is disabled. Strings from state
+  // should be parsed to numbers before being passed here.
+  beltCapacity: number | null,
+  pipeCapacity: number | null,
+};
+
+export type TransportInfo = {
+  medium: 'belt' | 'pipe',
+  tierLabel: string,   // e.g. 'Mk.4'
+  tierRate: number,    // capacity carried by one line at this tier
+  lineCount: number,   // parallel lines needed: ceil(rate / tierRate)
+  autoTier: boolean,   // true when the tier was auto-picked (option disabled)
+};
+
+// Describes how a flow of `rate` (items/min for belts, m³/min for pipes) is carried.
+// Returns null for non-positive rates (nothing to transport).
+export function describeTransport(
+  rate: number,
+  isFluid: boolean,
+  caps: TransportCapacities,
+): TransportInfo | null {
+  if (!(rate > 0)) return null;
+
+  const medium = isFluid ? 'pipe' : 'belt';
+  const tiers = isFluid ? PIPE_TIERS : BELT_TIERS;
+  const selected = isFluid ? caps.pipeCapacity : caps.beltCapacity;
+
+  if (selected != null && selected > 0) {
+    const tier = tiers.find((t) => t.rate === selected);
+    return {
+      medium,
+      tierLabel: tier?.label ?? `${selected}/min`,
+      tierRate: selected,
+      lineCount: Math.ceil(rate / selected),
+      autoTier: false,
+    };
+  }
+
+  // Auto: smallest tier that carries the whole flow on one line; if it exceeds even
+  // the top tier, use the top tier and count the parallel lines needed.
+  const tier = tiers.find((t) => t.rate >= rate) ?? tiers[tiers.length - 1];
+  return {
+    medium,
+    tierLabel: tier.label,
+    tierRate: tier.rate,
+    lineCount: Math.ceil(rate / tier.rate),
+    autoTier: true,
+  };
+}
+
+// Compact label for a transport requirement, e.g. "1× Mk.4" or "2× Mk.6".
+export function formatTransport(info: TransportInfo): string {
+  return `${info.lineCount}× ${info.tierLabel}`;
+}


### PR DESCRIPTION
## What & why

Adds infrastructure to ship **unfinished** features to `main` behind flags that are **off by default**, so half-baked work can land incrementally without being visible to normal users. Lands its first real consumer: the **balancer view** (previously on the unmerged `feat/balancer-view` branch), now gated.

## Design (decided via grilling)

- **Named flag registry** (not a single boolean): one `localStorage` key `experimental-flags` holding `Record<flagKey, boolean>`, **merged over manifest defaults** on read (unknown/removed keys dropped).
- A central manifest (`EXPERIMENTAL_FLAGS`) is the single source of truth for both context state and the settings UI.
- Consumption via `useExperimentalFlag('balancer-view')`. **Flags gate UI/presentation only**, never serialized/URL factory state.
- Scoped **"Experimental features" modal** (flask icon) with an "unfinished — may change or break" caveat. Entry points: flask `ActionIcon` in `SiteHeader` (desktop) + `Menu.Item` in the `MobileTopBar` overflow (mobile). Existing header controls untouched.
- `balancer-view` flag gates the whole feature: OFF ⇒ the two switches ("Dedicated lines" / "Belt/pipe needs") don't render and their effect is forced off (results header identical to `main`); ON ⇒ they work as designed. `MobileShell` reuses `PlannerResults`, so mobile is covered automatically.

## Implementation notes

- `contexts/experimental/` mirrors the `contexts/library/` module conventions. Merge-over-defaults derives from the raw stored value in a `useMemo` (not `useLocalStorage`'s `defaultValue`); `getInitialValueInEffect: false` avoids a first-render OFF→ON flash (safe — CSR only).
- Global theme fix: the dark-theme Switch off-track was near-identical to the modal body and invisible; added a track border. This applies to all switches app-wide (desirable — same issue affected every dark switch), verified in a real browser.

## Tests

216/216 pass, build green. Includes flag merge/hook + persistence round-trip units, modal render/toggle, mobile-menu entry point, gating show/hide, and an `ExperimentalModal` a11y (jest-axe) test. Note: axe under jsdom cannot evaluate colour-contrast, so the contrast fix was verified manually in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)