### PR TITLE
fix(client): copy share link inside the click gesture (#182)

### DIFF
--- a/client/src/api/useApi.ts
+++ b/client/src/api/useApi.ts
@@ -8,12 +8,18 @@ export function useApi<RES extends APIResponseData = APIResponseData, REQ extend
   const [loading, setLoading] = useState<boolean>(false);
   const prevLoading = usePrevious(loading);
 
-  const requestHandler = useCallback(async (req: REQ) => {
+  // Returns the response on success so callers that need the result *right now* (e.g.
+  // building a share link to copy inside a click gesture) can await it directly, while
+  // fire-and-forget callers keep reading from the data/error/loading state as before.
+  // On failure it resolves to undefined rather than throwing, so those un-awaited
+  // callers never produce an unhandled rejection — errors are still surfaced via state.
+  const requestHandler = useCallback(async (req: REQ): Promise<RES | undefined> => {
     setLoading(true);
     try {
       const result = await apiAction(req);
       setData(result);
       setError(null);
+      return result;
     } catch (e: any) {
       const apiError: APIError = {
         status: e.status || 0,
@@ -21,6 +27,7 @@ export function useApi<RES extends APIResponseData = APIResponseData, REQ extend
       }
       setData(null);
       setError(apiError);
+      return undefined;
     } finally {
       setLoading(false);
     }

--- a/client/src/containers/ProductionPlanner/MobileShell/FactoryPicker.tsx
+++ b/client/src/containers/ProductionPlanner/MobileShell/FactoryPicker.tsx
@@ -9,12 +9,12 @@
 // sit in the footer; Share targets the active factory, as on desktop.
 import React, { useMemo, useState } from 'react';
 import styled from 'styled-components';
-import { Menu, ActionIcon, Button, Group, Text, TextInput, Tooltip, Popover } from '@mantine/core';
-import { Search, Plus, Share2, Check, MoreVertical, Edit2, Copy, Trash2, RotateCcw } from 'react-feather';
+import { Menu, ActionIcon, Button, Group, Text, TextInput } from '@mantine/core';
+import { Search, Plus, Check, MoreVertical, Edit2, Copy, Trash2, RotateCcw } from 'react-feather';
 import { useProductionContext } from '../../../contexts/production';
 import { useLibraryContext } from '../../../contexts/library';
 import { labelOf, relativeTime } from '../../../utilities/factory-label';
-import { canShareFactory } from '../../../utilities/shared-factory/codec';
+import ShareButton from '../ShareButton';
 import { RenameDialog, DeleteDialog } from '../PlannerOptions/factory-dialogs';
 
 type Props = { onClose: () => void };
@@ -25,7 +25,6 @@ const FactoryPicker = ({ onClose }: Props) => {
   const [query, setQuery] = useState('');
   const [renameId, setRenameId] = useState<string | null>(null);
   const [deleteId, setDeleteId] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
 
   const byId = (id: string | null) => (id ? lib.factories.find((f) => f.id === id) : undefined);
 
@@ -35,10 +34,6 @@ const FactoryPicker = ({ onClose }: Props) => {
   );
 
   const pick = (id: string) => { lib.select(id); onClose(); };
-
-  // Guard the Share button rather than firing a POST that 400s with no feedback.
-  const canShare = canShareFactory(ctx.state);
-  const onShare = () => { ctx.generateShareLink(); setCopied(true); setTimeout(() => setCopied(false), 2500); };
 
   return (
     <>
@@ -94,19 +89,7 @@ const FactoryPicker = ({ onClose }: Props) => {
         <Button variant="default" leftSection={<Plus size={16} />} onClick={() => lib.create()} styles={{ root: { color: 'var(--mantine-color-text)' } }}>
           New factory
         </Button>
-        <Tooltip label="Add a product to share this factory" withArrow disabled={canShare}>
-          {/* The span keeps the Tooltip alive while the Button is disabled (a disabled
-              control emits no pointer events). The Popover targets the Button so its
-              aria-haspopup/expanded land on an element that supports them. */}
-          <span style={{ marginLeft: 'auto' }}>
-            <Popover opened={copied && canShare} position="top-end" withArrow>
-              <Popover.Target>
-                <Button color="positive.8" leftSection={<Share2 size={16} />} loading={ctx.shareLink.loading} disabled={!canShare} onClick={onShare}>Share</Button>
-              </Popover.Target>
-              <Popover.Dropdown><Text size="sm">{ctx.shareLink.link ? 'Link copied!' : 'Generating…'}</Text></Popover.Dropdown>
-            </Popover>
-          </span>
-        </Tooltip>
+        <ShareButton position="top-end" wrapperStyle={{ marginLeft: 'auto' }} />
       </Group>
 
       <RenameDialog opened={!!renameId} initial={byId(renameId)?.nickname ?? ''} onClose={() => setRenameId(null)} onSubmit={(v) => renameId && lib.rename(renameId, v)} />

--- a/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
@@ -4,12 +4,12 @@
 // control, presented as a header band with a divider above the view tabs. Switching
 // = the tabs; per-factory actions sit in a "⋯" menu + Share beside.
 import React, { useState } from 'react';
-import { Tabs, Group, Menu, Text, ActionIcon, Tooltip, Button, Popover } from '@mantine/core';
-import { Plus, Share2, MoreHorizontal, Edit2, Copy, Trash2, RotateCcw } from 'react-feather';
+import { Tabs, Group, Menu, ActionIcon, Tooltip } from '@mantine/core';
+import { Plus, MoreHorizontal, Edit2, Copy, Trash2, RotateCcw } from 'react-feather';
 import { useProductionContext } from '../../../contexts/production';
 import { useLibraryContext } from '../../../contexts/library';
 import { labelOf, relativeTime } from '../../../utilities/factory-label';
-import { canShareFactory } from '../../../utilities/shared-factory/codec';
+import ShareButton from '../ShareButton';
 import { RenameDialog, DeleteDialog } from './factory-dialogs';
 
 // `inline` (default) is the desktop header band: tabs and actions share one nowrap
@@ -23,7 +23,6 @@ const FactorySwitcher = ({ layout = 'inline' }: { layout?: FactorySwitcherLayout
   const lib = useLibraryContext();
   const [renameOpen, setRenameOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [copied, setCopied] = useState(false);
 
   const activeFactory = lib.activeFactory;
   if (!activeFactory) return null;
@@ -34,10 +33,6 @@ const FactorySwitcher = ({ layout = 'inline' }: { layout?: FactorySwitcherLayout
   // active label from the reducer state instead lags a render behind the switch and
   // flashes the previous factory's name.
   const activeLabel = labelOf(activeFactory, ctx.gameData);
-
-  // Guard the Share button rather than firing a POST that 400s with no feedback.
-  const canShare = canShareFactory(ctx.state);
-  const onShare = () => { ctx.generateShareLink(); setCopied(true); setTimeout(() => setCopied(false), 2500); };
 
   const stacked = layout === 'stacked';
 
@@ -104,20 +99,7 @@ const FactorySwitcher = ({ layout = 'inline' }: { layout?: FactorySwitcherLayout
       </Menu>
 
       {/* Share */}
-      <Tooltip label="Add a product to share this factory" withArrow disabled={canShare}>
-        {/* The span keeps the Tooltip working while the Button is disabled (a
-            disabled control emits no pointer events). The Popover targets the Button
-            itself — not the span — so its aria-haspopup/aria-expanded land on an
-            element that supports them (WCAG aria-allowed-attr). */}
-        <span>
-          <Popover opened={copied && canShare} position="bottom-end" withArrow>
-            <Popover.Target>
-              <Button color="positive.8" leftSection={<Share2 size={16} />} loading={ctx.shareLink.loading} disabled={!canShare} onClick={onShare}>Share</Button>
-            </Popover.Target>
-            <Popover.Dropdown><Text size="sm">{ctx.shareLink.link ? 'Link copied!' : 'Generating…'}</Text></Popover.Dropdown>
-          </Popover>
-        </span>
-      </Tooltip>
+      <ShareButton position="bottom-end" />
     </>
   );
 

--- a/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/index.tsx
@@ -1,30 +1,19 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { Container, Tabs } from '@mantine/core';
 import { TrendingUp, Shuffle, Box, Tool } from 'react-feather';
-import { useProductionContext } from '../../../contexts/production';
 import ProductionTab from './ProductionTab';
 import InputsTab from './InputsTab';
 import RecipesTab from './RecipesTab';
 import BuildingsTab from './BuildingsTab';
-import { usePrevious } from '../../../hooks/usePrevious';
 // The old Calculate/Auto-calc/Save&Share/Reset header is gone: WelcomeCard hosts the
 // relocated greeting and the factory switcher lives in the main body (FactorySwitcher).
 import WelcomeCard from './WelcomeCard';
 
 const PlannerOptions = () => {
-  const ctx = useProductionContext();
   // Drop the container chrome around the tab sections so the section cards sit flush
   // on the drawer surface, aligned with the Welcome card above.
   const flush = true;
-
-  // Copy the share link to the clipboard when one is generated.
-  const prevShareLink = usePrevious(ctx.shareLink.link);
-  useEffect(() => {
-    if (ctx.shareLink.copyToClipboard && ctx.shareLink.link && ctx.shareLink.link !== prevShareLink) {
-      navigator.clipboard.writeText(ctx.shareLink.link);
-    }
-  }, [ctx.shareLink, prevShareLink]);
 
   return (
     <>

--- a/client/src/containers/ProductionPlanner/ShareButton.tsx
+++ b/client/src/containers/ProductionPlanner/ShareButton.tsx
@@ -1,0 +1,45 @@
+// The Share control, shared by the desktop FactorySwitcher header band and the mobile
+// FactoryPicker sheet. The two rendered identical Tooltip + Popover + Button + feedback;
+// only the popover anchor and the wrapper alignment differ, so those are props. The copy
+// behavior and feedback lifecycle live in useShareFactory (see #182).
+import React from 'react';
+import { Tooltip, Button, Popover } from '@mantine/core';
+import { Share2 } from 'react-feather';
+import { useProductionContext } from '../../contexts/production';
+import { canShareFactory } from '../../utilities/shared-factory/codec';
+import { useShareFactory } from './useShareFactory';
+import ShareStatusView from './ShareStatusView';
+
+type Props = {
+  // Popover anchor: the desktop header band opens downward, the mobile sheet upward.
+  position?: 'bottom-end' | 'top-end';
+  // Optional style for the wrapping span (the mobile row pushes the button to the end).
+  wrapperStyle?: React.CSSProperties;
+};
+
+const ShareButton = ({ position = 'bottom-end', wrapperStyle }: Props) => {
+  const ctx = useProductionContext();
+  const share = useShareFactory();
+
+  // Guard the Share button rather than firing a POST that 400s with no feedback.
+  const canShare = canShareFactory(ctx.state);
+
+  return (
+    <Tooltip label="Add a product to share this factory" withArrow disabled={canShare}>
+      {/* The span keeps the Tooltip alive while the Button is disabled (a disabled
+          control emits no pointer events). The Popover targets the Button — not the
+          span — so its aria-haspopup/aria-expanded land on an element that supports
+          them (WCAG aria-allowed-attr). */}
+      <span style={wrapperStyle}>
+        <Popover opened={share.status !== 'idle' && canShare} position={position} withArrow>
+          <Popover.Target>
+            <Button color="positive.8" leftSection={<Share2 size={16} />} loading={ctx.shareLink.loading} disabled={!canShare} onClick={share.onShare}>Share</Button>
+          </Popover.Target>
+          <Popover.Dropdown><ShareStatusView status={share.status} link={share.link} /></Popover.Dropdown>
+        </Popover>
+      </span>
+    </Tooltip>
+  );
+};
+
+export default ShareButton;

--- a/client/src/containers/ProductionPlanner/ShareStatusView.tsx
+++ b/client/src/containers/ProductionPlanner/ShareStatusView.tsx
@@ -1,0 +1,43 @@
+// Shared Share-popover content, so the desktop FactorySwitcher and the mobile
+// FactoryPicker render identical feedback off the same useShareFactory status. The
+// popovers themselves differ (position/anchor) and stay in each component; only this
+// inner message + manual-copy fallback is shared.
+import React, { useEffect, useRef } from 'react';
+import { Text, TextInput } from '@mantine/core';
+import type { ShareStatus } from './useShareFactory';
+
+// A read-only, auto-selected field holding the link, shown when the clipboard write
+// couldn't complete (rejected, or an insecure/unsupported context). It guarantees the
+// link is always reachable — one Ctrl/Cmd-C away — even when the server was cold.
+const ManualCopyField = ({ link }: { link: string }) => {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+  return (
+    <TextInput
+      ref={ref}
+      value={link}
+      readOnly
+      onFocus={(e) => e.currentTarget.select()}
+      aria-label="Shareable link"
+      size="xs"
+    />
+  );
+};
+
+const ShareStatusView = ({ status, link }: { status: ShareStatus; link: string }) => {
+  if (status === 'failed') {
+    return (
+      <div style={{ maxWidth: 260 }}>
+        <Text size="sm" mb={6}>Couldn't copy — copy the link below</Text>
+        <ManualCopyField link={link} />
+      </div>
+    );
+  }
+  // 'copying' (and the closed 'idle') show progress; 'copied' confirms the write.
+  return <Text size="sm">{status === 'copied' ? 'Link copied!' : 'Generating…'}</Text>;
+};
+
+export default ShareStatusView;

--- a/client/src/containers/ProductionPlanner/useShareFactory.ts
+++ b/client/src/containers/ProductionPlanner/useShareFactory.ts
@@ -1,0 +1,76 @@
+import { useCallback, useRef, useState } from 'react';
+import { useProductionContext } from '../../contexts/production';
+
+// The Share flow's feedback lifecycle, driven by the *actual* clipboard result rather
+// than by "the POST returned a key" (see #182): on a cold-started server the write was
+// pushed past the click's user-activation window and silently rejected, yet the UI
+// still claimed "Link copied!". Now we only celebrate once the clipboard resolves, and
+// fall back to a manual-copy field when it doesn't.
+export type ShareStatus = 'idle' | 'copying' | 'copied' | 'failed';
+
+// How long the success popover lingers before auto-dismissing. The failure popover is
+// deliberately sticky — it hosts the manual-copy field — so it is never auto-closed.
+const COPIED_DISMISS_MS = 2500;
+
+export function useShareFactory() {
+  const ctx = useProductionContext();
+  const [status, setStatus] = useState<ShareStatus>('idle');
+  // The resolved link, kept so the manual-copy fallback always has something to show
+  // even when the clipboard write itself was rejected.
+  const [link, setLink] = useState('');
+  const dismissTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const onShare = useCallback(async () => {
+    clearTimeout(dismissTimer.current);
+    setStatus('copying');
+    setLink('');
+
+    // Confirm the copy and let it linger briefly before auto-dismissing. Shared by the
+    // async-write and the plain-text fallback paths so the two-step stays in sync.
+    const markCopied = () => {
+      setStatus('copied');
+      dismissTimer.current = setTimeout(() => setStatus('idle'), COPIED_DISMISS_MS);
+    };
+
+    // One promise, shared by the async ClipboardItem and our own state, so the POST
+    // fires exactly once.
+    const linkPromise = ctx.generateShareLink();
+
+    try {
+      // Async clipboard write: hand the browser a *pending* Blob via ClipboardItem so
+      // the write stays authorized by this click across the await for the (possibly
+      // cold-started) POST. A plain `await post; writeText(link)` runs after transient
+      // activation has expired, which Edge/Safari reject silently — the #182 bug.
+      const item = new ClipboardItem({
+        'text/plain': linkPromise.then((l) => new Blob([l], { type: 'text/plain' })),
+      });
+      await navigator.clipboard.write([item]);
+      setLink(await linkPromise);
+      markCopied();
+    } catch {
+      // ClipboardItem / clipboard.write is unavailable (older or insecure context) or
+      // the write was rejected. Recover the link for a best-effort plain-text write —
+      // mirroring the optional-chaining pattern in GraphContextMenu — then drop to the
+      // manual-copy field so the link is never stranded.
+      let resolved = '';
+      try {
+        resolved = await linkPromise;
+      } catch {
+        // Generation itself failed (e.g. the POST errored) — there is no link to offer.
+      }
+      setLink(resolved);
+      if (resolved) {
+        try {
+          await navigator.clipboard?.writeText(resolved);
+          markCopied();
+          return;
+        } catch {
+          // Both clipboard paths rejected — fall through to the manual-copy field.
+        }
+      }
+      setStatus('failed');
+    }
+  }, [ctx]);
+
+  return { status, link, onShare };
+}

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -11,7 +11,7 @@ import { useSolverRun } from './useSolverRun';
 import { useLibraryContext } from '../library';
 
 
-export type ShareLinkProps = { link: string, copyToClipboard: boolean, loading: boolean };
+export type ShareLinkProps = { loading: boolean };
 
 // TYPE
 export type ProductionContextType = {
@@ -21,7 +21,7 @@ export type ProductionContextType = {
   calculating: boolean,
   solverResults: SolverResults | null,
   calculate: () => void,
-  generateShareLink: () => void,
+  generateShareLink: () => Promise<string>,
   shareLink: ShareLinkProps,
 };
 
@@ -61,22 +61,24 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
   // and the calculating flag) lives in useSolverRun. The provider only decides WHEN to solve.
   const { solverResults, calculating, calculate: handleCalculateFactory } = useSolverRun(state, gameData);
 
-  const handleGenerateShareLink = () => {
-    postSharedFactory.request({ factoryConfig: state, gameVersion });
+  // Await the POST and resolve to the full share link so the caller can copy it inside
+  // the originating click gesture (see #182). Rejects if the server never returned a
+  // key, letting the Share UI drop to its manual-copy fallback.
+  const handleGenerateShareLink = async (): Promise<string> => {
+    const result = await postSharedFactory.request({ factoryConfig: state, gameVersion });
+    const key = result?.key;
+    if (!key) {
+      throw new Error('Failed to generate a share link');
+    }
+    return `${window.location.protocol}//${window.location.host}${window.location.pathname}?${SHARE_QUERY_PARAM}=${key}`;
   };
 
-  const shareLink: ShareLinkProps = useMemo(() => {
-    let link = '';
-    const key = postSharedFactory.data?.key;
-    if (key) {
-      link = `${window.location.protocol}//${window.location.host}${window.location.pathname}?${SHARE_QUERY_PARAM}=${key}`;
-    }
-    return {
-      link,
-      copyToClipboard: !!postSharedFactory.data?.key,
-      loading: postSharedFactory.loading,
-    }
-  }, [postSharedFactory.data?.key, postSharedFactory.loading]);
+  // The share link itself is returned by handleGenerateShareLink (awaited inside the
+  // Share click), so the context only needs to expose the in-flight state for the
+  // button's spinner — it no longer rebuilds the URL here.
+  const shareLink: ShareLinkProps = useMemo(() => ({
+    loading: postSharedFactory.loading,
+  }), [postSharedFactory.loading]);
 
   // Load the active factory's content into the reducer. Shared/legacy take priority
   // (URL imports), then a stored library config, else a fresh/empty factory.

--- a/client/tests/a11y.spec.ts
+++ b/client/tests/a11y.spec.ts
@@ -115,7 +115,14 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
     expect(results.violations).toEqual([]);
   });
 
-  test('Share-link "copied" popover has no WCAG A/AA violations', async ({ page }) => {
+  test('Share-link "copied" popover has no WCAG A/AA violations', async ({ page, context, browserName }) => {
+    // The popover now confirms "Link copied!" only once the clipboard write actually
+    // resolves (#182). Grant clipboard-write so Chromium's write succeeds here (its
+    // permission model gates it; Firefox/WebKit resolve without an explicit grant).
+    if (browserName === 'chromium') {
+      await context.grantPermissions(['clipboard-write']);
+    }
+
     // Stub the share endpoint so the popover opens without a live backend.
     await page.route(/\/share-factory$/, async (route) => {
       await route.fulfill({

--- a/client/tests/factory-library.spec.ts
+++ b/client/tests/factory-library.spec.ts
@@ -202,7 +202,14 @@ test.describe('Multi-factory library', () => {
     await expect(page.locator(FACTORY_TAB).filter({ hasText: 'Iron Plate' })).toHaveCount(1);
   });
 
-  test('Share is gated until a product exists, then posts and confirms', async ({ page }) => {
+  test('Share is gated until a product exists, then posts and confirms', async ({ page, context, browserName }) => {
+    // The confirmation popover now waits for the clipboard write to resolve (#182), so
+    // grant clipboard-write for Chromium (whose permission model gates it) to exercise
+    // the success path; Firefox/WebKit resolve the write without an explicit grant.
+    if (browserName === 'chromium') {
+      await context.grantPermissions(['clipboard-write']);
+    }
+
     // Stub the share endpoint so no real backend is needed.
     await page.route(/\/share-factory$/, async (route) => {
       await route.fulfill({

--- a/client/tests/share-cold-start.spec.ts
+++ b/client/tests/share-cold-start.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Regression coverage for #182: on a cold-started server the /share-factory POST is slow,
+// so the clipboard write must (a) stay tied to the click's user activation and (b) only
+// claim "Link copied!" once the write actually resolves — with a manual-copy fallback when
+// the browser rejects the write (Edge/Safari after activation lapses).
+
+const SHARE_ROUTE = /\/share-factory$/;
+const STUB_KEY = 'coldstart000000000';
+
+// Simulate a cold start: hold the POST open before returning a valid key. Uses
+// page.waitForTimeout for the delay (the route sandbox has no setTimeout of its own).
+async function routeColdStartShare(page: Page, delayMs: number) {
+  await page.route(SHARE_ROUTE, async (route) => {
+    await page.waitForTimeout(delayMs);
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: { key: STUB_KEY } }),
+    });
+  });
+}
+
+async function addProductAndReachShare(page: Page) {
+  await page.goto('/');
+  await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible({ timeout: 30_000 });
+  await page.getByRole('button', { name: 'Open Control Panel' }).click();
+  await page.getByRole('button', { name: '+ Add Product' }).click();
+  await page.getByPlaceholder('Select an item').click();
+  await page.getByRole('option', { name: 'Iron Plate', exact: true }).click();
+  // Share lives in the body FactorySwitcher — close the drawer so it isn't overlapped.
+  await page.getByRole('button', { name: 'Close Control Panel' }).click();
+  await expect(page.getByRole('button', { name: 'Share' })).toBeEnabled();
+}
+
+test.describe('Share on a cold-started server (#182)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Start with the drawer closed so "Open Control Panel" is the visible toggle. The
+    // hook stores JSON-encoded strings: '"false"' deserializes to the string 'false'.
+    await page.addInitScript(() => {
+      sessionStorage.setItem('drawer-open', '"false"');
+    });
+  });
+
+  test('does not claim "Link copied!" until the clipboard write resolves', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (e) => pageErrors.push(String(e)));
+
+    // Deterministic clipboard: record the write and resolve immediately, so the only
+    // thing gating "copied" is the (delayed) share link resolving.
+    await page.addInitScript(() => {
+      (window as any).__clipWrites = 0;
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          write: async () => { (window as any).__clipWrites += 1; },
+          writeText: async () => { (window as any).__clipWrites += 1; },
+        },
+      });
+    });
+
+    await routeColdStartShare(page, 3000);
+    await addProductAndReachShare(page);
+
+    await page.getByRole('button', { name: 'Share' }).click();
+
+    // While the cold POST is in flight the popover must read "Generating…", never "copied".
+    await expect(page.getByText('Generating…')).toBeVisible();
+    await expect(page.getByText('Link copied!')).toHaveCount(0);
+
+    // Once the link resolves and the write completes, success is shown.
+    await expect(page.getByText('Link copied!')).toBeVisible({ timeout: 10_000 });
+    expect(await page.evaluate(() => (window as any).__clipWrites)).toBeGreaterThan(0);
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('shows the manual-copy fallback when the clipboard write is rejected', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (e) => pageErrors.push(String(e)));
+
+    // Reproduce Edge/Safari dropping the write after activation lapses: both clipboard
+    // paths reject.
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: {
+          write: async () => { throw new Error('NotAllowedError'); },
+          writeText: async () => { throw new Error('NotAllowedError'); },
+        },
+      });
+    });
+
+    await routeColdStartShare(page, 1500);
+    await addProductAndReachShare(page);
+
+    await page.getByRole('button', { name: 'Share' }).click();
+
+    // The failure copy appears and the link is offered in a read-only field, never a
+    // false "Link copied!".
+    await expect(page.getByText("Couldn't copy — copy the link below")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Link copied!')).toHaveCount(0);
+
+    const manualField = page.getByRole('textbox', { name: 'Shareable link' });
+    await expect(manualField).toBeVisible();
+    await expect(manualField).toHaveValue(new RegExp(`${STUB_KEY}$`));
+
+    // The rejected writes must be caught, not left as unhandled rejections.
+    expect(pageErrors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #182.

## Problem
The Share button showed **"Link copied!"** but nothing landed on the clipboard — reported on Edge, and it worked after a refresh. Confirmed on the local Aspire stack + code analysis:

The clipboard write ran in a **detached `useEffect`** that fired only *after* the async `/share-factory` POST resolved — i.e. outside the click's user-activation window. On a **cold-started server** the POST is slow, so by the time the effect ran, Edge/Safari had dropped transient activation and **silently rejected** `navigator.clipboard.writeText` (un-awaited, no `.catch`). Meanwhile the popover text was gated purely on the link existing (never on copy success), and auto-closed on a fixed 2.5s timer.

## Fix
- **Copy inside the click gesture** using the async `ClipboardItem` + pending `Blob` pattern, so the write stays authorized across the awaited (possibly cold) POST.
- **Drive feedback off the real clipboard result**: "Link copied!" only once the write resolves; on rejection, drop to a read-only, auto-selected **manual-copy field** so the link is never stranded.
- `generateShareLink` now returns `Promise<string>` (via `useApi` returning its result) so the handler can await the link.
- Extract the shared copy/feedback into **`useShareFactory` + `ShareStatusView` + `ShareButton`**, de-duplicating the desktop (`FactorySwitcher`) and mobile (`FactoryPicker`) controls; drop the now-dead `shareLink.link` field.

## Tests
- New `client/tests/share-cold-start.spec.ts`: asserts a slow POST never shows a premature "Link copied!", and that a rejected write surfaces the manual-copy field with the link (no unhandled `pageerror`).
- Updated the two existing share tests (which asserted the *old* unconditional "Link copied!") to grant `clipboard-write` on Chromium so they exercise the genuine success path.
- **vitest: 356 passed** · **Playwright (chromium/firefox/webkit): 96 passed** · ESLint clean · no new `tsc` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)