### PR TITLE
fix(infra): hyphen-free Cosmos connection name for SWA app settings

### DIFF
--- a/YetAnotherFactoryPlanner.AppHost/AppHost.cs
+++ b/YetAnotherFactoryPlanner.AppHost/AppHost.cs
@@ -3,7 +3,7 @@ using Azure.Provisioning.CosmosDB;
 var builder = DistributedApplication.CreateBuilder(args);
 
 #pragma warning disable ASPIRECOSMOSDB001
-var cosmosDb = builder.AddAzureCosmosDB("cosmos-db")
+var cosmosDb = builder.AddAzureCosmosDB("cosmosdb")
     .RunAsPreviewEmulator(emulator =>
     {
         emulator.WithDataExplorer();
@@ -33,7 +33,7 @@ cosmosDb.ConfigureInfrastructure(infra =>
 // Azure Functions (.NET 9 isolated) API. Replaces the ACA-hosted api.web: in production this is
 // deployed as Azure Static Web Apps managed functions (served same-origin at /api/*), which removes
 // the scale-from-zero cold start on the share path. Locally, Aspire's Functions integration runs it
-// via the Azure Functions Core Tools and injects the Cosmos connection string (ConnectionStrings__cosmos-db)
+// via the Azure Functions Core Tools and injects the Cosmos connection string (ConnectionStrings__cosmosdb)
 // plus a host-storage (Azurite) connection for AzureWebJobsStorage. The ACA publish/probe/blue-green
 // config is gone — SWA owns hosting now (see Step 3 for the infra/CI teardown).
 var api = builder.AddAzureFunctionsProject<Projects.api_functions>("api")

--- a/api.functions/Program.cs
+++ b/api.functions/Program.cs
@@ -19,12 +19,13 @@ var jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
 builder.Services.AddSingleton(jsonOptions);
 
 // Raw Cosmos SDK (no EF Core, no CosmosWarmupService). The Aspire client integration reads the
-// connection string named "cosmos-db" (config key ConnectionStrings:cosmos-db, env
-// ConnectionStrings__cosmos-db) — injected locally by the AppHost's .WithReference(cosmosDb) and,
-// in production, supplied by the SWA app settings (key-based; see Step 3 infra). It also transparently
-// trusts the local preview emulator's self-signed certificate.
+// connection string named "cosmosdb" (config key ConnectionStrings:cosmosdb, env
+// ConnectionStrings__cosmosdb) — injected locally by the AppHost's .WithReference(cosmosDb) and,
+// in production, supplied by the SWA app settings (key-based; see Step 3 infra). The name is
+// hyphen-free because SWA app-setting keys reject '-'. It also transparently trusts the local
+// preview emulator's self-signed certificate.
 builder.AddAzureCosmosClient(
-    "cosmos-db",
+    "cosmosdb",
     configureClientOptions: options =>
     {
         options.UseSystemTextJsonSerializerWithOptions = jsonOptions;

--- a/infra/app/swa.bicep
+++ b/infra/app/swa.bicep
@@ -2,7 +2,7 @@ param location string
 param appName string
 param tags object = {}
 
-@description('Key-based Cosmos DB connection string (AccountEndpoint=…;AccountKey=…). Surfaces to the managed functions runtime as the ConnectionStrings__cosmos-db env var, read by AddAzureCosmosClient("cosmos-db").')
+@description('Key-based Cosmos DB connection string (AccountEndpoint=…;AccountKey=…). Surfaces to the managed functions runtime as the ConnectionStrings__cosmosdb env var, read by AddAzureCosmosClient("cosmosdb").')
 @secure()
 param cosmosConnectionString string
 
@@ -28,16 +28,18 @@ resource staticWebApp 'Microsoft.Web/staticSites@2024-11-01' = {
 }
 
 // App settings for the SWA-hosted managed functions. These surface to the isolated worker as
-// environment variables. `ConnectionStrings__cosmos-db` (double-underscore) maps to config key
-// `ConnectionStrings:cosmos-db`, which the functions' AddAzureCosmosClient("cosmos-db") reads for
-// key-based Cosmos auth. `APPLICATIONINSIGHTS_CONNECTION_STRING` wires the Functions host's built-in
-// App Insights telemetry. Name MUST be literally 'appsettings' (managed functions); 'functionappsettings'
-// is only for bring-your-own-functions.
+// environment variables. `ConnectionStrings__cosmosdb` (double-underscore) maps to config key
+// `ConnectionStrings:cosmosdb`, which the functions' AddAzureCosmosClient("cosmosdb") reads for
+// key-based Cosmos auth. The connection name is hyphen-free on purpose: SWA app-setting keys may
+// only contain alphanumerics, '.', and '_' — a hyphen (as in the Aspire default "cosmos-db")
+// makes the whole appSettings deployment fail with BadRequest. `APPLICATIONINSIGHTS_CONNECTION_STRING`
+// wires the Functions host's built-in App Insights telemetry. Name MUST be literally 'appsettings'
+// (managed functions); 'functionappsettings' is only for bring-your-own-functions.
 resource staticWebAppSettings 'Microsoft.Web/staticSites/config@2024-11-01' = {
   name: 'appsettings'
   parent: staticWebApp
   properties: {
-    'ConnectionStrings__cosmos-db': cosmosConnectionString
+    ConnectionStrings__cosmosdb: cosmosConnectionString
     APPLICATIONINSIGHTS_CONNECTION_STRING: appInsightsConnectionString
   }
 }

--- a/infra/cosmos-db/cosmos-db.module.bicep
+++ b/infra/cosmos-db/cosmos-db.module.bicep
@@ -22,7 +22,7 @@ resource cosmos_db 'Microsoft.DocumentDB/databaseAccounts@2024-08-15' = {
     databaseAccountOfferType: 'Standard'
     // Key-based (local) auth is ENABLED for the SWA managed-functions API. SWA managed functions
     // have no managed identity and no Key Vault refs, so they authenticate to Cosmos with an
-    // account key supplied via a SWA app setting (ConnectionStrings__cosmos-db). Accepted
+    // account key supplied via a SWA app setting (ConnectionStrings__cosmosdb). Accepted
     // security-posture trade-off: the `factories` container holds only publicly-shareable factory
     // configs with a 7-day TTL. (Was `disableLocalAuth: true` under the retired ACA managed-identity
     // setup — see infra/api-identity + infra/api-roles-cosmos-db, both deleted with ACA.)
@@ -64,7 +64,7 @@ resource factories 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/container
 }
 
 // Key-based (AccountEndpoint=…;AccountKey=…) connection string consumed by the SWA managed
-// functions' AddAzureCosmosClient("cosmos-db"). Marked @secure() so it is not logged and never
+// functions' AddAzureCosmosClient("cosmosdb"). Marked @secure() so it is not logged and never
 // surfaces in deployment output history; main.bicep passes it straight into the SWA app settings.
 @secure()
 output connectionString string = cosmos_db.listConnectionStrings().connectionStrings[0].connectionString


### PR DESCRIPTION
## Why

The production cutover deploy (merge of #180) **failed at `azd provision`**:

```
BadRequest: appSettings is invalid. App setting key can only consist of
alphanumeric characters, '.', and '_'. ConnectionStrings__cosmos-db is invalid.
```

SWA app-setting keys reject `-`, but the Aspire Cosmos resource name `cosmos-db` fed into the key `ConnectionStrings__cosmos-db`. Provision failed at **validation**, so the deploy steps never ran — **production stayed on the old ACA stack, no user-facing impact.**

## Fix

Rename the Cosmos connection identifier `cosmos-db` → `cosmosdb` (hyphen-free) consistently:
- `AppHost.cs` `AddAzureCosmosDB("cosmosdb")` (local Aspire injects `ConnectionStrings__cosmosdb`)
- `api.functions/Program.cs` `AddAzureCosmosClient("cosmosdb")`
- `infra/app/swa.bicep` app-setting key `ConnectionStrings__cosmosdb`

The Cosmos **account name, database (`shared-factory`), and container (`factories`) are unchanged**, so existing data and share links are unaffected. The bicep module name/path and the inert `aspire-resource-name` tag are left as-is.

## Verified

- Solution builds clean; `api.Tests` 37/37 (pinned hash `6a012cfd4bee911e` intact); `bicep build` of main + all modules.

## ⚠️ Note for the re-run

`azd provision` uses **incremental** ARM deployment, so removing the ACA env / user-assigned identity / Cosmos RBAC modules from bicep does **not** delete those live resources — they'll linger (and may still cost) until deleted manually (`az containerapp env delete`, delete the UAMI + role assignment). Worth cleaning up once the functions are confirmed serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)