### PR TITLE
fix(client): surface invalid/expired share links cohesively

### DIFF
--- a/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
+++ b/client/src/containers/Main/SiteHeader/index.a11y.test.tsx
@@ -24,6 +24,8 @@ const gameDataValue = {
   initializer: null,
   loading: false,
   loadingError: false,
+  shareError: false,
+  clearShareError: () => {},
   completedThisFrame: false,
   reinitToken: 0,
   gameVersion: DEFAULT_GAME_VERSION,

--- a/client/src/containers/ProductionPlanner/MobileShell/MobileTopBar.test.tsx
+++ b/client/src/containers/ProductionPlanner/MobileShell/MobileTopBar.test.tsx
@@ -20,6 +20,8 @@ const gameDataValue = {
   initializer: null,
   loading: false,
   loadingError: false,
+  shareError: false,
+  clearShareError: vi.fn(),
   completedThisFrame: false,
   reinitToken: 0,
   gameVersion: DEFAULT_GAME_VERSION,

--- a/client/src/containers/ProductionPlanner/ShareErrorModal.tsx
+++ b/client/src/containers/ProductionPlanner/ShareErrorModal.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Button, Text, Group } from '@mantine/core';
+import { useGameDataContext } from '../../contexts/gameData';
+
+// Shown when a ?factory= share link can't be resolved (invalid or past its
+// 7-day TTL). Deliberately escapable — "Continue" drops the user straight into
+// the normal factory that loaded behind it, instead of the old full-screen
+// dead-end. gameData already fell through to a normal load; this is purely the
+// explanation.
+export default function ShareErrorModal() {
+  const { shareError, clearShareError } = useGameDataContext();
+  // Local latch so dismissing closes the modal without racing context state; a
+  // fresh failure re-opens it (shareError goes false→true between loads).
+  const [dismissed, setDismissed] = useState(false);
+  useEffect(() => { if (shareError) setDismissed(false); }, [shareError]);
+
+  const close = () => { setDismissed(true); clearShareError(); };
+
+  return (
+    <Modal
+      opened={shareError && !dismissed}
+      onClose={close}
+      centered
+      withCloseButton={false}
+      title="Shared factory not found"
+    >
+      <Text size="sm" mb="lg">
+        That share link is invalid or has expired, so there&apos;s nothing to load.
+        Share links are only valid for <strong>7 days</strong> — after that they
+        expire automatically. We&apos;ve dropped you into a fresh factory instead.
+      </Text>
+      <Group justify="flex-end" gap={8}>
+        <Button onClick={close}>Continue</Button>
+      </Group>
+    </Modal>
+  );
+}

--- a/client/src/containers/ProductionPlanner/index.tsx
+++ b/client/src/containers/ProductionPlanner/index.tsx
@@ -16,6 +16,7 @@ import MobileShell from './MobileShell';
 import FactorySwitcher from './PlannerOptions/FactorySwitcher';
 import Portal from '../../components/Portal';
 import { useSessionStorage } from '../../hooks/useSessionStorage';
+import ShareErrorModal from './ShareErrorModal';
 
 // Staged reassurance while the Azure Container App cold-starts. Each entry fires
 // once the loader has been up for `after` seconds; the last one just sticks.
@@ -103,6 +104,9 @@ const ProductionPlanner = () => {
   return (
     <>
       {renderLoading()}
+      {/* Surfaces an invalid/expired share link over the loaded planner, instead
+          of the full-screen dead-end that a failed share fetch used to cause. */}
+      {gdCtx.gameData && <ShareErrorModal />}
       {gdCtx.gameData && (
         <ProductionProvider
           gameData={gdCtx.gameData}

--- a/client/src/contexts/gameData/index.tsx
+++ b/client/src/contexts/gameData/index.tsx
@@ -25,6 +25,11 @@ export type GameDataContextType = {
   initializer: FactoryInitializer | null,
   loading: boolean,
   loadingError: boolean,
+  // A ?factory= share link that couldn't be resolved (invalid or past its 7-day
+  // TTL). Non-fatal: the app still loads a normal factory; the UI surfaces this
+  // so the user knows why their link didn't open. Cleared on the next load.
+  shareError: boolean,
+  clearShareError: () => void,
   completedThisFrame: boolean,
   // Bumped to reload the active factory into the reducer WITHOUT refetching game
   // data (a same-version factory switch). Different-version switches refetch instead.
@@ -58,6 +63,7 @@ export const GameDataProvider = ({ children }: PropTypes) => {
   const [initializer, setInitializer] = useState<FactoryInitializer | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadingError, setLoadingError] = useState(false);
+  const [shareError, setShareError] = useState(false);
   const [reinitToken, setReinitToken] = useState(0);
   const prevLoading = usePrevious(loading);
   const [needToFetchGameData, setNeedToFetchGameData] = useState(true);
@@ -134,6 +140,7 @@ export const GameDataProvider = ({ children }: PropTypes) => {
       setNeedToFetchGameData(false);
       setGameData(null);
       setInitializer(null);
+      setShareError(false);
 
       const params = new URLSearchParams(window.location.search);
       const shareKey = params.get(SHARE_QUERY_PARAM);
@@ -158,8 +165,18 @@ export const GameDataProvider = ({ children }: PropTypes) => {
   useEffect(() => {
     if (sharedFactory.completedThisFrame) {
       if (sharedFactory.error) {
-        setLoadingError(true);
-        setLoading(false);
+        // Invalid or expired ?factory= link (share links live 7 days — the
+        // factories container's Cosmos TTL). Don't dead-end: drop the dead key
+        // from the URL so finalizeLoad takes the normal library path (not an
+        // import of a non-existent share) and a refresh won't retry, flag the
+        // failure for the UI, then load a normal factory.
+        const params = new URLSearchParams(window.location.search);
+        params.delete(SHARE_QUERY_PARAM);
+        const rest = params.toString();
+        window.history.replaceState(null, '', rest ? `${window.location.pathname}?${rest}` : window.location.pathname);
+        setShareError(true);
+        const version = lib.activeFactory?.gameVersion || gameVersion || DEFAULT_GAME_VERSION;
+        void finalizeLoad({ version, factoryConfig: null });
         return;
       }
       const factoryConfig = sharedFactory.data?.factory_config || null;
@@ -194,18 +211,22 @@ export const GameDataProvider = ({ children }: PropTypes) => {
     }
   }, [gameVersion, lib]);
 
+  const clearShareError = useCallback(() => setShareError(false), []);
+
   const ctxValue = useMemo(() => {
     return {
       gameData,
       initializer,
       loading,
       loadingError,
+      shareError,
+      clearShareError,
       completedThisFrame,
       reinitToken,
       gameVersion,
       setGameVersion: handleSetGameVersion,
     }
-  }, [completedThisFrame, gameData, gameVersion, handleSetGameVersion, initializer, loading, loadingError, reinitToken]);
+  }, [clearShareError, completedThisFrame, gameData, gameVersion, handleSetGameVersion, initializer, loading, loadingError, shareError, reinitToken]);
 
   return (
     <GameDataContext.Provider value={ctxValue}>

--- a/client/tests/share-error.spec.ts
+++ b/client/tests/share-error.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+// An invalid or expired (>7-day TTL) ?factory= link must NOT dead-end the app
+// with the old full-screen "error connecting to the server x_x" takeover.
+// Instead the normal planner loads and an escapable modal explains why the link
+// didn't open. See ProductionPlanner/ShareErrorModal + contexts/gameData.
+
+const DEAD_KEY = 'expired00000000000';
+// Match the real GET endpoint by its exact key — a broad /shared-factories/
+// pattern also swallows Vite's own useGetSharedFactory.ts module request.
+const SHARED_GET_ROUTE = new RegExp(`/shared-factories/${DEAD_KEY}$`);
+
+test.describe('Invalid / expired share link', () => {
+  test.beforeEach(async ({ page }) => {
+    // The share GET 404s, exactly as it would for a key past its Cosmos TTL.
+    await page.route(SHARED_GET_ROUTE, async (route) => {
+      await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+    });
+  });
+
+  test('loads the normal planner and surfaces a cohesive modal, not a dead-end', async ({ page }) => {
+    await page.goto(`/?factory=${DEAD_KEY}`);
+
+    // The real app loads — the planner chrome is present, not a blocking overlay.
+    await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible({ timeout: 30_000 });
+
+    // The old dead-end must be gone.
+    await expect(page.getByText(/error occurred connecting to the server/i)).toHaveCount(0);
+
+    // The cohesive explanation is shown, including the 7-day validity.
+    const dialog = page.getByRole('dialog', { name: /Shared factory not found/i });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText(/valid for/i)).toContainText('7 days');
+
+    // It's escapable: Continue drops straight into the loaded factory.
+    await dialog.getByRole('button', { name: 'Continue' }).click();
+    await expect(dialog).toHaveCount(0);
+    await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible();
+  });
+
+  test('strips the dead ?factory= key so a refresh does not retry it', async ({ page }) => {
+    await page.goto(`/?factory=${DEAD_KEY}`);
+    await expect(page.getByRole('dialog', { name: /Shared factory not found/i })).toBeVisible({ timeout: 30_000 });
+    // The URL no longer carries the dead key.
+    await expect.poll(() => new URL(page.url()).searchParams.get('factory')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Opening a wrong or expired `?factory=` share link threw up a full-screen dead-end — *"An error occurred connecting to the server x_x"* with a lone "Start a new factory" button. A failed share fetch was treated as a fatal `loadingError`, so game data never loaded and there was nothing to fall back to.

## Change

- **`contexts/gameData`** — a failed share fetch no longer sets `loadingError`. It strips the dead key from the URL (so a refresh won't retry), falls through to a normal default/library factory load, and exposes a `shareError` flag (+ `clearShareError`). Reset at the start of each load.
- **`ShareErrorModal`** (new) — a centered, **escapable** Mantine modal over the loaded planner. Single **Continue** button; notes that share links are valid for **7 days** (validated against the factories container's Cosmos `defaultTtl: 604800` in both `AppHost.cs` and the bicep infra).
- **`ProductionPlanner`** — renders the modal when `shareError` is set.

The old full-screen dead-end now only fires for a genuine game-data *bundle* load failure (a real can't-start case), not for share links.

## Tests

- New `tests/share-error.spec.ts` — cohesive modal shown + dead-end gone; dead `?factory=` key stripped from the URL.
- Context mocks updated for the new fields.

Verified locally: unit **356 passed**, Playwright e2e **102 passed**, Lighthouse a11y **passed** (≥0.98), `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)