### PR TITLE
feat(client): import/export factories to JSON files

### DIFF
--- a/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/FactorySwitcher.tsx
@@ -5,12 +5,13 @@
 // = the tabs; per-factory actions sit in a "⋯" menu + Share beside.
 import React, { useState } from 'react';
 import { Tabs, Group, Menu, ActionIcon, Tooltip } from '@mantine/core';
-import { Plus, MoreHorizontal, Edit2, Copy, Trash2, RotateCcw } from 'react-feather';
+import { Plus, MoreHorizontal, Edit2, Copy, Trash2, RotateCcw, Folder } from 'react-feather';
 import { useProductionContext } from '../../../contexts/production';
 import { useLibraryContext } from '../../../contexts/library';
 import { labelOf, relativeTime } from '../../../utilities/factory-label';
 import ShareButton from '../ShareButton';
 import { RenameDialog, DeleteDialog } from './factory-dialogs';
+import { LibraryManagerModal } from './LibraryManagerModal';
 
 // `inline` (default) is the desktop header band: tabs and actions share one nowrap
 // row. `stacked` is for the narrow mobile factory sheet, where that single row makes
@@ -23,6 +24,7 @@ const FactorySwitcher = ({ layout = 'inline' }: { layout?: FactorySwitcherLayout
   const lib = useLibraryContext();
   const [renameOpen, setRenameOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [manageOpen, setManageOpen] = useState(false);
 
   const activeFactory = lib.activeFactory;
   if (!activeFactory) return null;
@@ -97,6 +99,8 @@ const FactorySwitcher = ({ layout = 'inline' }: { layout?: FactorySwitcherLayout
           <Menu.Item leftSection={<Trash2 size={14} />} color="red" onClick={() => setDeleteOpen(true)}>Delete</Menu.Item>
           <Menu.Divider />
           <Menu.Item leftSection={<RotateCcw size={14} />} onClick={() => ctx.dispatch({ type: 'RESET_FACTORY', gameData: ctx.gameData })}>Reset to empty</Menu.Item>
+          <Menu.Divider />
+          <Menu.Item leftSection={<Folder size={14} />} onClick={() => setManageOpen(true)}>Manage library…</Menu.Item>
         </Menu.Dropdown>
       </Menu>
 
@@ -135,6 +139,7 @@ const FactorySwitcher = ({ layout = 'inline' }: { layout?: FactorySwitcherLayout
 
       <RenameDialog opened={renameOpen} initial={activeFactory.nickname ?? ''} onClose={() => setRenameOpen(false)} onSubmit={(v) => lib.rename(lib.activeId, v)} />
       <DeleteDialog opened={deleteOpen} label={activeLabel} onClose={() => setDeleteOpen(false)} onConfirm={() => lib.remove(lib.activeId)} />
+      <LibraryManagerModal opened={manageOpen} onClose={() => setManageOpen(false)} gameData={ctx.gameData} />
     </div>
   );
 };

--- a/client/src/containers/ProductionPlanner/PlannerOptions/LibraryManagerModal.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/LibraryManagerModal.tsx
@@ -1,0 +1,153 @@
+// The factory-library manager: bulk-export selected factories to a .json file and
+// import factories from a file (drag-drop or browse). Opened from the FactorySwitcher
+// "⋯" menu. Import adds factories as new copies (fresh ids) via lib.importFactory.
+import React, { useEffect, useRef, useState } from 'react';
+import { Modal, Stack, Group, Button, Checkbox, Text, Badge, Alert } from '@mantine/core';
+import { Download, Upload } from 'react-feather';
+import { useLibraryContext } from '../../../contexts/library';
+import { GameData } from '../../../contexts/gameData/types';
+import { labelOf, relativeTime } from '../../../utilities/factory-label';
+import { downloadFactories, parseBundle, ImportableFactory } from '../../../utilities/factory-io';
+
+type ImportResult = { added: number; warnings: string[]; errors: string[] };
+
+const emptyResult = (): ImportResult => ({ added: 0, warnings: [], errors: [] });
+
+export const LibraryManagerModal = ({
+  opened,
+  onClose,
+  gameData,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  gameData: GameData;
+}) => {
+  const lib = useLibraryContext();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [dragging, setDragging] = useState(false);
+  const [result, setResult] = useState<ImportResult | null>(null);
+
+  // Reset transient state each time the modal opens.
+  useEffect(() => {
+    if (opened) { setSelected(new Set()); setResult(null); }
+  }, [opened]);
+
+  const chosen = lib.factories.filter((f) => selected.has(f.id));
+  const toggle = (id: string) =>
+    setSelected((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  const importFiles = async (files: FileList | File[] | null | undefined) => {
+    if (!files || Array.from(files).length === 0) return;
+    const res = emptyResult();
+    // Collect every valid factory across all dropped files, then commit them in a
+    // single importFactories call — per-file/per-factory calls would clobber each
+    // other (each closes over stale library state).
+    const toImport: ImportableFactory[] = [];
+    for (const file of Array.from(files)) {
+      let raw: string;
+      try {
+        raw = await file.text();
+      } catch {
+        res.errors.push(`${file.name}: could not read file.`);
+        continue;
+      }
+      const parsed = parseBundle(raw);
+      if (!parsed.ok) {
+        res.errors.push(`${file.name}: ${parsed.error}`);
+        continue;
+      }
+      res.warnings.push(...parsed.warnings);
+      toImport.push(...parsed.factories);
+    }
+    lib.importFactories(toImport);
+    res.added = toImport.length;
+    setResult(res);
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Factory library" size="lg" centered>
+      <Stack gap="sm">
+        <Group justify="space-between">
+          <Text size="sm" c="dimmed">{lib.factories.length} {lib.factories.length === 1 ? 'factory' : 'factories'}</Text>
+          <Button
+            size="xs"
+            variant="default"
+            styles={{ root: { color: 'var(--mantine-color-text)' } }}
+            onClick={() => setSelected(new Set(lib.factories.map((f) => f.id)))}
+          >
+            Select all
+          </Button>
+        </Group>
+
+        <Stack gap={4} style={{ maxHeight: 260, overflow: 'auto' }}>
+          {lib.factories.map((f) => (
+            <Group
+              key={f.id}
+              justify="space-between"
+              wrap="nowrap"
+              style={{ padding: '4px 6px', borderRadius: 4, background: f.id === lib.activeId ? 'var(--mantine-color-default-hover)' : undefined }}
+            >
+              <Checkbox
+                checked={selected.has(f.id)}
+                onChange={() => toggle(f.id)}
+                label={<span>{labelOf(f, gameData)} {f.id === lib.activeId && <Badge size="xs" variant="light">active</Badge>}</span>}
+              />
+              <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>v{f.gameVersion} · {relativeTime(f.updatedAt)}</Text>
+            </Group>
+          ))}
+        </Stack>
+
+        <Button
+          leftSection={<Download size={16} />}
+          disabled={!chosen.length}
+          onClick={() => downloadFactories(chosen)}
+        >
+          Export {chosen.length ? `${chosen.length} selected` : 'selected'}
+        </Button>
+
+        <input
+          ref={inputRef}
+          type="file"
+          accept="application/json,.json"
+          multiple
+          style={{ display: 'none' }}
+          onChange={(e) => { void importFiles(e.target.files); e.target.value = ''; }}
+        />
+        <div
+          onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={(e) => { e.preventDefault(); setDragging(false); void importFiles(e.dataTransfer.files); }}
+          onClick={() => inputRef.current?.click()}
+          role="button"
+          tabIndex={0}
+          aria-label="Import factories from a file"
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') inputRef.current?.click(); }}
+          style={{
+            border: `2px dashed ${dragging ? 'var(--mantine-color-blue-5)' : 'var(--yafp-graph-border)'}`,
+            background: dragging ? 'var(--mantine-color-blue-light)' : 'transparent',
+            borderRadius: 8, padding: 20, textAlign: 'center', cursor: 'pointer',
+          }}
+        >
+          <Upload size={18} style={{ opacity: 0.7 }} />
+          <Text size="sm" mt={4}>Drop a .json file here, or click to browse</Text>
+          <Text size="xs" c="dimmed">Imported factories are added as new copies</Text>
+        </div>
+
+        {result && (
+          <Alert
+            color={result.errors.length ? 'red' : 'green'}
+            withCloseButton
+            onClose={() => setResult(null)}
+            title={result.added ? `Imported ${result.added} ${result.added === 1 ? 'factory' : 'factories'}` : 'Nothing imported'}
+          >
+            <Stack gap={2}>
+              {result.errors.map((e, i) => <Text key={`e${i}`} size="sm">⛔ {e}</Text>)}
+              {result.warnings.map((w, i) => <Text key={`w${i}`} size="sm" c="yellow.7">⚠ {w}</Text>)}
+            </Stack>
+          </Alert>
+        )}
+      </Stack>
+    </Modal>
+  );
+};

--- a/client/src/contexts/library/index.test.tsx
+++ b/client/src/contexts/library/index.test.tsx
@@ -192,3 +192,35 @@ describe('importFactory', () => {
     expect(loadLibrary()[imported.id].sourceKey).toBe('shareKey1');
   });
 });
+
+describe('importFactories', () => {
+  it('adds every factory in one commit (a multi-factory import is not clobbered)', () => {
+    const { result } = setup();
+    const a = { key: 'a' } as unknown as FactoryOptions;
+    const b = { key: 'b' } as unknown as FactoryOptions;
+
+    tick();
+    act(() => {
+      result.current.importFactories([
+        { config: a, gameVersion: '1.2', nickname: 'Alpha' },
+        { config: b, gameVersion: '1.1', nickname: 'Beta' },
+      ]);
+    });
+
+    // 1 auto-created + 2 imported — the earlier per-factory loop dropped all but the last.
+    expect(result.current.factories).toHaveLength(3);
+    const nicks = result.current.factories.map((f) => f.nickname);
+    expect(nicks).toContain('Alpha');
+    expect(nicks).toContain('Beta');
+    // Persisted, and the last import is active.
+    expect(Object.keys(loadLibrary())).toHaveLength(3);
+    expect(result.current.activeFactory!.nickname).toBe('Beta');
+  });
+
+  it('is a no-op for an empty list', () => {
+    const { result } = setup();
+    tick();
+    act(() => { result.current.importFactories([]); });
+    expect(result.current.factories).toHaveLength(1);
+  });
+});

--- a/client/src/contexts/library/index.tsx
+++ b/client/src/contexts/library/index.tsx
@@ -13,6 +13,15 @@ import {
 } from './storage';
 
 
+// One factory to import: a config + version, optionally a nickname and the share
+// key it came from. Id and timestamps are minted fresh on import (import = copy).
+export type FactoryImportInput = {
+  config?: FactoryOptions;
+  gameVersion: string;
+  nickname?: string;
+  sourceKey?: string;
+};
+
 // TYPE
 export type LibraryContextType = {
   factories: LibraryFactory[]; // stable display order (createdAt asc)
@@ -26,6 +35,7 @@ export type LibraryContextType = {
   saveActiveConfig: (config: FactoryOptions) => void;
   setActiveVersion: (gameVersion: string) => void;
   importFactory: (input: { config?: FactoryOptions; gameVersion: string; sourceKey?: string }) => LibraryFactory;
+  importFactories: (inputs: FactoryImportInput[]) => LibraryFactory[];
 };
 
 
@@ -117,6 +127,24 @@ export const LibraryProvider = ({ children }: PropTypes) => {
     [addFactory],
   );
 
+  // Batch-import factories in ONE commit. addFactory/importFactory each close over
+  // the render's `library`, so calling them in a loop makes every call overwrite the
+  // previous (last-write-wins). This adds them all via a single functional update, so
+  // a multi-factory file lands intact. Nicknames from the file are preserved; ids are
+  // re-minted (import = copy). The last imported factory becomes active.
+  const importFactories = useCallback((inputs: FactoryImportInput[]): LibraryFactory[] => {
+    if (inputs.length === 0) return [];
+    const created = inputs.map((i) => makeFactory(i.gameVersion, { config: i.config, nickname: i.nickname, sourceKey: i.sourceKey }));
+    setLibrary((prev) => {
+      const next = { ...prev };
+      for (const f of created) next[f.id] = f;
+      writeLibrary(next);
+      return next;
+    });
+    selectId(created[created.length - 1].id);
+    return created;
+  }, [selectId]);
+
   const duplicate = useCallback((id: string) => {
     const src = library[id];
     if (!src) return;
@@ -186,7 +214,8 @@ export const LibraryProvider = ({ children }: PropTypes) => {
     saveActiveConfig,
     setActiveVersion,
     importFactory,
-  }), [factories, activeId, activeFactory, select, create, duplicate, rename, remove, saveActiveConfig, setActiveVersion, importFactory]);
+    importFactories,
+  }), [factories, activeId, activeFactory, select, create, duplicate, rename, remove, saveActiveConfig, setActiveVersion, importFactory, importFactories]);
 
   return (
     <LibraryContext.Provider value={ctxValue}>

--- a/client/src/utilities/factory-io/index.test.ts
+++ b/client/src/utilities/factory-io/index.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { buildBundle, parseBundle, serializeBundle, EXPORT_ENVELOPE_VERSION, EXPORT_APP_NAME } from './index';
+import { LibraryFactory } from '../../contexts/library/types';
+import { FactoryOptions } from '../../contexts/production/types';
+
+function sampleConfig(itemKey = 'Desc_IronPlate_C'): FactoryOptions {
+  return {
+    key: 'k',
+    productionItems: [{ key: 'p1', itemKey, mode: 'per-minute', value: '20' }],
+    inputItems: [],
+    inputResources: [],
+    allowHandGatheredItems: false,
+    weightingOptions: { resources: '1', power: '1', complexity: '1', buildings: '1' },
+    gameModeOptions: { recipePartsCost: '0', powerConsumption: '0' },
+    allowedRecipes: { Recipe_IronPlate_C: true },
+    allowedBuildings: {},
+    nodesPositions: [],
+    maximizeBalanceMode: 'proportional',
+    transportOptions: { beltCapacity: null, pipeCapacity: null },
+  };
+}
+
+function factory(id: string, gameVersion = '1.2'): LibraryFactory {
+  return { id, nickname: `Nick ${id}`, gameVersion, config: sampleConfig(), createdAt: 1, updatedAt: 2 };
+}
+
+describe('buildBundle', () => {
+  it('wraps factories in a versioned envelope and drops library-local fields', () => {
+    const bundle = buildBundle([factory('a')]);
+    expect(bundle.app).toBe(EXPORT_APP_NAME);
+    expect(bundle.envelopeVersion).toBe(EXPORT_ENVELOPE_VERSION);
+    expect(bundle.factories).toHaveLength(1);
+    // createdAt/updatedAt are library-local and must not travel in the file.
+    expect(bundle.factories[0]).not.toHaveProperty('createdAt');
+    expect(bundle.factories[0]).not.toHaveProperty('updatedAt');
+    expect(bundle.factories[0].config).toEqual(sampleConfig());
+  });
+});
+
+describe('parseBundle', () => {
+  it('round-trips a serialized bundle back to importable factories', () => {
+    const raw = serializeBundle([factory('a'), factory('b')]);
+    const res = parseBundle(raw);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.factories).toHaveLength(2);
+      expect(res.warnings).toHaveLength(0);
+      expect(res.factories[0]).toEqual({ config: sampleConfig(), gameVersion: '1.2', nickname: 'Nick a', sourceKey: undefined });
+    }
+  });
+
+  it('rejects malformed JSON', () => {
+    const res = parseBundle('{ not json ');
+    expect(res).toMatchObject({ ok: false });
+    if (!res.ok) expect(res.error).toMatch(/not valid json/i);
+  });
+
+  it('rejects a file that is not an export envelope', () => {
+    const res = parseBundle(JSON.stringify({ hello: 'world' }));
+    expect(res).toMatchObject({ ok: false });
+    if (!res.ok) expect(res.error).toMatch(/not a factory export/i);
+  });
+
+  it('refuses a newer envelope version', () => {
+    const res = parseBundle(JSON.stringify({ app: EXPORT_APP_NAME, envelopeVersion: 99, exportedAt: '', factories: [] }));
+    expect(res).toMatchObject({ ok: false });
+    if (!res.ok) expect(res.error).toMatch(/newer version/i);
+  });
+
+  it('warns on an unknown game version but still imports the factory', () => {
+    const raw = JSON.stringify({
+      app: EXPORT_APP_NAME, envelopeVersion: 1, exportedAt: '',
+      factories: [{ id: 'x', nickname: 'Future', gameVersion: '9.9', config: sampleConfig() }],
+    });
+    const res = parseBundle(raw);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.factories).toHaveLength(1);
+      expect(res.warnings[0]).toMatch(/unknown game version/i);
+    }
+  });
+
+  it('drops a factory with no game version but keeps valid siblings', () => {
+    const raw = JSON.stringify({
+      app: EXPORT_APP_NAME, envelopeVersion: 1, exportedAt: '',
+      factories: [{ id: 'bad', nickname: 'Bad' }, { id: 'ok', gameVersion: '1.2', config: sampleConfig() }],
+    });
+    const res = parseBundle(raw);
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.factories).toHaveLength(1);
+      expect(res.warnings[0]).toMatch(/no game version/i);
+    }
+  });
+
+  it('errors when the file has no importable factories', () => {
+    const raw = JSON.stringify({ app: EXPORT_APP_NAME, envelopeVersion: 1, exportedAt: '', factories: [{ id: 'bad' }] });
+    const res = parseBundle(raw);
+    expect(res).toMatchObject({ ok: false });
+    if (!res.ok) expect(res.error).toMatch(/no importable factories/i);
+  });
+});

--- a/client/src/utilities/factory-io/index.ts
+++ b/client/src/utilities/factory-io/index.ts
@@ -1,0 +1,123 @@
+import { LibraryFactory } from '../../contexts/library/types';
+import { FactoryOptions } from '../../contexts/production/types';
+
+/**
+ * The JSON-file contract for exporting/importing factories to disk.
+ *
+ * This is a SEPARATE contract from the share-link wire format in
+ * `shared-factory/codec` (which is number-coerced for the API/URL). A file
+ * export keeps the client-shape `config` verbatim so a round-trip through disk
+ * needs no game data to decode and is lossless. The envelope is versioned so a
+ * future importer can refuse a file it doesn't understand.
+ */
+export const EXPORT_ENVELOPE_VERSION = 1;
+export const EXPORT_APP_NAME = 'yet-another-factory-planner';
+
+// Versions this build ships game data for. Unknown versions still import (the
+// factory just may not solve) but are surfaced as a warning.
+const KNOWN_VERSIONS = new Set(['1.1', '1.2']);
+
+export type ExportedFactory = {
+  id: string;
+  nickname?: string;
+  gameVersion: string;
+  config?: FactoryOptions;
+  sourceKey?: string;
+};
+
+export type ExportBundle = {
+  app: string;
+  envelopeVersion: number;
+  exportedAt: string;
+  factories: ExportedFactory[];
+};
+
+// A parsed factory ready to hand to `importFactories`, minus the library-local
+// id/timestamps (those are re-minted on import). The nickname IS preserved so an
+// imported factory keeps the name the user gave it.
+export type ImportableFactory = Pick<ExportedFactory, 'config' | 'gameVersion' | 'nickname' | 'sourceKey'>;
+
+export type ParseResult =
+  | { ok: true; factories: ImportableFactory[]; warnings: string[] }
+  | { ok: false; error: string };
+
+// ---- Export ---------------------------------------------------------------
+
+export function buildBundle(factories: LibraryFactory[]): ExportBundle {
+  return {
+    app: EXPORT_APP_NAME,
+    envelopeVersion: EXPORT_ENVELOPE_VERSION,
+    exportedAt: new Date().toISOString(),
+    factories: factories.map((f) => ({
+      id: f.id,
+      nickname: f.nickname,
+      gameVersion: f.gameVersion,
+      config: f.config,
+      sourceKey: f.sourceKey,
+    })),
+  };
+}
+
+export function serializeBundle(factories: LibraryFactory[]): string {
+  return JSON.stringify(buildBundle(factories), null, 2);
+}
+
+function exportFilename(factories: LibraryFactory[], label?: string): string {
+  if (factories.length === 1) {
+    const base = label ?? factories[0].nickname ?? factories[0].id;
+    return `factory-${base.replace(/\W+/g, '-').toLowerCase()}.json`;
+  }
+  const stamp = new Date().toISOString().slice(0, 10);
+  return `factories-${factories.length}-${stamp}.json`;
+}
+
+// Trigger a browser download of the given factories as one .json bundle.
+export function downloadFactories(factories: LibraryFactory[], label?: string): void {
+  const blob = new Blob([serializeBundle(factories)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = exportFilename(factories, label);
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ---- Import ---------------------------------------------------------------
+
+// Validate untrusted file text into importable factories. One malformed factory
+// is dropped with a warning rather than sinking the whole file; only a
+// structurally invalid envelope is a hard error.
+export function parseBundle(raw: string): ParseResult {
+  let json: unknown;
+  try {
+    json = JSON.parse(raw);
+  } catch (e) {
+    return { ok: false, error: `Not valid JSON: ${(e as Error).message}` };
+  }
+
+  if (!json || typeof json !== 'object') return { ok: false, error: 'File is not a factory export.' };
+  const b = json as Partial<ExportBundle>;
+  if (b.envelopeVersion == null || !Array.isArray(b.factories)) {
+    return { ok: false, error: 'Not a factory export file (missing envelope or factories).' };
+  }
+  if (b.envelopeVersion > EXPORT_ENVELOPE_VERSION) {
+    return { ok: false, error: `This file was made by a newer version (v${b.envelopeVersion}). Update the app to import it.` };
+  }
+
+  const warnings: string[] = [];
+  const factories: ImportableFactory[] = [];
+  b.factories.forEach((f, i) => {
+    const label = f?.nickname ? `"${f.nickname}"` : `#${i + 1}`;
+    if (!f || typeof f !== 'object' || !f.gameVersion) {
+      warnings.push(`Factory ${label} has no game version and was skipped.`);
+      return;
+    }
+    if (!KNOWN_VERSIONS.has(f.gameVersion)) {
+      warnings.push(`Factory ${label} uses an unknown game version "${f.gameVersion}" and may not solve.`);
+    }
+    factories.push({ config: f.config, gameVersion: f.gameVersion, nickname: f.nickname, sourceKey: f.sourceKey });
+  });
+
+  if (factories.length === 0) return { ok: false, error: 'No importable factories were found in the file.' };
+  return { ok: true, factories, warnings };
+}


### PR DESCRIPTION
## What

Adds the ability to **export and import one or more factories to/from JSON files**, surfaced as a **Manage library…** item in the factory-switcher `⋯` menu.

- **Export** — multi-select factories in the manager modal → one `.json` bundle download.
- **Import** — drag-drop a `.json` file (or click to browse) → factories are added as **new copies** (fresh ids), nicknames preserved. Unknown game versions / malformed files are surfaced in an inline result alert.

Because it lives in the shared action cluster, it also appears on the mobile factory sheet.

## How it was designed

Two throwaway prototypes drove this:
1. A **logic prototype** settled the JSON envelope format + validation + collision policy (import = copy, new ids).
2. A **UI prototype** (4 variants) settled placement — **variant D** won: A's uncluttered toolbar + a full library manager reached via one menu item.

## Changes

- **`utilities/factory-io/`** — versioned export envelope + validating parser (`buildBundle` / `serializeBundle` / `parseBundle`) and a `downloadFactories` DOM trigger. Unit-tested: round-trip, malformed JSON, wrong schema, newer-envelope rejection, unknown-version warning, partial-failure drop.
- **`LibraryManagerModal.tsx`** — the export/import UI with an inline result alert.
- **`FactorySwitcher.tsx`** — `⋯ → Manage library…` opens the modal (6-line diff).
- **`contexts/library`** — new **batched `importFactories()`**.

## Bug caught during verification

Round-trip testing a 2-factory file exposed that only **1** factory survived import: the modal looped `importFactory()` per factory, and that path closes over the render's stale `library` (last-write-wins). Also nicknames were dropped. Fixed with a batched `importFactories()` (single functional state update) that preserves nicknames; **regression test added**.

## Testing

- `tsc --noEmit`: clean
- Full suite: **366 tests pass** (added factory-io + batching tests)
- Verified live via Playwright: menu → modal → real import of a 2-factory file (both land, nicknames preserved, unknown-version warning shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)