### PR TITLE
fix(functions): target .NET 8 isolated (SWA rejects .NET 9 managed deploy)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,9 +197,10 @@ jobs:
           npm ci --prefix client
           npm run build --prefix client
 
-      # Functions: pre-publish the .NET 9 isolated worker so the SWA action deploys the built output
-      # (skip_api_build) rather than asking Oryx to build a .NET 9 isolated project it can't reliably
-      # build. staticwebapp.config.json pins platform.apiRuntime to dotnet-isolated:9.0.
+      # Functions: pre-publish the .NET 8 isolated worker so the SWA action deploys the built output
+      # (skip_api_build) rather than asking Oryx to build it. staticwebapp.config.json pins
+      # platform.apiRuntime to dotnet-isolated:8.0 — dotnet-isolated:9.0 fails to deploy as a SWA
+      # managed function ("Failed to deploy the Azure Functions"; verified via a minimal repro).
       - name: Publish managed functions
         run: dotnet publish api.functions/api.functions.csproj --configuration Release --output ./api-publish
 

--- a/api.Core/api.Core.csproj
+++ b/api.Core/api.Core.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- net9.0 so SWA managed functions (dotnet-isolated:9.0) and api.functions can share this. -->
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- net8.0: SWA managed functions reject dotnet-isolated:9.0 at deploy time ("Failed to
+         deploy the Azure Functions"); dotnet-isolated:8.0 deploys. Shared by api.functions. -->
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>api</RootNamespace>

--- a/api.functions/api.functions.csproj
+++ b/api.functions/api.functions.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- net9.0 isolated worker: SWA managed functions cap is dotnet-isolated:9.0. -->
-    <TargetFramework>net9.0</TargetFramework>
+    <!-- net8.0 isolated worker. dotnet-isolated:9.0 is listed in the SWA apiRuntime table but
+         fails to deploy as a managed function ("Failed to deploy the Azure Functions", verified
+         via a minimal repro); dotnet-isolated:8.0 deploys cleanly. -->
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>

--- a/client/public/staticwebapp.config.json
+++ b/client/public/staticwebapp.config.json
@@ -1,6 +1,6 @@
 {
   "platform": {
-    "apiRuntime": "dotnet-isolated:9.0"
+    "apiRuntime": "dotnet-isolated:8.0"
   },
   "globalHeaders": {
     "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; worker-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'",


### PR DESCRIPTION
## Why

The production cutover (PR #180 + #181) deployed everything except the **managed functions**, which failed at the SWA step with the generic **"Failed to deploy the Azure Functions"** — no detail exposed via ARM, CLI, GitHub logs, App Insights (no data), or the portal.

I root-caused it with a **minimal local repro** — the SWA CLI (`swa deploy … -n stapp-production`, authenticating via `az` login; a `secrets-list` deployment token gets rejected and fails opaquely) against the real SWA, deploying to a throwaway preview env:

| Function | Result |
|---|---|
| minimal **.NET 9** isolated (no deps) | ❌ "Failed to deploy the Azure Functions" |
| minimal **.NET 8** isolated (no deps) | ✅ Deployment Complete |

So it's **not our code/dependencies** — `dotnet-isolated:9.0` simply does not deploy as a SWA **managed** function on the Free plan (it's listed in the apiRuntime table, but the managed-functions *constraints* doc caps at .NET 8). `dotnet-isolated:8.0` deploys cleanly.

## Fix

- Retarget `api.functions` and `api.Core` to **net8.0**.
- Pin `staticwebapp.config.json` `platform.apiRuntime` to **`dotnet-isolated:8.0`**.
- Update the stale CI comment.

## Validated live (not just built)

Deployed the **real** functions (Cosmos + Aspire + FluentValidation) to a preview environment and exercised them end-to-end against production Cosmos:
- `POST /api/share-factory` (empty productionItems) → **400** `"'Production Items' must not be empty."` (validator runs)
- `GET /api/shared-factories/<missing>` → **404** `"Factory not found"` (Cosmos cross-partition query ran → not a 500)
- `POST /api/share-factory` (valid) → **201** `{"data":{"key":…}}` (Cosmos write)
- `POST` the pinned `KnownConfig` → **`6a012cfd4bee911e`** — byte-identical hash **on the net8 runtime**, so existing share links keep resolving.

`api.Tests` 37/37 green (pinned hash), solution builds clean.

## Notes
- No change to Cosmos data, container names, or the wire contract.
- The earlier deploy failed on the *staging* environment, so production was never touched — the site is still on the old stack until this merges and the deploy completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)