### PR TITLE
fix(ci): deploy API via az containerapp update (unblock GHCR cutover)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,11 +201,10 @@ jobs:
         run: azd provision --no-prompt
 
       # ── API blue-green ────────────────────────────────────────────────────────
-      # Resolve the current production ("blue") revision and pin it for the deploy. The API
-      # bicep keeps 100% of ingress traffic on api_blue_revision (fed via BLUE_REVISION), so
-      # `azd deploy api` lands the new ("green") revision at 0% instead of letting ACA reset
-      # traffic to 100%→latest. Empty on a greenfield deploy → bicep falls back to
-      # latestRevision. Also exported to the env for the rollback step's target.
+      # Record the current production ("blue") revision so the rollback step has an explicit
+      # target. `az containerapp update` (deploy step below) creates the new ("green") revision
+      # at 0% without shifting traffic, so blue keeps serving until the explicit shift — no
+      # traffic pin is needed. Empty on a greenfield deploy (no revisions yet).
       - name: Resolve production (blue) revision
         id: resolve_blue
         run: |
@@ -235,29 +234,22 @@ jobs:
             -p:ContainerImageTag=${{ github.sha }}
           echo "image=$image" >> "$GITHUB_OUTPUT"
 
-      # Deploy the API container-app module directly with the az CLI (not `azd deploy`),
-      # feeding the freshly-pushed GHCR image and the pinned blue revision. This applies the
-      # exact committed bicep that encodes the blue-green traffic pin, so the new (green)
-      # revision lands at 0% and smoke validates it before any shift — identical semantics to
-      # the old `azd deploy api`. The module params that azd's bicepparam templating used to
-      # supply are read from the azd env (captured from the `azd provision` outputs above).
+      # Deploy the new image with `az containerapp update`, which swaps ONLY the image and
+      # creates a new revision — it does NOT touch the registries list or traffic weights.
+      # That matters for the ACR→GHCR migration: a full bicep apply that sets registries: []
+      # is rejected (ContainerAppRegistryInUse) while older revisions still pull from ACR, and
+      # applying traffic is what forced the api_blue_revision pin in the first place. In
+      # Multiple-revision mode a new revision lands at 0% and existing traffic stays on blue,
+      # so deploy-green → smoke → shift still gate the promotion. All env vars/probes/scale are
+      # preserved from the current template. (The api module bicep remains for greenfield.)
       - name: Deploy API (green revision at 0%)
         id: deploy_api
         run: |
           set -euo pipefail
-          az deployment group create \
+          az containerapp update \
+            --name "$ACA_APP_NAME" \
             --resource-group "$ACA_RESOURCE_GROUP" \
-            --template-file YetAnotherFactoryPlanner.AppHost/infra/api/api-containerapp.module.bicep \
-            --parameters \
-              api_containerimage="${{ steps.build_api_image.outputs.image }}" \
-              api_blue_revision="${BLUE_REVISION:-}" \
-              api_containerport=8080 \
-              api_identity_outputs_clientid="$(azd env get-value API_IDENTITY_CLIENTID)" \
-              api_identity_outputs_id="$(azd env get-value API_IDENTITY_ID)" \
-              cosmos_db_outputs_connectionstring="$(azd env get-value COSMOS_DB_CONNECTIONSTRING)" \
-              env_outputs_azure_container_apps_environment_default_domain="$(azd env get-value ENV_AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN)" \
-              env_outputs_azure_container_apps_environment_id="$(azd env get-value ENV_AZURE_CONTAINER_APPS_ENVIRONMENT_ID)" \
-              env_outputs_applicationinsights_connection_string="$(azd env get-value ENV_APPLICATIONINSIGHTS_CONNECTION_STRING)"
+            --image "${{ steps.build_api_image.outputs.image }}"
 
       # Verify a new (green) revision exists and differs from blue. No traffic change.
       - name: Verify green revision


### PR DESCRIPTION
## Problem

The first post-merge production deploy of #178 failed:

```
ContainerAppRegistryInUse: Container App 'api' has active revisions pulling
images from the registries you are trying to delete ... deactivate the
revisions: api--0000001..0000005, api--1m27j4i
```

The `az deployment group create` step applies the registry-less api module, which sets `registries: []`. ACA **refuses to remove a registry while active revisions still reference it** — blue (`api--0000005`) and all history still pull from the old ACR. Chicken-and-egg: can't drop the registry until those revisions are gone; can't retire blue until green serves.

The GHCR build+push **succeeded** and the package is public — only the deploy mechanism was wrong. Prod was unaffected (blue kept serving; no green created, no shift).

## Fix

Deploy with `az containerapp update --image` instead of a full bicep apply. It swaps **only** the image and creates a new revision — it does not touch the registries list or traffic weights. In Multiple-revision mode green lands at 0% and blue keeps serving, so `deploy-green → smoke → shift` still gate promotion. The `api_blue_revision` traffic pin is no longer needed by CI (its only purpose was to counter azd's full-apply traffic reset); the module bicep stays for greenfield.

## Follow-up (manual, to actually delete ACR)

Once this deploy has green (GHCR) serving 100%:
1. Deactivate the old ACR-backed revisions: `az containerapp revision deactivate`.
2. Remove ACR from the app: `az containerapp registry remove --server envacrmtprvsbekbtsi.azurecr.io`.
3. Delete the registry + leftover MI/role: `az acr delete` (this is where the ~\$5/mo is actually saved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)