### PR TITLE
feat(client): allow producible resources as production goals

### DIFF
--- a/client/src/containers/ProductionPlanner/PlannerOptions/ProductionTab/buildProductionGoalOptions.test.ts
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/ProductionTab/buildProductionGoalOptions.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildProductionGoalOptions } from './index';
+import { GameData } from '../../../../contexts/gameData/types';
+import { POINTS_ITEM_KEY } from '../../../../utilities/production-solver/models';
+import gameData_1_2 from '../../../../data/1.2';
+
+describe('buildProductionGoalOptions', () => {
+  it('always offers AWESOME Sink Points first', () => {
+    const opts = buildProductionGoalOptions(gameData_1_2);
+    expect(opts[0]).toEqual({ value: POINTS_ITEM_KEY, label: 'AWESOME Sink Points (x1000)' });
+  });
+
+  it('includes base resources that a recipe can produce (Crude Oil, Water, Nitrogen Gas)', () => {
+    const values = new Set(buildProductionGoalOptions(gameData_1_2).map((o) => o.value));
+    // These are base resources but each has a producing recipe (unpackage recipes), so they
+    // are legitimate production goals. Regression guard for the dropped `!resources[key]` filter.
+    expect(values.has('Desc_LiquidOil_C')).toBe(true); // Crude Oil <- Unpackage Oil
+    expect(values.has('Desc_Water_C')).toBe(true);     // Water <- Unpackage Water
+    expect(values.has('Desc_NitrogenGas_C')).toBe(true); // Nitrogen Gas <- Unpackage Nitrogen Gas
+  });
+
+  it('excludes resources that no recipe can produce (SAM)', () => {
+    const values = new Set(buildProductionGoalOptions(gameData_1_2).map((o) => o.value));
+    expect(values.has('Desc_SAM_C')).toBe(false);
+  });
+
+  it('excludes any item with no producing recipe and keeps producible ones', () => {
+    const gameData = {
+      items: {
+        Producible: { name: 'Producible', producedFromRecipes: ['R1'] },
+        RawOnly: { name: 'RawOnly', producedFromRecipes: [] },
+      },
+    } as unknown as GameData;
+
+    const values = buildProductionGoalOptions(gameData).map((o) => o.value);
+    expect(values).toContain('Producible');
+    expect(values).not.toContain('RawOnly');
+  });
+
+  it('sorts item labels alphabetically after the points entry', () => {
+    const gameData = {
+      items: {
+        b: { name: 'Beta', producedFromRecipes: ['R'] },
+        a: { name: 'Alpha', producedFromRecipes: ['R'] },
+        c: { name: 'Gamma', producedFromRecipes: ['R'] },
+      },
+    } as unknown as GameData;
+
+    const labels = buildProductionGoalOptions(gameData).map((o) => o.label);
+    expect(labels).toEqual(['AWESOME Sink Points (x1000)', 'Alpha', 'Beta', 'Gamma']);
+  });
+});

--- a/client/src/containers/ProductionPlanner/PlannerOptions/ProductionTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/ProductionTab/index.tsx
@@ -11,6 +11,7 @@ import TrashButton from '../../../../components/TrashButton';
 import LabelWithTooltip from '../../../../components/LabelWithTooltip';
 import { MOBILE_MEDIA } from '../../../../theme';
 import { ProductionItemOptions, TransportOptions } from '../../../../contexts/production/types';
+import { GameData } from '../../../../contexts/gameData/types';
 
 
 const baseModeOptions = [
@@ -74,6 +75,27 @@ interface ItemRowProps {
   itemOptions: { value: string; label: string }[];
   gameData: any;
   dispatch: (action: any) => void;
+}
+
+// The selectable Production Goals. Any item a recipe can produce is a valid goal — including base
+// resources that have a producing recipe (e.g. Crude Oil via Unpackage Oil, Water/Nitrogen via
+// their unpackage recipes, ores via converter recipes). The producedFromRecipes check alone keeps
+// out un-producible resources like SAM; we intentionally do NOT exclude resources outright.
+export function buildProductionGoalOptions(gameData: GameData): { value: string; label: string }[] {
+  const opts = Object.keys(gameData.items)
+    .filter((key) => gameData.items[key].producedFromRecipes.length !== 0)
+    .map((key) => ({
+      value: key,
+      label: gameData.items[key].name,
+    }))
+    .sort((a, b) => (a.label > b.label ? 1 : -1));
+
+  opts.unshift({
+    value: POINTS_ITEM_KEY,
+    label: 'AWESOME Sink Points (x1000)',
+  });
+
+  return opts;
 }
 
 const ProductionItemRow = ({ data, itemOptions, gameData, dispatch }: ItemRowProps) => {
@@ -182,24 +204,7 @@ const ProductionTab = () => {
   const ctx = useProductionContext();
   const { gameVersion } = useGameDataContext();
 
-  const itemOptions = useMemo(() => {
-    const opts = Object.keys(ctx.gameData.items)
-      .filter((key) => ctx.gameData.items[key].producedFromRecipes.length !== 0 && !ctx.gameData.resources[key])
-      .map((key) => ({
-        value: key,
-        label: ctx.gameData.items[key].name,
-      }))
-      .sort((a, b) => {
-        return a.label > b.label ? 1 : -1;
-      });
-
-    opts.unshift({
-      value: POINTS_ITEM_KEY,
-      label: 'AWESOME Sink Points (x1000)'
-    });
-
-    return opts;
-  }, [ctx.gameData]);
+  const itemOptions = useMemo(() => buildProductionGoalOptions(ctx.gameData), [ctx.gameData]);
 
   const maximizeCount = ctx.state.productionItems.filter((i) => i.mode === 'maximize').length;
 


### PR DESCRIPTION
## What & why

You couldn't set **Crude Oil** as a production goal even though the **Unpackage Oil** recipe legitimately produces it (e.g. a factory that takes Packaged Crude Oil and unpackages it). The gate wasn't the solver — it was a single UI filter in the Production Goals dropdown that excluded **every** base resource:

```js
.filter((key) => items[key].producedFromRecipes.length !== 0 && !resources[key])
```

The solver, `assembleGraph`, and `buildReport` already handle a resource as a final product correctly. This drops the blanket `!resources[key]` clause so any item a recipe can produce is a valid goal.

## Scope

12 of 13 resources become selectable goals:
- **Unpackage recipes**: Crude Oil, Water, Nitrogen Gas
- **Converter recipes**: Iron Ore, Copper Ore, Limestone, Coal, Caterium, Raw Quartz, Sulfur, Bauxite, Uranium
- **SAM** stays excluded — it has no producing recipe, so `producedFromRecipes.length` still filters it out.

## Note on workflow

Resources are added as inputs by default, so to use e.g. Crude Oil as a goal you must zero out its resource input (and add Packaged Crude Oil as an input item). Setting an item as both a nonzero input and an output still throws the existing clear error — that's expected, not a regression.

## Testing

- Extracted the filter into a `buildProductionGoalOptions` helper and added unit coverage (real 1.2 data + synthetic fixtures).
- Unit: 371 passed · Lint + tsc: clean · Playwright e2e + a11y: 102 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)