### PR TITLE
chore: fix TS type errors, migrate xunit v2→v3, green the integration suite

### DIFF
--- a/YetAnotherFactoryPlanner.IntegrationTests/AppHostFixture.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/AppHostFixture.cs
@@ -15,7 +15,7 @@ public sealed class AppHostFixture : IAsyncLifetime
 
 	public DistributedApplication App => _app ?? throw new InvalidOperationException("App has not been initialised — ensure InitializeAsync completed successfully.");
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		var appHost = await DistributedApplicationTestingBuilder
 			.CreateAsync<Projects.YetAnotherFactoryPlanner_AppHost>(["--environment=Testing"]);
@@ -30,7 +30,7 @@ public sealed class AppHostFixture : IAsyncLifetime
 			.WaitForResourceAsync("api", KnownResourceStates.Running, cts.Token);
 	}
 
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		if (_app is not null)
 			await _app.DisposeAsync();

--- a/YetAnotherFactoryPlanner.IntegrationTests/BrowserFixture.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/BrowserFixture.cs
@@ -15,7 +15,7 @@ public sealed class BrowserFixture : IAsyncLifetime
 
 	public IBrowser Browser => _browser ?? throw new InvalidOperationException("Browser has not been initialised.");
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		_playwright = await Playwright.CreateAsync();
 		_browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions
@@ -25,7 +25,7 @@ public sealed class BrowserFixture : IAsyncLifetime
 		});
 	}
 
-	public async Task DisposeAsync()
+	public async ValueTask DisposeAsync()
 	{
 		if (_browser is not null)
 			await _browser.DisposeAsync();

--- a/YetAnotherFactoryPlanner.IntegrationTests/ControlPanelPlaywrightTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/ControlPanelPlaywrightTests.cs
@@ -26,13 +26,13 @@ public sealed class ControlPanelPlaywrightTests(AppHostFixture appHost, BrowserF
 
 	private Uri _clientBaseUri = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		await appHost.WaitForClientAsync();
 		_clientBaseUri = appHost.GetClientBaseUri();
 	}
 
-	public Task DisposeAsync() => Task.CompletedTask;
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
 	/// <summary>
 	/// Clicking "Share" shows a "Link copied!" popover that auto-dismisses after ~2.5 s.
@@ -40,8 +40,14 @@ public sealed class ControlPanelPlaywrightTests(AppHostFixture appHost, BrowserF
 	[Fact]
 	public async Task Share_LinkCopiedTooltipDismissesAutomatically()
 	{
-		// Arrange
-		await using var context = await browser.Browser.NewContextAsync();
+		// Arrange — headless Chromium rejects navigator.clipboard.write unless the context
+		// is granted clipboard permission. Without it the Share flow's write throws and the
+		// app drops to its manual-copy fallback (status 'failed'), so "Link copied!" never
+		// renders. Granting the permission exercises the real success path.
+		await using var context = await browser.Browser.NewContextAsync(new BrowserNewContextOptions
+		{
+			Permissions = ["clipboard-read", "clipboard-write"],
+		});
 		var page = await context.NewPageAsync();
 
 		await page.GotoAsync(_clientBaseUri.ToString());

--- a/YetAnotherFactoryPlanner.IntegrationTests/ErrorScreenPlaywrightTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/ErrorScreenPlaywrightTests.cs
@@ -22,13 +22,13 @@ public sealed class ErrorScreenPlaywrightTests(AppHostFixture appHost, BrowserFi
 
 	private Uri _clientBaseUri = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		await appHost.WaitForClientAsync();
 		_clientBaseUri = appHost.GetClientBaseUri();
 	}
 
-	public Task DisposeAsync() => Task.CompletedTask;
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
 	/// <summary>
 	/// Bug 3 — reproducer.

--- a/YetAnotherFactoryPlanner.IntegrationTests/GraphPlaywrightTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/GraphPlaywrightTests.cs
@@ -28,13 +28,13 @@ public sealed class GraphPlaywrightTests(AppHostFixture appHost, BrowserFixture 
 
 	private Uri _clientBaseUri = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		await appHost.WaitForClientAsync();
 		_clientBaseUri = appHost.GetClientBaseUri();
 	}
 
-	public Task DisposeAsync() => Task.CompletedTask;
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
 	/// <summary>
 	/// Bug 7 — reproducer.

--- a/YetAnotherFactoryPlanner.IntegrationTests/ProductionTabPlaywrightTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/ProductionTabPlaywrightTests.cs
@@ -20,13 +20,13 @@ public sealed class ProductionTabPlaywrightTests(AppHostFixture appHost, Browser
 
 	private Uri _clientBaseUri = null!;
 
-	public async Task InitializeAsync()
+	public async ValueTask InitializeAsync()
 	{
 		await appHost.WaitForClientAsync();
 		_clientBaseUri = appHost.GetClientBaseUri();
 	}
 
-	public Task DisposeAsync() => Task.CompletedTask;
+	public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 
 	/// <summary>
 	/// Bug 8 — reproducer.

--- a/YetAnotherFactoryPlanner.IntegrationTests/ShareFactoryEndpointTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/ShareFactoryEndpointTests.cs
@@ -37,8 +37,8 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 		var requestBody = BuildMinimalFactoryRequest("Desc_IronIngot_C", amount: 30);
 
 		// Act
-		var firstResponse = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions);
-		var secondResponse = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions);
+		var firstResponse = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions, TestContext.Current.CancellationToken);
+		var secondResponse = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions, TestContext.Current.CancellationToken);
 
 		// Assert — both calls must succeed
 		Assert.Equal(HttpStatusCode.Created, firstResponse.StatusCode);
@@ -69,8 +69,8 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 			recipePartsCost: 2, powerConsumption: 2);
 
 		// Act
-		var defaultResponse = await client.PostAsJsonAsync("/api/share-factory", defaultMultipliers, JsonOptions);
-		var scaledResponse = await client.PostAsJsonAsync("/api/share-factory", scaledMultipliers, JsonOptions);
+		var defaultResponse = await client.PostAsJsonAsync("/api/share-factory", defaultMultipliers, JsonOptions, TestContext.Current.CancellationToken);
+		var scaledResponse = await client.PostAsJsonAsync("/api/share-factory", scaledMultipliers, JsonOptions, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.Equal(HttpStatusCode.Created, defaultResponse.StatusCode);
@@ -95,15 +95,15 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 			recipePartsCost: 0.5m, powerConsumption: 2);
 
 		// Act — save, then fetch back
-		var postResponse = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions);
+		var postResponse = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions, TestContext.Current.CancellationToken);
 		Assert.Equal(HttpStatusCode.Created, postResponse.StatusCode);
 		var key = await ExtractKeyAsync(postResponse);
 
-		var getResponse = await client.GetAsync($"/api/shared-factories/{key}");
+		var getResponse = await client.GetAsync($"/api/shared-factories/{key}", TestContext.Current.CancellationToken);
 		Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
 
 		// Assert — the multipliers persisted exactly as sent
-		var json = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions);
+		var json = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
 		var gameModeOptions = json.GetProperty("data").GetProperty("factory_config").GetProperty("gameModeOptions");
 		Assert.Equal(0.5m, gameModeOptions.GetProperty("recipePartsCost").GetDecimal());
 		Assert.Equal(2m, gameModeOptions.GetProperty("powerConsumption").GetDecimal());
@@ -122,7 +122,7 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 		var requestBody = BuildMinimalFactoryRequest("Desc_IronPlate_C", amount: 15);
 
 		// Act
-		var response = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions);
+		var response = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions, TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.Equal(HttpStatusCode.Created, response.StatusCode);
@@ -146,7 +146,7 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 		const string nonExistentKey = "aaaaaaaaaaaaaaaa";
 
 		// Act
-		var response = await client.GetAsync($"/api/shared-factories/{nonExistentKey}");
+		var response = await client.GetAsync($"/api/shared-factories/{nonExistentKey}", TestContext.Current.CancellationToken);
 
 		// Assert
 		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);

--- a/YetAnotherFactoryPlanner.IntegrationTests/YetAnotherFactoryPlanner.IntegrationTests.csproj
+++ b/YetAnotherFactoryPlanner.IntegrationTests/YetAnotherFactoryPlanner.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -13,7 +14,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.59.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/api.Tests/api.Tests.csproj
+++ b/api.Tests/api.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net10.0</TargetFramework>
+		<OutputType>Exe</OutputType>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>
@@ -8,7 +9,7 @@
 	<ItemGroup>
 		<PackageReference Include="FluentValidation" Version="12.1.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>

--- a/client/src/components/Card/index.a11y.test.tsx
+++ b/client/src/components/Card/index.a11y.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { MantineProvider } from '@mantine/core';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider, DefaultTheme } from 'styled-components';
 import Card from './index';
 import { theme } from '../../theme';
 
@@ -13,7 +13,7 @@ const scTheme = {
     background: ['#26282b', '#373b40', '#3f434a', '#50565e', '#6c7582'],
     primary: ['#fcebde', '#f9d8be', '#f7c59f', '#f4b17f', '#f19e60', '#ef8b40', '#ec7821'],
   },
-};
+} as unknown as DefaultTheme;
 
 function Wrapper({ children }: { children: React.ReactNode }) {
   return (

--- a/client/src/components/Section/index.a11y.test.tsx
+++ b/client/src/components/Section/index.a11y.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { MantineProvider } from '@mantine/core';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider, DefaultTheme } from 'styled-components';
 import { Section, SectionDescription } from './index';
 import { theme } from '../../theme';
 
@@ -13,7 +13,7 @@ const scTheme = {
     background: ['#26282b', '#373b40', '#3f434a', '#50565e', '#6c7582'],
     primary: ['#fcebde', '#f9d8be', '#f7c59f', '#f4b17f', '#f19e60', '#ef8b40', '#ec7821'],
   },
-};
+} as unknown as DefaultTheme;
 
 function Wrapper({ children }: { children: React.ReactNode }) {
   return (

--- a/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
+++ b/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import { MantineProvider } from '@mantine/core';
-import { ThemeProvider } from 'styled-components';
+import { ThemeProvider, DefaultTheme } from 'styled-components';
 import SiteHeader from './index';
 import { theme } from '../../../theme';
 import { GameDataContext, GameDataContextType } from '../../../contexts/gameData';
@@ -15,7 +15,7 @@ const scTheme = {
   other: {
     pageLeftMargin: '55px',
   },
-};
+} as unknown as DefaultTheme;
 
 // Minimal GameDataContext value: SiteHeader only reads gameVersion, setGameVersion,
 // and loading. The rest of the contract is stubbed out.

--- a/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
@@ -67,7 +67,9 @@ const FactorySwitcher = ({ layout = 'inline' }: { layout?: FactorySwitcherLayout
             per factory (keepMounted, so inactive tabs resolve too) to keep those
             references valid (WCAG aria-valid-attr-value). */}
         {lib.factories.map((f) => (
-          <Tabs.Panel key={f.id} value={f.id} keepMounted style={{ display: 'none' }} />
+          <Tabs.Panel key={f.id} value={f.id} keepMounted style={{ display: 'none' }}>
+            <></>
+          </Tabs.Panel>
         ))}
       </Tabs>
     </div>


### PR DESCRIPTION
## Summary

Cleanup pass off a full clean-install/build/test audit. Everything now builds and tests green with zero warnings.

### Client (`tsc --noEmit`: 4 errors → 0; vitest 356/356)
- **FactorySwitcher** — give the intentionally-blank keep-mounted `Tabs.Panel` an empty-fragment child to satisfy the required `TabsPanelProps.children` (was invisible to the Vite build, which skips typechecking).
- **Card / Section / SiteHeader a11y tests** — cast the partial theme via `as unknown as DefaultTheme`, matching the pattern the `PlannerResults` tests already use.

### .NET tests (build now 0 warnings / 0 errors; api.Tests 37/37; IntegrationTests 12/12)
- **xunit v2 → v3** — migrate `api.Tests` + `IntegrationTests` off xunit 2.9.3 (flagged deprecated "Legacy") to `xunit.v3` 3.2.2: `IAsyncLifetime` `Task`→`ValueTask`, `OutputType=Exe`. `--deprecated` is now clean.
- **xUnit1051 warnings (9)** — thread `TestContext.Current.CancellationToken` into the HTTP calls in `ShareFactoryEndpointTests`.
- **Clipboard Playwright test** — grant `clipboard-read`/`clipboard-write` on the browser context so headless Chromium exercises the Share **success** path instead of the manual-copy fallback; the "Link copied!" tooltip now renders.

### Context worth flagging
The integration suite had been failing entirely because the **.NET 8 runtime was missing** on the dev box — the net8 isolated Functions worker couldn't launch (`exit 150`), so every request 503'd. Build was clean because the 10.x SDK cross-compiles net8; nothing supplied the *runtime*. Installing `aspnetcore-runtime-8.0` resolved it, and the suite is now 12/12 on a genuine net8 runtime (no roll-forward).

## Test results
- Client: `tsc --noEmit` 0 errors, vitest 356/356, lint clean, build clean
- .NET: build 0/0, `api.Tests` 37/37, `IntegrationTests` 12/12

🤖 Generated with [Claude Code](https://claude.com/claude-code)