### PR TITLE
feat(client): optimize somersloops & power shards in the solver

### DIFF
--- a/client/src/api/modules/shared-factories/unwrapSharedFactory.ts
+++ b/client/src/api/modules/shared-factories/unwrapSharedFactory.ts
@@ -1,0 +1,8 @@
+// The shared-factory GET envelope shape lives in exactly one place. The API returns
+// `{ data: { factory_config } }` and axios wraps that under `response.data`, so the
+// wire config sits at `response.data.data.factory_config`. Both the useGetSharedFactory
+// hook and the multi-share receive path (which calls the raw `get` so it can fan out
+// with Promise.allSettled) unwrap through here.
+export function unwrapSharedFactoryConfig(response: { data?: { data?: { factory_config?: any } } } | undefined): any {
+  return response?.data?.data?.factory_config;
+}

--- a/client/src/api/modules/shared-factories/useGetSharedFactory.ts
+++ b/client/src/api/modules/shared-factories/useGetSharedFactory.ts
@@ -1,5 +1,6 @@
 import { get } from '../..';
 import { useApi } from "../../useApi";
+import { unwrapSharedFactoryConfig } from './unwrapSharedFactory';
 
 interface GetSharedFactoryRequest {
   factoryKey: string,
@@ -12,7 +13,6 @@ interface GetSharedFactoryResponse {
 export function useGetSharedFactory() {
   return useApi<GetSharedFactoryResponse, GetSharedFactoryRequest>(async (req) => {
     const res = await get('/shared-factories/:factoryKey', req);
-    const json = res.data;
-    return json.data;
+    return { factory_config: unwrapSharedFactoryConfig(res) };
   });
 }

--- a/client/src/components/GraphContextMenu/index.tsx
+++ b/client/src/components/GraphContextMenu/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { useMantineTheme } from '@mantine/core';
 import { truncateFloat } from '../../utilities/number';
 import { NODE_TYPE } from '../../utilities/production-solver/models';
+import { buildVariant, sloopSlotsFor, OC_THROUGHPUT_MULT } from '../../utilities/production-solver/amplification';
 import { NodeData } from '../../containers/ProductionPlanner/PlannerResults/ProductionGraphTab';
 import Portal from '../Portal';
 import { useProductionContext } from '../../contexts/production';
@@ -28,9 +29,12 @@ function buildMenuItems(node: NodeData, gameData: GameData): MenuItem[] {
   if (node.type === NODE_TYPE.RECIPE) {
     const recipeInfo = gameData.recipes[node.key];
     const primaryProduct = recipeInfo.products[0];
+    const variant = buildVariant(node.suffix ?? '', sloopSlotsFor(recipeInfo.producedIn));
+    const isOverclocked = node.suffix === 'OC' || node.suffix === 'AMPOC';
+    const maxClock = isOverclocked ? 100 * OC_THROUGHPUT_MULT : 100;
     const totalBuildings = Math.ceil(node.multiplier);
-    const clockPercentage = node.multiplier / totalBuildings * 100;
-    const itemsPerMinPerBuilding = primaryProduct.perMinute * node.multiplier / totalBuildings;
+    const clockPercentage = node.multiplier / totalBuildings * maxClock;
+    const itemsPerMinPerBuilding = primaryProduct.perMinute * variant.outputMult * node.multiplier / totalBuildings;
     return [
       { label: `Copy clock speed (${truncateFloat(clockPercentage)}%)`, value: truncateFloat(clockPercentage) },
       { label: `Copy items/min per machine (${truncateFloat(itemsPerMinPerBuilding)})`, value: truncateFloat(itemsPerMinPerBuilding) },

--- a/client/src/components/GraphTooltip/index.tsx
+++ b/client/src/components/GraphTooltip/index.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { Title, Text, Divider, List, useMantineTheme, Paper } from '@mantine/core';
 import { truncateFloat } from '../../utilities/number';
 import { NODE_TYPE } from '../../utilities/production-solver/models';
+import { buildVariant, sloopSlotsFor, variantLabel, OC_THROUGHPUT_MULT } from '../../utilities/production-solver/amplification';
 import { NodeData } from '../../containers/ProductionPlanner/PlannerResults/ProductionGraphTab';
 import Portal from '../Portal';
 import { useProductionContext } from '../../contexts/production';
@@ -38,13 +39,18 @@ const GraphTooltip = forwardRef<HTMLDivElement, Props>((props, ref) => {
     const recipeInfo = ctx.gameData.recipes[data.key];
     const primaryProduct = recipeInfo.products[0];
 
+    // Boost variant (somersloops/power shards) scales throughput and, for overclocking, the clock.
+    const variant = buildVariant(data.suffix ?? '', sloopSlotsFor(recipeInfo.producedIn));
+    const isOverclocked = data.suffix === 'OC' || data.suffix === 'AMPOC';
+    const maxClock = isOverclocked ? 100 * OC_THROUGHPUT_MULT : 100;
+
     const totalBuildings = Math.ceil(data.multiplier);
-    const clockPercentage = data.multiplier / totalBuildings * 100;
-    const itemsPerMinPerBuilding = primaryProduct.perMinute * data.multiplier / totalBuildings;
+    const clockPercentage = data.multiplier / totalBuildings * maxClock;
+    const itemsPerMinPerBuilding = primaryProduct.perMinute * variant.outputMult * data.multiplier / totalBuildings;
 
     return (
       <Tooltip>
-        <TooltipTitle order={3}>Recipe: [{recipeInfo.name}]</TooltipTitle>
+        <TooltipTitle order={3}>Recipe: [{recipeInfo.name}{variantLabel(data.suffix)}]</TooltipTitle>
         <TooltipDivider />
         <TooltipText>
           <b>Buildings:</b> {totalBuildings}x {ctx.gameData.buildings[recipeInfo.producedIn].name}
@@ -52,6 +58,16 @@ const GraphTooltip = forwardRef<HTMLDivElement, Props>((props, ref) => {
         <TooltipText>
           <b>Clock speed:</b> {truncateFloat(clockPercentage)}% each
         </TooltipText>
+        {variant.sloops > 0 && (
+          <TooltipText>
+            <b>Somersloops:</b> {variant.sloops} each ({variant.sloops * totalBuildings} total)
+          </TooltipText>
+        )}
+        {variant.shards > 0 && (
+          <TooltipText>
+            <b>Power shards:</b> {variant.shards} each ({variant.shards * totalBuildings} total)
+          </TooltipText>
+        )}
         <TooltipText>
           <b>Items per min:</b> {truncateFloat(itemsPerMinPerBuilding)} each
         </TooltipText>
@@ -61,7 +77,7 @@ const GraphTooltip = forwardRef<HTMLDivElement, Props>((props, ref) => {
           {
             recipeInfo.ingredients.map((ingredient) => (
               <List.Item key={ingredient.itemClass}>
-                <TooltipText>{ctx.gameData.items[ingredient.itemClass].name}: {truncateFloat(ingredient.perMinute * data.multiplier)} / min</TooltipText>
+                <TooltipText>{ctx.gameData.items[ingredient.itemClass].name}: {truncateFloat(ingredient.perMinute * variant.inputMult * data.multiplier)} / min</TooltipText>
               </List.Item>
             ))
           }
@@ -71,7 +87,7 @@ const GraphTooltip = forwardRef<HTMLDivElement, Props>((props, ref) => {
           {
             recipeInfo.products.map((product) => (
               <List.Item key={product.itemClass}>
-                <TooltipText>{ctx.gameData.items[product.itemClass].name}: {truncateFloat(product.perMinute * data.multiplier)} / min</TooltipText>
+                <TooltipText>{ctx.gameData.items[product.itemClass].name}: {truncateFloat(product.perMinute * variant.outputMult * data.multiplier)} / min</TooltipText>
               </List.Item>
             ))
           }

--- a/client/src/containers/ProductionPlanner/ImportPickerModal.tsx
+++ b/client/src/containers/ProductionPlanner/ImportPickerModal.tsx
@@ -1,0 +1,76 @@
+// The receive side of multi-share: when a `?factory=k1,k2,…` link opens with more
+// than one key, the gameData layer resolves each key and hands the results here so
+// the recipient can pick which to import. Resolved (ok:true) rows are pre-checked;
+// unresolvable (ok:false — 404 / expired / over the cap) rows are greyed and
+// unselectable. Selection is capped at MAX_SHARE_FACTORIES. This is a pure
+// presentational picker: the gameData layer owns fetching and the actual import.
+import React, { useEffect } from 'react';
+import { Modal, Stack, Group, Button } from '@mantine/core';
+import { FactoryOptions } from '../../contexts/production/types';
+import { MAX_SHARE_FACTORIES, OVER_CAP_REASON } from '../../utilities/shared-factory/share-url';
+import { FactorySelectList, SelectRow } from './PlannerOptions/FactorySelectList';
+import { useRowSelection } from './PlannerOptions/useRowSelection';
+
+// Resolved rows carry the fully-hydrated config so the gameData layer hydrates each
+// incoming factory exactly once (at resolve time) and the import is a plain map.
+export type IncomingFactory =
+  | { key: string; ok: true; config: FactoryOptions; version: string; label: string }
+  | { key: string; ok: false }; // 404 / expired / over-cap
+
+export function ImportPickerModal({
+  opened,
+  incoming,
+  onCancel,
+  onImport,
+}: {
+  opened: boolean;
+  incoming: IncomingFactory[];
+  onCancel: () => void;
+  onImport: (chosen: IncomingFactory[]) => void; // only ok:true rows
+}) {
+  const { selected, setSelected, toggle } = useRowSelection();
+
+  // Default-check every resolved row, up to the cap, each time the picker opens.
+  useEffect(() => {
+    if (!opened) return;
+    const ok = incoming.filter((i) => i.ok).slice(0, MAX_SHARE_FACTORIES);
+    setSelected(new Set(ok.map((i) => i.key)));
+  }, [opened, incoming, setSelected]);
+
+  const atCap = selected.size >= MAX_SHARE_FACTORIES;
+
+  const rows: SelectRow[] = incoming.map((i) => {
+    if (!i.ok) {
+      return { id: i.key, label: i.key, meta: '', disabled: true, disabledReason: 'Expired or invalid' };
+    }
+    const overCap = atCap && !selected.has(i.key);
+    return {
+      id: i.key,
+      label: i.label,
+      meta: `v${i.version}`,
+      disabled: overCap,
+      disabledReason: overCap ? OVER_CAP_REASON : undefined,
+    };
+  });
+
+  const chosen = incoming.filter((i) => i.ok && selected.has(i.key));
+
+  return (
+    <Modal opened={opened} onClose={onCancel} title="Import shared factories" size="lg" centered>
+      <Stack gap="sm">
+        <FactorySelectList rows={rows} selected={selected} onToggle={toggle} />
+
+        <Group justify="flex-end">
+          <Button variant="default" styles={{ root: { color: 'var(--mantine-color-text)' } }} onClick={onCancel}>Cancel</Button>
+          <Button
+            color="positive.8"
+            disabled={chosen.length === 0}
+            onClick={() => onImport(chosen)}
+          >
+            Import {chosen.length ? `${chosen.length} selected` : 'selected'}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/client/src/containers/ProductionPlanner/ImportPickerModal.tsx
+++ b/client/src/containers/ProductionPlanner/ImportPickerModal.tsx
@@ -13,9 +13,11 @@ import { useRowSelection } from './PlannerOptions/useRowSelection';
 
 // Resolved rows carry the fully-hydrated config so the gameData layer hydrates each
 // incoming factory exactly once (at resolve time) and the import is a plain map.
+// Unresolvable rows carry the reason they can't be imported (expired/invalid vs. past
+// the cap) so the picker shows the accurate message.
 export type IncomingFactory =
   | { key: string; ok: true; config: FactoryOptions; version: string; label: string }
-  | { key: string; ok: false }; // 404 / expired / over-cap
+  | { key: string; ok: false; reason: string };
 
 export function ImportPickerModal({
   opened,
@@ -41,7 +43,7 @@ export function ImportPickerModal({
 
   const rows: SelectRow[] = incoming.map((i) => {
     if (!i.ok) {
-      return { id: i.key, label: i.key, meta: '', disabled: true, disabledReason: 'Expired or invalid' };
+      return { id: i.key, label: i.key, meta: '', disabled: true, disabledReason: i.reason };
     }
     const overCap = atCap && !selected.has(i.key);
     return {

--- a/client/src/containers/ProductionPlanner/PlannerOptions/FactorySelectList.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/FactorySelectList.tsx
@@ -1,0 +1,80 @@
+// The checkbox row list shared by every factory-picker modal: the library manager
+// (export/import), the share-multiple picker, and the import picker. Each modal maps
+// its own domain objects into `SelectRow`s; this component only knows how to render a
+// scrollable, selectable list. Extracted from LibraryManagerModal, whose visible
+// rows (label + active badge + version/time meta) it reproduces exactly.
+import React from 'react';
+import { Stack, Group, Checkbox, Text, Badge, Button } from '@mantine/core';
+
+export type SelectRow = {
+  id: string;
+  label: string; // labelOf(factory, gameData)
+  meta: string; // e.g. "v1.2 · 3m ago"
+  isActive?: boolean; // renders the "active" badge
+  disabled?: boolean;
+  disabledReason?: string; // shown inline when disabled (e.g. "No products to share")
+};
+
+export function FactorySelectList({
+  rows,
+  selected,
+  onToggle,
+  onSelectAll,
+  maxHeight = 260,
+}: {
+  rows: SelectRow[];
+  selected: Set<string>;
+  onToggle: (id: string) => void;
+  onSelectAll?: () => void;
+  maxHeight?: number;
+}) {
+  return (
+    <>
+      {onSelectAll && (
+        <Group justify="flex-end">
+          <Button
+            size="xs"
+            variant="default"
+            styles={{ root: { color: 'var(--mantine-color-text)' } }}
+            onClick={onSelectAll}
+          >
+            Select all
+          </Button>
+        </Group>
+      )}
+
+      <Stack gap={4} style={{ maxHeight, overflow: 'auto' }}>
+        {rows.map((row) => (
+          <Group
+            key={row.id}
+            justify="space-between"
+            wrap="nowrap"
+            style={{
+              padding: '4px 6px',
+              borderRadius: 4,
+              background: row.isActive ? 'var(--mantine-color-default-hover)' : undefined,
+              opacity: row.disabled ? 0.55 : undefined,
+            }}
+          >
+            <Checkbox
+              checked={selected.has(row.id)}
+              disabled={row.disabled}
+              onChange={() => onToggle(row.id)}
+              label={
+                <span>
+                  {row.label} {row.isActive && <Badge size="xs" variant="light">active</Badge>}
+                  {row.disabled && row.disabledReason && (
+                    <Text span size="xs" c="dimmed"> — {row.disabledReason}</Text>
+                  )}
+                </span>
+              }
+            />
+            {row.meta && (
+              <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>{row.meta}</Text>
+            )}
+          </Group>
+        ))}
+      </Stack>
+    </>
+  );
+}

--- a/client/src/containers/ProductionPlanner/PlannerOptions/LibraryManagerModal.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/LibraryManagerModal.tsx
@@ -2,12 +2,14 @@
 // import factories from a file (drag-drop or browse). Opened from the FactorySwitcher
 // "⋯" menu. Import adds factories as new copies (fresh ids) via lib.importFactory.
 import React, { useEffect, useRef, useState } from 'react';
-import { Modal, Stack, Group, Button, Checkbox, Text, Badge, Alert } from '@mantine/core';
+import { Modal, Stack, Button, Text, Alert } from '@mantine/core';
 import { Download, Upload } from 'react-feather';
 import { useLibraryContext } from '../../../contexts/library';
 import { GameData } from '../../../contexts/gameData/types';
 import { labelOf, relativeTime } from '../../../utilities/factory-label';
 import { downloadFactories, parseBundle, ImportableFactory } from '../../../utilities/factory-io';
+import { FactorySelectList, SelectRow } from './FactorySelectList';
+import { useRowSelection } from './useRowSelection';
 
 type ImportResult = { added: number; warnings: string[]; errors: string[] };
 
@@ -24,18 +26,23 @@ export const LibraryManagerModal = ({
 }) => {
   const lib = useLibraryContext();
   const inputRef = useRef<HTMLInputElement>(null);
-  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const { selected, setSelected, toggle } = useRowSelection();
   const [dragging, setDragging] = useState(false);
   const [result, setResult] = useState<ImportResult | null>(null);
 
   // Reset transient state each time the modal opens.
   useEffect(() => {
     if (opened) { setSelected(new Set()); setResult(null); }
-  }, [opened]);
+  }, [opened, setSelected]);
 
   const chosen = lib.factories.filter((f) => selected.has(f.id));
-  const toggle = (id: string) =>
-    setSelected((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; });
+
+  const rows: SelectRow[] = lib.factories.map((f) => ({
+    id: f.id,
+    label: labelOf(f, gameData),
+    meta: `v${f.gameVersion} · ${relativeTime(f.updatedAt)}`,
+    isActive: f.id === lib.activeId,
+  }));
 
   const importFiles = async (files: FileList | File[] | null | undefined) => {
     if (!files || Array.from(files).length === 0) return;
@@ -68,35 +75,14 @@ export const LibraryManagerModal = ({
   return (
     <Modal opened={opened} onClose={onClose} title="Factory library" size="lg" centered>
       <Stack gap="sm">
-        <Group justify="space-between">
-          <Text size="sm" c="dimmed">{lib.factories.length} {lib.factories.length === 1 ? 'factory' : 'factories'}</Text>
-          <Button
-            size="xs"
-            variant="default"
-            styles={{ root: { color: 'var(--mantine-color-text)' } }}
-            onClick={() => setSelected(new Set(lib.factories.map((f) => f.id)))}
-          >
-            Select all
-          </Button>
-        </Group>
+        <Text size="sm" c="dimmed">{lib.factories.length} {lib.factories.length === 1 ? 'factory' : 'factories'}</Text>
 
-        <Stack gap={4} style={{ maxHeight: 260, overflow: 'auto' }}>
-          {lib.factories.map((f) => (
-            <Group
-              key={f.id}
-              justify="space-between"
-              wrap="nowrap"
-              style={{ padding: '4px 6px', borderRadius: 4, background: f.id === lib.activeId ? 'var(--mantine-color-default-hover)' : undefined }}
-            >
-              <Checkbox
-                checked={selected.has(f.id)}
-                onChange={() => toggle(f.id)}
-                label={<span>{labelOf(f, gameData)} {f.id === lib.activeId && <Badge size="xs" variant="light">active</Badge>}</span>}
-              />
-              <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>v{f.gameVersion} · {relativeTime(f.updatedAt)}</Text>
-            </Group>
-          ))}
-        </Stack>
+        <FactorySelectList
+          rows={rows}
+          selected={selected}
+          onToggle={toggle}
+          onSelectAll={() => setSelected(new Set(lib.factories.map((f) => f.id)))}
+        />
 
         <Button
           leftSection={<Download size={16} />}

--- a/client/src/containers/ProductionPlanner/PlannerOptions/ProductionTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/ProductionTab/index.tsx
@@ -307,6 +307,42 @@ const ProductionTab = () => {
     )
   }
 
+  function renderAmplificationInputs() {
+    const amplificationOptions = ctx.state.amplificationOptions;
+    return (
+      <Group grow>
+        <TextInput
+          label={<LabelWithTooltip label='Somersloops' tooltip='How many somersloops you have available. The solver spends them to amplify machines (up to 2x output for the same input, at 4x power). Usage may be fractional — round up when building in-game.' />}
+          className='no-spinner'
+          type='number'
+          min='0'
+          step='1'
+          value={amplificationOptions.availableSloops}
+          onChange={(e) => {
+            ctx.dispatch({
+              type: 'UPDATE_AMPLIFICATION_OPTIONS',
+              data: { ...amplificationOptions, availableSloops: e.currentTarget.value },
+            });
+          }}
+        />
+        <TextInput
+          label={<LabelWithTooltip label='Power Shards' tooltip='How many power shards you have available. The solver spends them to overclock machines to 250% (2.5x throughput at ~3.36x power), trading power for fewer buildings. 3 shards per overclocked building.' />}
+          className='no-spinner'
+          type='number'
+          min='0'
+          step='1'
+          value={amplificationOptions.availableShards}
+          onChange={(e) => {
+            ctx.dispatch({
+              type: 'UPDATE_AMPLIFICATION_OPTIONS',
+              data: { ...amplificationOptions, availableShards: e.currentTarget.value },
+            });
+          }}
+        />
+      </Group>
+    );
+  }
+
   function renderTransportOptions() {
     const opts: TransportOptions = ctx.state.transportOptions;
     const beltSelectValue = getSelectValue(opts.beltCapacity, BELT_PRESET_VALUES);
@@ -397,6 +433,14 @@ const ProductionTab = () => {
           {renderGameModeInputs()}
           <Button color='danger.8' onClick={() => { ctx.dispatch({ type: 'UPDATE_GAME_MODE_OPTIONS', data: { recipePartsCost: '1', powerConsumption: '1' } }) }} style={{ marginTop: '15px' }}>
             Reset Game Mode
+          </Button>
+        </CollapsibleSection>
+      )}
+      {gameVersion === GV_1_2 && (
+        <CollapsibleSection title='Amplification' tooltip='Give the solver a budget of somersloops and power shards to allocate. It amplifies (more output per input) and overclocks (fewer buildings) where that improves your weighting, up to the budget. Only full-boost machines are modeled.'>
+          {renderAmplificationInputs()}
+          <Button color='danger.8' onClick={() => { ctx.dispatch({ type: 'UPDATE_AMPLIFICATION_OPTIONS', data: { availableSloops: '0', availableShards: '0' } }) }} style={{ marginTop: '15px' }}>
+            Reset Amplification
           </Button>
         </CollapsibleSection>
       )}

--- a/client/src/containers/ProductionPlanner/PlannerOptions/useRowSelection.ts
+++ b/client/src/containers/ProductionPlanner/PlannerOptions/useRowSelection.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from 'react';
+
+// The Set-of-selected-ids state shared by every factory-picker modal (library
+// manager, share-multiple, import picker). Each modal owns WHEN to reset/seed the
+// selection (they differ — empty vs. default-checked), so only the state and the
+// toggle live here.
+export function useRowSelection() {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  const toggle = useCallback((id: string) => {
+    setSelected((s) => {
+      const n = new Set(s);
+      n.has(id) ? n.delete(id) : n.add(id);
+      return n;
+    });
+  }, []);
+
+  return { selected, setSelected, toggle };
+}

--- a/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ProductionGraphTab/index.tsx
@@ -218,6 +218,21 @@ const stylesheet: Cytoscape.StylesheetStyle[] = [
     style: { 'background-color': graphColors.nuclear.selected },
   },
 
+  // Boost-indicator borders (placed after the selection rules so the ring stays visible
+  // even when a boosted node is selected). Combined amp+OC gets the blended colour.
+  {
+    selector: 'node.amplified',
+    style: { 'border-width': 5, 'border-color': graphColors.amplification.amplified },
+  },
+  {
+    selector: 'node.overclocked',
+    style: { 'border-width': 5, 'border-color': graphColors.amplification.overclocked },
+  },
+  {
+    selector: 'node.amplified.overclocked',
+    style: { 'border-width': 5, 'border-color': graphColors.amplification.both },
+  },
+
 
   // ====== EDGES ====== //
   {
@@ -316,6 +331,9 @@ function getNodeClasses(node: GraphNode, gameData: GameData) {
     } else {
       classes.push(NODE_COLOR_CLASS[node.type]);
     }
+    // Boost indicators: a somersloop (amplified) and/or power-shard (overclocked) border.
+    if (node.suffix === 'AMP' || node.suffix === 'AMPOC') classes.push('amplified');
+    if (node.suffix === 'OC' || node.suffix === 'AMPOC') classes.push('overclocked');
   } else {
     classes.push('item-shape');
     classes.push(NODE_COLOR_CLASS[node.type]);

--- a/client/src/containers/ProductionPlanner/PlannerResults/ReportTab/index.tsx
+++ b/client/src/containers/ProductionPlanner/PlannerResults/ReportTab/index.tsx
@@ -58,6 +58,24 @@ const ReportTab = () => {
           </StatCard>
         </StatGrid>
 
+        {(report!.amplification.sloopsAvailable > 0 || report!.amplification.shardsAvailable > 0) && (
+          <>
+            <SectionTitle order={2}>Amplification</SectionTitle>
+            <StatGrid>
+              <StatCard>
+                <StatLabel>Somersloops Used</StatLabel>
+                <StatValue>{formatFloat(report!.amplification.sloopsUsed)}<StatUnit> / {formatFloat(report!.amplification.sloopsAvailable)}</StatUnit></StatValue>
+                <StatSub>whole machines, all slots filled</StatSub>
+              </StatCard>
+              <StatCard>
+                <StatLabel>Power Shards Used</StatLabel>
+                <StatValue>{formatFloat(report!.amplification.shardsUsed)}<StatUnit> / {formatFloat(report!.amplification.shardsAvailable)}</StatUnit></StatValue>
+                <StatSub>3 per overclocked machine</StatSub>
+              </StatCard>
+            </StatGrid>
+          </>
+        )}
+
         <SectionTitle order={2}>Summary of Produced Items</SectionTitle>
         {renderLoopWarning()}
         {renderSteps()}

--- a/client/src/containers/ProductionPlanner/ShareButton.tsx
+++ b/client/src/containers/ProductionPlanner/ShareButton.tsx
@@ -1,44 +1,63 @@
 // The Share control, shared by the desktop FactorySwitcher header band and the mobile
-// FactoryPicker sheet. The two rendered identical Tooltip + Popover + Button + feedback;
-// only the popover anchor and the wrapper alignment differ, so those are props. The copy
-// behavior and feedback lifecycle live in useShareFactory (see #182).
-import React from 'react';
-import { Tooltip, Button, Popover } from '@mantine/core';
-import { Share2 } from 'react-feather';
+// FactoryPicker sheet. It is a split button: the main Share button posts + copies the
+// ACTIVE factory (unchanged single-share behavior, gated by canShareFactory), and a
+// narrow chevron opens a menu with "Share multiple…" — which shares a picked set of
+// LIBRARY factories in one link (see ShareMultipleModal). The chevron is always
+// enabled; only the main button is gated. Copy behavior/feedback live in
+// useShareFactory (single) / useShareFactories (multi) — see #182.
+import React, { useState } from 'react';
+import { Tooltip, Button, Popover, Menu } from '@mantine/core';
+import { Share2, ChevronDown } from 'react-feather';
 import { useProductionContext } from '../../contexts/production';
 import { canShareFactory } from '../../utilities/shared-factory/codec';
 import { useShareFactory } from './useShareFactory';
 import ShareStatusView from './ShareStatusView';
+import { ShareMultipleModal } from './ShareMultipleModal';
 
 type Props = {
-  // Popover anchor: the desktop header band opens downward, the mobile sheet upward.
+  // Popover/menu anchor: the desktop header band opens downward, the mobile sheet upward.
   position?: 'bottom-end' | 'top-end';
-  // Optional style for the wrapping span (the mobile row pushes the button to the end).
+  // Optional style for the wrapping group (the mobile row pushes the button to the end).
   wrapperStyle?: React.CSSProperties;
 };
 
 const ShareButton = ({ position = 'bottom-end', wrapperStyle }: Props) => {
   const ctx = useProductionContext();
   const share = useShareFactory();
+  const [multiOpen, setMultiOpen] = useState(false);
 
-  // Guard the Share button rather than firing a POST that 400s with no feedback.
+  // Guard the main Share button rather than firing a POST that 400s with no feedback.
   const canShare = canShareFactory(ctx.state);
 
   return (
-    <Tooltip label="Add a product to share this factory" withArrow disabled={canShare}>
-      {/* The span keeps the Tooltip alive while the Button is disabled (a disabled
-          control emits no pointer events). The Popover targets the Button — not the
-          span — so its aria-haspopup/aria-expanded land on an element that supports
-          them (WCAG aria-allowed-attr). */}
-      <span style={wrapperStyle}>
-        <Popover opened={share.status !== 'idle' && canShare} position={position} withArrow>
-          <Popover.Target>
-            <Button color="positive.8" leftSection={<Share2 size={16} />} loading={ctx.shareLink.loading} disabled={!canShare} onClick={share.onShare}>Share</Button>
-          </Popover.Target>
-          <Popover.Dropdown><ShareStatusView status={share.status} link={share.link} /></Popover.Dropdown>
-        </Popover>
-      </span>
-    </Tooltip>
+    <>
+      <Button.Group style={wrapperStyle}>
+        <Tooltip label="Add a product to share this factory" withArrow disabled={canShare}>
+          {/* The span keeps the Tooltip alive while the Button is disabled (a disabled
+              control emits no pointer events). The Popover targets the Button — not the
+              span — so its aria-haspopup/aria-expanded land on an element that supports
+              them (WCAG aria-allowed-attr). */}
+          <span>
+            <Popover opened={share.status !== 'idle' && canShare} position={position} withArrow>
+              <Popover.Target>
+                <Button color="positive.8" leftSection={<Share2 size={16} />} loading={ctx.shareLink.loading} disabled={!canShare} onClick={share.onShare}>Share</Button>
+              </Popover.Target>
+              <Popover.Dropdown><ShareStatusView status={share.status} link={share.link} /></Popover.Dropdown>
+            </Popover>
+          </span>
+        </Tooltip>
+        <Menu position={position} withArrow shadow="md">
+          <Menu.Target>
+            <Button color="positive.8" aria-label="More share options" px={8}><ChevronDown size={16} /></Button>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item onClick={() => setMultiOpen(true)}>Share multiple…</Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Button.Group>
+
+      <ShareMultipleModal opened={multiOpen} onClose={() => setMultiOpen(false)} gameData={ctx.gameData} />
+    </>
   );
 };
 

--- a/client/src/containers/ProductionPlanner/ShareMultipleModal.tsx
+++ b/client/src/containers/ProductionPlanner/ShareMultipleModal.tsx
@@ -1,0 +1,104 @@
+// Share several library factories in ONE link. Opened from the Share split-button
+// dropdown (see ShareButton). Operates over the whole library, not the active
+// factory: rows list every saved factory, un-shareable ones are disabled, and the
+// selection is capped at MAX_SHARE_FACTORIES. Posting each factory + copying the
+// combined link is owned by useShareFactories (which reuses the #182 clipboard
+// discipline); this modal is the selection UI + feedback around it.
+import React, { useEffect } from 'react';
+import { Modal, Stack, Button, Text, Alert } from '@mantine/core';
+import { useLibraryContext } from '../../contexts/library';
+import { GameData } from '../../contexts/gameData/types';
+import { labelOf, relativeTime } from '../../utilities/factory-label';
+import { canShareFactory } from '../../utilities/shared-factory/codec';
+import { MAX_SHARE_FACTORIES, OVER_CAP_REASON } from '../../utilities/shared-factory/share-url';
+import { FactorySelectList, SelectRow } from './PlannerOptions/FactorySelectList';
+import { useRowSelection } from './PlannerOptions/useRowSelection';
+import { useShareFactories } from './useShareFactories';
+import { ManualCopyField } from './ShareStatusView';
+
+export const ShareMultipleModal = ({
+  opened,
+  onClose,
+  gameData,
+}: {
+  opened: boolean;
+  onClose: () => void;
+  gameData: GameData;
+}) => {
+  const lib = useLibraryContext();
+  const share = useShareFactories();
+  const { selected, setSelected, toggle } = useRowSelection();
+
+  // Reset the selection each time the modal opens.
+  useEffect(() => {
+    if (opened) setSelected(new Set());
+  }, [opened, setSelected]);
+
+  const atCap = selected.size >= MAX_SHARE_FACTORIES;
+
+  const rows: SelectRow[] = lib.factories.map((f) => {
+    const shareable = !!f.config && canShareFactory(f.config);
+    const overCap = atCap && !selected.has(f.id);
+    let disabledReason: string | undefined;
+    if (!shareable) disabledReason = 'No products to share';
+    else if (overCap) disabledReason = OVER_CAP_REASON;
+    return {
+      id: f.id,
+      label: labelOf(f, gameData),
+      meta: `v${f.gameVersion} · ${relativeTime(f.updatedAt)}`,
+      isActive: f.id === lib.activeId,
+      disabled: !shareable || overCap,
+      disabledReason,
+    };
+  });
+
+  // Only shareable factories can end up selected (disabled rows can't be toggled on),
+  // so `chosen` is safe to POST directly.
+  const chosen = lib.factories.filter((f) => selected.has(f.id));
+
+  // Select all shareable factories, up to the cap.
+  const selectAll = () => {
+    const ids = lib.factories
+      .filter((f) => !!f.config && canShareFactory(f.config))
+      .slice(0, MAX_SHARE_FACTORIES)
+      .map((f) => f.id);
+    setSelected(new Set(ids));
+  };
+
+  const busy = share.status === 'copying';
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Share factories" size="lg" centered>
+      <Stack gap="sm">
+        <FactorySelectList rows={rows} selected={selected} onToggle={toggle} onSelectAll={selectAll} />
+
+        {atCap && (
+          <Text size="xs" c="dimmed">You can share up to {MAX_SHARE_FACTORIES} factories in one link.</Text>
+        )}
+
+        <Button
+          color="positive.8"
+          disabled={chosen.length === 0 || busy}
+          loading={busy}
+          onClick={() => share.onShare(chosen)}
+        >
+          Share {chosen.length ? `${chosen.length} selected` : 'selected'}
+        </Button>
+
+        {share.status === 'failed' && (
+          <Alert color="red" title="Couldn't copy — copy the link below">
+            <ManualCopyField link={share.link} />
+          </Alert>
+        )}
+        {share.status === 'copied' && (
+          <Text size="sm" c="green">
+            {share.sharedCount < share.totalCount
+              ? `Shared ${share.sharedCount} of ${share.totalCount} — copied`
+              : 'Link copied!'}
+          </Text>
+        )}
+        {share.status === 'copying' && <Text size="sm">Generating…</Text>}
+      </Stack>
+    </Modal>
+  );
+};

--- a/client/src/containers/ProductionPlanner/ShareStatusView.tsx
+++ b/client/src/containers/ProductionPlanner/ShareStatusView.tsx
@@ -9,7 +9,7 @@ import type { ShareStatus } from './useShareFactory';
 // A read-only, auto-selected field holding the link, shown when the clipboard write
 // couldn't complete (rejected, or an insecure/unsupported context). It guarantees the
 // link is always reachable — one Ctrl/Cmd-C away — even when the server was cold.
-const ManualCopyField = ({ link }: { link: string }) => {
+export const ManualCopyField = ({ link }: { link: string }) => {
   const ref = useRef<HTMLInputElement>(null);
   useEffect(() => {
     ref.current?.focus();

--- a/client/src/containers/ProductionPlanner/useClipboardShare.ts
+++ b/client/src/containers/ProductionPlanner/useClipboardShare.ts
@@ -1,0 +1,71 @@
+import { useCallback, useRef, useState } from 'react';
+
+// The Share clipboard lifecycle, shared by the single-factory (useShareFactory) and
+// multi-factory (useShareFactories) hooks. It is driven by the *actual* clipboard
+// result rather than by "the POST returned a key" (see #182): on a cold-started
+// server the write could be pushed past the click's user-activation window and
+// silently rejected, yet the UI would still claim success. We only celebrate once
+// the clipboard resolves, and fall back to a manual-copy field when it doesn't.
+export type ShareStatus = 'idle' | 'copying' | 'copied' | 'failed';
+
+// How long the success feedback lingers before auto-dismissing. The failure state is
+// deliberately sticky — it hosts the manual-copy field — so it is never auto-closed.
+const COPIED_DISMISS_MS = 2500;
+
+// Drives status/link off a single `linkPromise` (the awaited share-link generation).
+// The promise must reject when there is no link to offer so the flow drops to the
+// manual-copy fallback. Callers own generating the promise (one POST or a batch).
+export function useClipboardShare() {
+  const [status, setStatus] = useState<ShareStatus>('idle');
+  // The resolved link, kept so the manual-copy fallback always has something to show
+  // even when the clipboard write itself was rejected.
+  const [link, setLink] = useState('');
+  const dismissTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const copy = useCallback(async (linkPromise: Promise<string>) => {
+    clearTimeout(dismissTimer.current);
+    setStatus('copying');
+    setLink('');
+
+    const markCopied = () => {
+      setStatus('copied');
+      dismissTimer.current = setTimeout(() => setStatus('idle'), COPIED_DISMISS_MS);
+    };
+
+    try {
+      // Async clipboard write: hand the browser a *pending* Blob via ClipboardItem so
+      // the write stays authorized by this click across the await for the (possibly
+      // cold-started) POST. A plain `await post; writeText(link)` runs after transient
+      // activation has expired, which Edge/Safari reject silently — the #182 bug.
+      const item = new ClipboardItem({
+        'text/plain': linkPromise.then((l) => new Blob([l], { type: 'text/plain' })),
+      });
+      await navigator.clipboard.write([item]);
+      setLink(await linkPromise);
+      markCopied();
+    } catch {
+      // ClipboardItem / clipboard.write is unavailable (older or insecure context) or
+      // the write was rejected. Recover the link for a best-effort plain-text write,
+      // then drop to the manual-copy field so the link is never stranded.
+      let resolved = '';
+      try {
+        resolved = await linkPromise;
+      } catch {
+        // Generation itself failed (e.g. the POST errored) — there is no link to offer.
+      }
+      setLink(resolved);
+      if (resolved) {
+        try {
+          await navigator.clipboard?.writeText(resolved);
+          markCopied();
+          return;
+        } catch {
+          // Both clipboard paths rejected — fall through to the manual-copy field.
+        }
+      }
+      setStatus('failed');
+    }
+  }, []);
+
+  return { status, link, copy };
+}

--- a/client/src/containers/ProductionPlanner/useShareFactories.test.ts
+++ b/client/src/containers/ProductionPlanner/useShareFactories.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock the POST hook: succeed for every factory except gameVersion 'bad', which
+// resolves to undefined (a failed POST). This lets us assert partial-failure counting
+// without a real network round-trip.
+vi.mock('../../api/modules/shared-factories/usePostSharedFactory', () => ({
+  usePostSharedFactory: () => ({
+    data: null,
+    error: null,
+    loading: false,
+    completedThisFrame: false,
+    request: async (req: { gameVersion: string }) =>
+      req.gameVersion === 'bad' ? undefined : { key: `key-${req.gameVersion}` },
+  }),
+}));
+
+import { useShareFactories } from './useShareFactories';
+import { LibraryFactory } from '../../contexts/library/types';
+
+function fac(gameVersion: string): LibraryFactory {
+  return { id: `id-${gameVersion}`, gameVersion, config: {} as any, createdAt: 0, updatedAt: 0 };
+}
+
+// Real clipboard.write awaits each ClipboardItem's pending Blob and rejects if one
+// rejects; the mock mirrors that so the "nothing shared" path (value promise throws)
+// drops into the failed branch just like a browser.
+const clipboardWrite = vi.fn().mockImplementation(async (items: any[]) => {
+  await Promise.all(items.flatMap((i) => i._values));
+});
+const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  clipboardWrite.mockClear();
+  clipboardWriteText.mockClear();
+  (globalThis as any).ClipboardItem = class {
+    _values: Promise<Blob>[];
+    constructor(items: Record<string, Promise<Blob>>) {
+      this._values = Object.values(items);
+      // Swallow rejections on a copy so they never surface as unhandled rejections.
+      this._values.forEach((p) => p.catch(() => {}));
+    }
+  };
+  Object.assign(navigator, { clipboard: { write: clipboardWrite, writeText: clipboardWriteText } });
+});
+
+describe('useShareFactories', () => {
+  it('copies the combined link and reports full counts on all-success', async () => {
+    const { result } = renderHook(() => useShareFactories());
+    await act(async () => {
+      await result.current.onShare([fac('1.2'), fac('1.1')]);
+    });
+    expect(clipboardWrite).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('copied');
+    expect(result.current.sharedCount).toBe(2);
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.link).toContain('factory=key-1.2,key-1.1');
+  });
+
+  it('builds the link from successful keys and reports the shortfall on partial failure', async () => {
+    const { result } = renderHook(() => useShareFactories());
+    await act(async () => {
+      await result.current.onShare([fac('1.2'), fac('bad'), fac('1.1')]);
+    });
+    expect(result.current.status).toBe('copied');
+    expect(result.current.sharedCount).toBe(2);
+    expect(result.current.totalCount).toBe(3);
+    expect(result.current.link).toContain('factory=key-1.2,key-1.1');
+  });
+
+  it('falls back to the failed state when nothing was shared', async () => {
+    const { result } = renderHook(() => useShareFactories());
+    await act(async () => {
+      await result.current.onShare([fac('bad'), fac('bad')]);
+    });
+    expect(result.current.status).toBe('failed');
+    expect(result.current.sharedCount).toBe(0);
+    expect(result.current.totalCount).toBe(2);
+    expect(result.current.link).toBe('');
+  });
+});

--- a/client/src/containers/ProductionPlanner/useShareFactories.ts
+++ b/client/src/containers/ProductionPlanner/useShareFactories.ts
@@ -1,0 +1,41 @@
+import { useCallback, useState } from 'react';
+import { usePostSharedFactory } from '../../api/modules/shared-factories/usePostSharedFactory';
+import { LibraryFactory } from '../../contexts/library/types';
+import { buildShareUrl } from '../../utilities/shared-factory/share-url';
+import { useClipboardShare } from './useClipboardShare';
+
+// Multi-factory Share: POST each selected factory, combine the keys into one link,
+// and copy it. The clipboard lifecycle (and the #182 discipline) is shared with the
+// single-factory hook via useClipboardShare; this hook only adds the batch POST and
+// the sharedCount/totalCount shortfall reporting.
+export function useShareFactories() {
+  const post = usePostSharedFactory();
+  const { status, link, copy } = useClipboardShare();
+  const [sharedCount, setSharedCount] = useState(0);
+  const [totalCount, setTotalCount] = useState(0);
+
+  const onShare = useCallback((factories: LibraryFactory[]) => {
+    setSharedCount(0);
+    setTotalCount(factories.length);
+
+    // ONE promise resolving to the final link. Each factory is encoded with its OWN
+    // game version. Partial failure is fine: the link is built from the keys that came
+    // back and sharedCount reports the shortfall; an empty result rejects so the
+    // clipboard flow drops to the manual-copy field.
+    const linkPromise = Promise.allSettled(
+      factories.map((f) => post.request({ factoryConfig: f.config!, gameVersion: f.gameVersion })),
+    ).then((results) => {
+      const keys = results
+        .filter((r): r is PromiseFulfilledResult<{ key: string } | undefined> => r.status === 'fulfilled')
+        .map((r) => r.value?.key)
+        .filter((k): k is string => !!k);
+      setSharedCount(keys.length);
+      if (!keys.length) throw new Error('No factories were shared');
+      return buildShareUrl(keys);
+    });
+
+    return copy(linkPromise);
+  }, [post, copy]);
+
+  return { status, link, sharedCount, totalCount, onShare };
+}

--- a/client/src/containers/ProductionPlanner/useShareFactory.ts
+++ b/client/src/containers/ProductionPlanner/useShareFactory.ts
@@ -1,76 +1,21 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback } from 'react';
 import { useProductionContext } from '../../contexts/production';
+import { useClipboardShare, ShareStatus } from './useClipboardShare';
 
-// The Share flow's feedback lifecycle, driven by the *actual* clipboard result rather
-// than by "the POST returned a key" (see #182): on a cold-started server the write was
-// pushed past the click's user-activation window and silently rejected, yet the UI
-// still claimed "Link copied!". Now we only celebrate once the clipboard resolves, and
-// fall back to a manual-copy field when it doesn't.
-export type ShareStatus = 'idle' | 'copying' | 'copied' | 'failed';
-
-// How long the success popover lingers before auto-dismissing. The failure popover is
-// deliberately sticky — it hosts the manual-copy field — so it is never auto-closed.
-const COPIED_DISMISS_MS = 2500;
+// Single-factory Share: generate the active factory's link and copy it inside the
+// click gesture. The clipboard lifecycle (and the #182 discipline) lives in
+// useClipboardShare, shared with the multi-factory hook.
+export type { ShareStatus };
 
 export function useShareFactory() {
   const ctx = useProductionContext();
-  const [status, setStatus] = useState<ShareStatus>('idle');
-  // The resolved link, kept so the manual-copy fallback always has something to show
-  // even when the clipboard write itself was rejected.
-  const [link, setLink] = useState('');
-  const dismissTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const { status, link, copy } = useClipboardShare();
 
-  const onShare = useCallback(async () => {
-    clearTimeout(dismissTimer.current);
-    setStatus('copying');
-    setLink('');
-
-    // Confirm the copy and let it linger briefly before auto-dismissing. Shared by the
-    // async-write and the plain-text fallback paths so the two-step stays in sync.
-    const markCopied = () => {
-      setStatus('copied');
-      dismissTimer.current = setTimeout(() => setStatus('idle'), COPIED_DISMISS_MS);
-    };
-
-    // One promise, shared by the async ClipboardItem and our own state, so the POST
-    // fires exactly once.
-    const linkPromise = ctx.generateShareLink();
-
-    try {
-      // Async clipboard write: hand the browser a *pending* Blob via ClipboardItem so
-      // the write stays authorized by this click across the await for the (possibly
-      // cold-started) POST. A plain `await post; writeText(link)` runs after transient
-      // activation has expired, which Edge/Safari reject silently — the #182 bug.
-      const item = new ClipboardItem({
-        'text/plain': linkPromise.then((l) => new Blob([l], { type: 'text/plain' })),
-      });
-      await navigator.clipboard.write([item]);
-      setLink(await linkPromise);
-      markCopied();
-    } catch {
-      // ClipboardItem / clipboard.write is unavailable (older or insecure context) or
-      // the write was rejected. Recover the link for a best-effort plain-text write —
-      // mirroring the optional-chaining pattern in GraphContextMenu — then drop to the
-      // manual-copy field so the link is never stranded.
-      let resolved = '';
-      try {
-        resolved = await linkPromise;
-      } catch {
-        // Generation itself failed (e.g. the POST errored) — there is no link to offer.
-      }
-      setLink(resolved);
-      if (resolved) {
-        try {
-          await navigator.clipboard?.writeText(resolved);
-          markCopied();
-          return;
-        } catch {
-          // Both clipboard paths rejected — fall through to the manual-copy field.
-        }
-      }
-      setStatus('failed');
-    }
-  }, [ctx]);
+  const onShare = useCallback(() => {
+    // generateShareLink rejects when the server never returned a key, which drops the
+    // clipboard flow to its manual-copy fallback.
+    return copy(ctx.generateShareLink());
+  }, [ctx, copy]);
 
   return { status, link, onShare };
 }

--- a/client/src/contexts/gameData/index.tsx
+++ b/client/src/contexts/gameData/index.tsx
@@ -1,13 +1,19 @@
 import React, { createContext, useContext, useState, useEffect, useMemo, useCallback, useRef } from 'react';
 import { useGetSharedFactory } from '../../api/modules/shared-factories/useGetSharedFactory';
+import { unwrapSharedFactoryConfig } from '../../api/modules/shared-factories/unwrapSharedFactory';
+import { get } from '../../api';
 import { GameData } from './types';
 import { loadGameData } from './loadGameData';
 import { DEFAULT_GAME_VERSION, SHARE_QUERY_PARAM } from './consts';
 import { toDisplay } from '../../utilities/shared-factory/codec';
+import { parseShareKeys, MAX_SHARE_FACTORIES } from '../../utilities/shared-factory/share-url';
+import { hydrateSharedFactory } from '../../utilities/shared-factory/hydrate';
 import { usePrevious } from '../../hooks/usePrevious';
 import { FactoryOptions } from '../production/types';
 import { usePageTitle } from '../../hooks/usePageTitle';
-import { useLibraryContext } from '../library';
+import { deriveAutoLabel } from '../../utilities/factory-label';
+import { useLibraryContext, FactoryImportInput } from '../library';
+import { ImportPickerModal, IncomingFactory } from '../../containers/ProductionPlanner/ImportPickerModal';
 
 
 // TYPE
@@ -54,6 +60,17 @@ export function useGameDataContext() {
 }
 
 
+// Remove the given query params from the URL in place (history.replaceState), keeping
+// any other params so a refresh neither re-imports a consumed share nor drops unrelated
+// state (e.g. the prototype's ?variant=).
+function stripUrlParams(names: string[]) {
+  const params = new URLSearchParams(window.location.search);
+  names.forEach((n) => params.delete(n));
+  const rest = params.toString();
+  window.history.replaceState(null, '', rest ? `${window.location.pathname}?${rest}` : window.location.pathname);
+}
+
+
 // PROVIDER
 type PropTypes = { children: React.ReactNode };
 export const GameDataProvider = ({ children }: PropTypes) => {
@@ -65,6 +82,9 @@ export const GameDataProvider = ({ children }: PropTypes) => {
   const [loadingError, setLoadingError] = useState(false);
   const [shareError, setShareError] = useState(false);
   const [reinitToken, setReinitToken] = useState(0);
+  // The multi-share receive picker: resolved incoming factories + open state.
+  const [importIncoming, setImportIncoming] = useState<IncomingFactory[]>([]);
+  const [importOpen, setImportOpen] = useState(false);
   const prevLoading = usePrevious(loading);
   const [needToFetchGameData, setNeedToFetchGameData] = useState(true);
   const completedThisFrame = useMemo(() => !loading && loading !== prevLoading, [loading, prevLoading]);
@@ -101,13 +121,8 @@ export const GameDataProvider = ({ children }: PropTypes) => {
     const params = new URLSearchParams(window.location.search);
     const shareKey = params.get(SHARE_QUERY_PARAM);
     const legacyEncoding = params.get('f');
-    // Clear only the share keys we just imported — leave any other query params
-    // (e.g. the prototype's ?variant=) intact so a refresh doesn't re-import the
-    // shared factory while still preserving the rest of the URL.
-    params.delete(SHARE_QUERY_PARAM);
-    params.delete('f');
-    const rest = params.toString();
-    window.history.replaceState(null, '', rest ? `${window.location.pathname}?${rest}` : window.location.pathname);
+    // Clear only the share keys we just imported (see stripUrlParams).
+    stripUrlParams([SHARE_QUERY_PARAM, 'f']);
 
     let libraryConfig: FactoryOptions | null = null;
     if (shareKey || legacyEncoding) {
@@ -134,6 +149,65 @@ export const GameDataProvider = ({ children }: PropTypes) => {
     setLoading(false);
   };
 
+  // Multi-share receive (`?factory=k1,k2,…`, >1 key). Unlike the single path this
+  // never hydrates the active factory: it boots the planner normally, resolves each
+  // key in parallel, and opens a picker so the recipient chooses what to import. The
+  // share param is stripped up front so a refresh can't re-import.
+  const resolveMultiShare = async (keys: string[]) => {
+    stripUrlParams([SHARE_QUERY_PARAM]);
+
+    // Boot the planner normally so it's usable while (and after) the picker is open.
+    const version = lib.activeFactory?.gameVersion || gameVersion || DEFAULT_GAME_VERSION;
+    void finalizeLoad({ version, factoryConfig: null });
+
+    // Cap how many keys we resolve; extras past the cap surface as unresolvable rows.
+    const capped = keys.slice(0, MAX_SHARE_FACTORIES);
+    const overflow = keys.slice(MAX_SHARE_FACTORIES);
+
+    const settled = await Promise.allSettled(
+      capped.map((key) => get('/shared-factories/:factoryKey', { factoryKey: key })),
+    );
+    const incoming: IncomingFactory[] = await Promise.all(
+      settled.map(async (res, idx): Promise<IncomingFactory> => {
+        const key = capped[idx];
+        if (res.status !== 'fulfilled') return { key, ok: false };
+        const wire = unwrapSharedFactoryConfig(res.value);
+        if (!wire) return { key, ok: false };
+        try {
+          const v = wire.gameVersion ? toDisplay(wire.gameVersion) : DEFAULT_GAME_VERSION;
+          const gd = await loadGameData(v);
+          // Hydrate once, here: the picker's label and the eventual import both reuse
+          // this config, so handleImportShared never re-hydrates.
+          const config = hydrateSharedFactory(wire, gd);
+          return { key, ok: true, config, version: v, label: deriveAutoLabel(config, gd) };
+        } catch {
+          return { key, ok: false };
+        }
+      }),
+    );
+    overflow.forEach((key) => incoming.push({ key, ok: false }));
+
+    // All keys dead (invalid/expired/over-cap): surface cohesively like a bad single
+    // link instead of opening an empty picker.
+    if (incoming.every((i) => !i.ok)) {
+      setShareError(true);
+      return;
+    }
+    setImportIncoming(incoming);
+    setImportOpen(true);
+  };
+
+  // Import the picked resolved factories in ONE library commit (importFactories
+  // selects the last + persists). Each config was already hydrated at resolve time,
+  // so this is a plain map — no re-fetch, no re-hydrate.
+  const handleImportShared = (chosen: IncomingFactory[]) => {
+    setImportOpen(false);
+    const inputs: FactoryImportInput[] = chosen
+      .filter((i): i is Extract<IncomingFactory, { ok: true }> => i.ok)
+      .map((i) => ({ config: i.config, gameVersion: i.version, sourceKey: i.key }));
+    if (inputs.length) lib.importFactories(inputs);
+  };
+
   useEffect(() => {
     if (needToFetchGameData) {
       setLoading(true);
@@ -143,13 +217,16 @@ export const GameDataProvider = ({ children }: PropTypes) => {
       setShareError(false);
 
       const params = new URLSearchParams(window.location.search);
-      const shareKey = params.get(SHARE_QUERY_PARAM);
+      const shareKeys = parseShareKeys(params.get(SHARE_QUERY_PARAM));
       const legacyEncoding = params.get('f');
 
-      if (shareKey) {
-        // Resolve the saved config first; finalizeLoad runs once it arrives so we
-        // can load the bundle for the share's own game version (below).
-        sharedFactory.request({ factoryKey: shareKey });
+      if (shareKeys.length > 1) {
+        // Multi-share link: boot normally + resolve the set for the import picker.
+        void resolveMultiShare(shareKeys);
+      } else if (shareKeys.length === 1) {
+        // Single share — unchanged: resolve the saved config first; finalizeLoad runs
+        // once it arrives so we can load the bundle for the share's own game version.
+        sharedFactory.request({ factoryKey: shareKeys[0] });
       } else if (legacyEncoding) {
         // Legacy ?f= links never carried a server config; default the version.
         void finalizeLoad({ version: DEFAULT_GAME_VERSION, factoryConfig: null });
@@ -170,10 +247,7 @@ export const GameDataProvider = ({ children }: PropTypes) => {
         // from the URL so finalizeLoad takes the normal library path (not an
         // import of a non-existent share) and a refresh won't retry, flag the
         // failure for the UI, then load a normal factory.
-        const params = new URLSearchParams(window.location.search);
-        params.delete(SHARE_QUERY_PARAM);
-        const rest = params.toString();
-        window.history.replaceState(null, '', rest ? `${window.location.pathname}?${rest}` : window.location.pathname);
+        stripUrlParams([SHARE_QUERY_PARAM]);
         setShareError(true);
         const version = lib.activeFactory?.gameVersion || gameVersion || DEFAULT_GAME_VERSION;
         void finalizeLoad({ version, factoryConfig: null });
@@ -231,6 +305,12 @@ export const GameDataProvider = ({ children }: PropTypes) => {
   return (
     <GameDataContext.Provider value={ctxValue}>
       {children}
+      <ImportPickerModal
+        opened={importOpen}
+        incoming={importIncoming}
+        onCancel={() => setImportOpen(false)}
+        onImport={handleImportShared}
+      />
     </GameDataContext.Provider>
   );
 }

--- a/client/src/contexts/gameData/index.tsx
+++ b/client/src/contexts/gameData/index.tsx
@@ -6,7 +6,7 @@ import { GameData } from './types';
 import { loadGameData } from './loadGameData';
 import { DEFAULT_GAME_VERSION, SHARE_QUERY_PARAM } from './consts';
 import { toDisplay } from '../../utilities/shared-factory/codec';
-import { parseShareKeys, MAX_SHARE_FACTORIES } from '../../utilities/shared-factory/share-url';
+import { parseShareKeys, MAX_SHARE_FACTORIES, OVER_CAP_REASON } from '../../utilities/shared-factory/share-url';
 import { hydrateSharedFactory } from '../../utilities/shared-factory/hydrate';
 import { usePrevious } from '../../hooks/usePrevious';
 import { FactoryOptions } from '../production/types';
@@ -59,6 +59,10 @@ export function useGameDataContext() {
   return ctx;
 }
 
+
+// Reason shown for a multi-share key that couldn't be resolved (404 / past its 7-day
+// TTL / malformed). Distinct from the over-the-cap reason (OVER_CAP_REASON).
+const EXPIRED_REASON = 'Expired or invalid';
 
 // Remove the given query params from the URL in place (history.replaceState), keeping
 // any other params so a refresh neither re-imports a consumed share nor drops unrelated
@@ -160,7 +164,7 @@ export const GameDataProvider = ({ children }: PropTypes) => {
     const version = lib.activeFactory?.gameVersion || gameVersion || DEFAULT_GAME_VERSION;
     void finalizeLoad({ version, factoryConfig: null });
 
-    // Cap how many keys we resolve; extras past the cap surface as unresolvable rows.
+    // Cap how many keys we resolve; extras past the cap surface as over-limit rows.
     const capped = keys.slice(0, MAX_SHARE_FACTORIES);
     const overflow = keys.slice(MAX_SHARE_FACTORIES);
 
@@ -170,9 +174,9 @@ export const GameDataProvider = ({ children }: PropTypes) => {
     const incoming: IncomingFactory[] = await Promise.all(
       settled.map(async (res, idx): Promise<IncomingFactory> => {
         const key = capped[idx];
-        if (res.status !== 'fulfilled') return { key, ok: false };
+        if (res.status !== 'fulfilled') return { key, ok: false, reason: EXPIRED_REASON };
         const wire = unwrapSharedFactoryConfig(res.value);
-        if (!wire) return { key, ok: false };
+        if (!wire) return { key, ok: false, reason: EXPIRED_REASON };
         try {
           const v = wire.gameVersion ? toDisplay(wire.gameVersion) : DEFAULT_GAME_VERSION;
           const gd = await loadGameData(v);
@@ -181,11 +185,12 @@ export const GameDataProvider = ({ children }: PropTypes) => {
           const config = hydrateSharedFactory(wire, gd);
           return { key, ok: true, config, version: v, label: deriveAutoLabel(config, gd) };
         } catch {
-          return { key, ok: false };
+          return { key, ok: false, reason: EXPIRED_REASON };
         }
       }),
     );
-    overflow.forEach((key) => incoming.push({ key, ok: false }));
+    // Keys past the cap were never fetched: they're over the limit, not expired.
+    overflow.forEach((key) => incoming.push({ key, ok: false, reason: OVER_CAP_REASON }));
 
     // All keys dead (invalid/expired/over-cap): surface cohesively like a bad single
     // link instead of opening an empty picker.

--- a/client/src/contexts/production/defaults.ts
+++ b/client/src/contexts/production/defaults.ts
@@ -1,5 +1,5 @@
 import { nanoid } from 'nanoid';
-import { ProductionItemOptions, InputItemOptions, WeightingOptions, GameModeOptions, RecipeSelectionMap, BuildingSelectionMap, FactoryOptions, TransportOptions } from './types';
+import { ProductionItemOptions, InputItemOptions, WeightingOptions, GameModeOptions, AmplificationOptions, RecipeSelectionMap, BuildingSelectionMap, FactoryOptions, TransportOptions } from './types';
 import { GameData, RecipeMap, ResourceMap } from '../gameData/types';
 import { DEFAULT_MAXIMIZE_BALANCE_MODE } from './consts';
 
@@ -84,6 +84,15 @@ export function getInitialGameModeOptions(): GameModeOptions {
   };
 }
 
+// Somersloop/power-shard budgets default to 0 -> the solver offers no boost variants
+// and behaves exactly as before until the user makes some available.
+export function getInitialAmplificationOptions(): AmplificationOptions {
+  return {
+    availableSloops: '0',
+    availableShards: '0',
+  };
+}
+
 export function getInitialTransportOptions(): TransportOptions {
   return {
     beltCapacity: null,
@@ -119,6 +128,7 @@ export function getInitialState(gameData: GameData): FactoryOptions {
     allowHandGatheredItems: false,
     weightingOptions: getInitialWeightingOptions(),
     gameModeOptions: getInitialGameModeOptions(),
+    amplificationOptions: getInitialAmplificationOptions(),
     allowedRecipes: getInitialAllowedRecipes(gameData.recipes),
     allowedBuildings: getInitialAllowedBuildings(gameData.recipes),
     nodesPositions: [],

--- a/client/src/contexts/production/defaults.ts
+++ b/client/src/contexts/production/defaults.ts
@@ -1,0 +1,128 @@
+import { nanoid } from 'nanoid';
+import { ProductionItemOptions, InputItemOptions, WeightingOptions, GameModeOptions, RecipeSelectionMap, BuildingSelectionMap, FactoryOptions, TransportOptions } from './types';
+import { GameData, RecipeMap, ResourceMap } from '../gameData/types';
+import { DEFAULT_MAXIMIZE_BALANCE_MODE } from './consts';
+
+// The FactoryOptions default/initial-state builders. These live in their own module
+// (not the reducer) so the shared-factory hydrate utility can build a fresh state
+// without importing the reducer — which would form a cycle (reducer imports hydrate).
+
+export function getDefaultProductionItem(): ProductionItemOptions {
+  return ({
+    key: nanoid(),
+    itemKey: '',
+    mode: 'per-minute',
+    value: '10',
+  });
+}
+
+export function getDefaultInputItem(): InputItemOptions {
+  return ({
+    key: nanoid(),
+    itemKey: '',
+    value: '10',
+    weight: '0',
+    unlimited: false,
+  });
+}
+
+const ORDERED_RESOURCES = [
+  'Desc_OreIron_C',
+  'Desc_OreCopper_C',
+  'Desc_Stone_C',
+  'Desc_Coal_C',
+  'Desc_OreGold_C',
+  'Desc_RawQuartz_C',
+  'Desc_Sulfur_C',
+  'Desc_LiquidOil_C',
+  'Desc_OreBauxite_C',
+  'Desc_OreUranium_C',
+  'Desc_NitrogenGas_C',
+  'Desc_Water_C',
+];
+
+export function getInitialInputResources(resources: ResourceMap): InputItemOptions[] {
+  return Object.entries(resources)
+    .map(([key, data]) => {
+      let value = '0';
+      let unlimited = false;
+      if (key === 'Desc_Water_C') {
+        unlimited = true;
+      } else {
+        value = String(data.maxExtraction);
+      }
+      return {
+        key: key,
+        itemKey: key,
+        value,
+        weight: String(data.relativeValue),
+        unlimited,
+      };
+    })
+    .sort((a, b) => {
+      let aIndex = ORDERED_RESOURCES.findIndex((r) => r === a.itemKey);
+      if (aIndex === -1) aIndex = Infinity;
+      let bIndex = ORDERED_RESOURCES.findIndex((r) => r === b.itemKey);
+      if (bIndex === -1) bIndex = Infinity;
+      return aIndex < bIndex ? -1 : 1;
+    });
+}
+
+export function getInitialWeightingOptions(): WeightingOptions {
+  return {
+    resources: '1000',
+    power: '1',
+    complexity: '0',
+    buildings: '0',
+  };
+}
+
+export function getInitialGameModeOptions(): GameModeOptions {
+  return {
+    recipePartsCost: '1',
+    powerConsumption: '1',
+  };
+}
+
+export function getInitialTransportOptions(): TransportOptions {
+  return {
+    beltCapacity: null,
+    pipeCapacity: null,
+  };
+}
+
+export function getInitialAllowedRecipes(recipes: RecipeMap): RecipeSelectionMap {
+  const recipeMap: RecipeSelectionMap = {};
+  Object.entries(recipes).forEach(([key, data]) => {
+    recipeMap[key] = !data.isAlternate;
+  });
+  return recipeMap;
+}
+
+// Keyed only by buildings that actually produce a recipe (derived from recipes,
+// not gameData.buildings, so generators/extractors/foundations don't appear).
+// Buildings have no "alternates" concept, so every machine starts enabled.
+export function getInitialAllowedBuildings(recipes: RecipeMap): BuildingSelectionMap {
+  const buildingMap: BuildingSelectionMap = {};
+  Object.values(recipes).forEach((data) => {
+    buildingMap[data.producedIn] = true;
+  });
+  return buildingMap;
+}
+
+export function getInitialState(gameData: GameData): FactoryOptions {
+  return {
+    key: nanoid(),
+    productionItems: [],
+    inputItems: [],
+    inputResources: getInitialInputResources(gameData.resources),
+    allowHandGatheredItems: false,
+    weightingOptions: getInitialWeightingOptions(),
+    gameModeOptions: getInitialGameModeOptions(),
+    allowedRecipes: getInitialAllowedRecipes(gameData.recipes),
+    allowedBuildings: getInitialAllowedBuildings(gameData.recipes),
+    nodesPositions: [],
+    maximizeBalanceMode: DEFAULT_MAXIMIZE_BALANCE_MODE,
+    transportOptions: getInitialTransportOptions(),
+  };
+}

--- a/client/src/contexts/production/index.tsx
+++ b/client/src/contexts/production/index.tsx
@@ -5,7 +5,7 @@ import { reducer, FactoryAction, getInitialState } from './reducer';
 import { FactoryOptions } from './types';
 import { FactoryInitializer } from '../gameData';
 import { GameData } from '../gameData/types';
-import { SHARE_QUERY_PARAM } from '../gameData/consts';
+import { buildShareUrl } from '../../utilities/shared-factory/share-url';
 import { SolverResults } from '../../utilities/production-solver/models';
 import { useSolverRun } from './useSolverRun';
 import { useLibraryContext } from '../library';
@@ -70,7 +70,7 @@ export const ProductionProvider = ({ gameData, gameVersion, initializer, trigger
     if (!key) {
       throw new Error('Failed to generate a share link');
     }
-    return `${window.location.protocol}//${window.location.host}${window.location.pathname}?${SHARE_QUERY_PARAM}=${key}`;
+    return buildShareUrl([key]);
   };
 
   // The share link itself is returned by handleGenerateShareLink (awaited inside the

--- a/client/src/contexts/production/reducer.test.ts
+++ b/client/src/contexts/production/reducer.test.ts
@@ -401,6 +401,17 @@ describe('reducer', () => {
     });
   });
 
+  describe('UPDATE_AMPLIFICATION_OPTIONS', () => {
+    it('updates the somersloop/power-shard budgets', () => {
+      const state = createInitialState();
+      const result = reducer(state, {
+        type: 'UPDATE_AMPLIFICATION_OPTIONS',
+        data: { availableSloops: '106', availableShards: '250' },
+      });
+      expect(result.amplificationOptions).toEqual({ availableSloops: '106', availableShards: '250' });
+    });
+  });
+
   describe('SET_ALL_WEIGHTS_DEFAULT', () => {
     it('resets weighting options to defaults', () => {
       const state = createInitialState();

--- a/client/src/contexts/production/reducer.tsx
+++ b/client/src/contexts/production/reducer.tsx
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid';
 import { decodeState_v1_U5 } from './legacy-state-decoders/v1_U5';
 import { decodeState_v2_U5 } from './legacy-state-decoders/v2_U5';
 import { decodeState_v3_U5 } from './legacy-state-decoders/v3_U5';
-import { InputItemOptions, WeightingOptions, GameModeOptions, FactoryOptions, NodeInfo, TransportOptions } from './types';
+import { InputItemOptions, WeightingOptions, GameModeOptions, AmplificationOptions, FactoryOptions, NodeInfo, TransportOptions } from './types';
 import { GameData } from '../gameData/types';
 import { MAX_PRIORITY, MaximizeBalanceMode, DEFAULT_MAXIMIZE_BALANCE_MODE } from './consts';
 import { WireFactory } from '../../utilities/shared-factory/codec';
@@ -14,6 +14,7 @@ import {
   getInitialInputResources,
   getInitialWeightingOptions,
   getInitialGameModeOptions,
+  getInitialAmplificationOptions,
   getInitialTransportOptions,
   getInitialAllowedBuildings,
 } from './defaults';
@@ -41,6 +42,7 @@ export type FactoryAction =
   | { type: 'SET_ALLOW_HAND_GATHERED_ITEMS', active: boolean }
   | { type: 'UPDATE_WEIGHTING_OPTIONS', data: WeightingOptions }
   | { type: 'UPDATE_GAME_MODE_OPTIONS', data: GameModeOptions }
+  | { type: 'UPDATE_AMPLIFICATION_OPTIONS', data: AmplificationOptions }
   | { type: 'SET_ALL_WEIGHTS_DEFAULT', gameData: GameData }
   | { type: 'SET_RECIPE_ACTIVE', key: string, active: boolean }
   | { type: 'MASS_SET_RECIPES_ACTIVE', recipes: string[], active: boolean }
@@ -174,6 +176,10 @@ export function reducer(state: FactoryOptions, action: FactoryAction): FactoryOp
       const newGameModeOptions = { ...action.data };
       return { ...state, gameModeOptions: newGameModeOptions };
     }
+    case 'UPDATE_AMPLIFICATION_OPTIONS': {
+      const newAmplificationOptions = { ...action.data };
+      return { ...state, amplificationOptions: newAmplificationOptions };
+    }
     case 'SET_ALL_WEIGHTS_DEFAULT': {
       const newWeightingOptions = getInitialWeightingOptions();
       const newInputResources = state.inputResources
@@ -226,6 +232,7 @@ export function reducer(state: FactoryOptions, action: FactoryAction): FactoryOp
           maximizeBalanceMode: action.config.maximizeBalanceMode ?? DEFAULT_MAXIMIZE_BALANCE_MODE,
           transportOptions: action.config.transportOptions ?? getInitialTransportOptions(),
           gameModeOptions: action.config.gameModeOptions ?? getInitialGameModeOptions(),
+          amplificationOptions: action.config.amplificationOptions ?? getInitialAmplificationOptions(),
           allowedBuildings: action.config.allowedBuildings ?? getInitialAllowedBuildings(action.gameData.recipes),
         };
       } catch (e) {

--- a/client/src/contexts/production/reducer.tsx
+++ b/client/src/contexts/production/reducer.tsx
@@ -2,131 +2,26 @@ import { nanoid } from 'nanoid';
 import { decodeState_v1_U5 } from './legacy-state-decoders/v1_U5';
 import { decodeState_v2_U5 } from './legacy-state-decoders/v2_U5';
 import { decodeState_v3_U5 } from './legacy-state-decoders/v3_U5';
-import { ProductionItemOptions, InputItemOptions, WeightingOptions, GameModeOptions, RecipeSelectionMap, BuildingSelectionMap, FactoryOptions, NodeInfo, TransportOptions } from './types';
-import { GameData, RecipeMap, ResourceMap } from '../gameData/types';
+import { InputItemOptions, WeightingOptions, GameModeOptions, FactoryOptions, NodeInfo, TransportOptions } from './types';
+import { GameData } from '../gameData/types';
 import { MAX_PRIORITY, MaximizeBalanceMode, DEFAULT_MAXIMIZE_BALANCE_MODE } from './consts';
-import { decode, WireFactory } from '../../utilities/shared-factory/codec';
+import { WireFactory } from '../../utilities/shared-factory/codec';
+import { hydrateSharedFactory } from '../../utilities/shared-factory/hydrate';
+import {
+  getInitialState,
+  getDefaultProductionItem,
+  getDefaultInputItem,
+  getInitialInputResources,
+  getInitialWeightingOptions,
+  getInitialGameModeOptions,
+  getInitialTransportOptions,
+  getInitialAllowedBuildings,
+} from './defaults';
 
-// DEFAULTS
-function getDefaultProductionItem(): ProductionItemOptions {
-  return ({
-    key: nanoid(),
-    itemKey: '',
-    mode: 'per-minute',
-    value: '10',
-  });
-}
-
-function getDefaultInputItem(): InputItemOptions {
-  return ({
-    key: nanoid(),
-    itemKey: '',
-    value: '10',
-    weight: '0',
-    unlimited: false,
-  });
-}
-
-const ORDERED_RESOURCES = [
-  'Desc_OreIron_C',
-  'Desc_OreCopper_C',
-  'Desc_Stone_C',
-  'Desc_Coal_C',
-  'Desc_OreGold_C',
-  'Desc_RawQuartz_C',
-  'Desc_Sulfur_C',
-  'Desc_LiquidOil_C',
-  'Desc_OreBauxite_C',
-  'Desc_OreUranium_C',
-  'Desc_NitrogenGas_C',
-  'Desc_Water_C',
-];
-
-function getInitialInputResources(resources: ResourceMap): InputItemOptions[] {
-  return Object.entries(resources)
-    .map(([key, data]) => {
-      let value = '0';
-      let unlimited = false;
-      if (key === 'Desc_Water_C') {
-        unlimited = true;
-      } else {
-        value = String(data.maxExtraction);
-      }
-      return {
-        key: key,
-        itemKey: key,
-        value,
-        weight: String(data.relativeValue),
-        unlimited,
-      };
-    })
-    .sort((a, b) => {
-      let aIndex = ORDERED_RESOURCES.findIndex((r) => r === a.itemKey);
-      if (aIndex === -1) aIndex = Infinity;
-      let bIndex = ORDERED_RESOURCES.findIndex((r) => r === b.itemKey);
-      if (bIndex === -1) bIndex = Infinity;
-      return aIndex < bIndex ? -1 : 1;
-    });
-}
-
-function getInitialWeightingOptions(): WeightingOptions {
-  return {
-    resources: '1000',
-    power: '1',
-    complexity: '0',
-    buildings: '0',
-  };
-}
-
-function getInitialGameModeOptions(): GameModeOptions {
-  return {
-    recipePartsCost: '1',
-    powerConsumption: '1',
-  };
-}
-
-function getInitialTransportOptions(): TransportOptions {
-  return {
-    beltCapacity: null,
-    pipeCapacity: null,
-  };
-}
-
-function getInitialAllowedRecipes(recipes: RecipeMap): RecipeSelectionMap {
-  const recipeMap: RecipeSelectionMap = {};
-  Object.entries(recipes).forEach(([key, data]) => {
-    recipeMap[key] = !data.isAlternate;
-  });
-  return recipeMap;
-}
-
-// Keyed only by buildings that actually produce a recipe (derived from recipes,
-// not gameData.buildings, so generators/extractors/foundations don't appear).
-// Buildings have no "alternates" concept, so every machine starts enabled.
-function getInitialAllowedBuildings(recipes: RecipeMap): BuildingSelectionMap {
-  const buildingMap: BuildingSelectionMap = {};
-  Object.values(recipes).forEach((data) => {
-    buildingMap[data.producedIn] = true;
-  });
-  return buildingMap;
-}
-
-export function getInitialState(gameData: GameData): FactoryOptions {
-  return {
-    key: nanoid(),
-    productionItems: [],
-    inputItems: [],
-    inputResources: getInitialInputResources(gameData.resources),
-    allowHandGatheredItems: false,
-    weightingOptions: getInitialWeightingOptions(),
-    gameModeOptions: getInitialGameModeOptions(),
-    allowedRecipes: getInitialAllowedRecipes(gameData.recipes),
-    allowedBuildings: getInitialAllowedBuildings(gameData.recipes),
-    nodesPositions: [],
-    maximizeBalanceMode: DEFAULT_MAXIMIZE_BALANCE_MODE,
-    transportOptions: getInitialTransportOptions(),
-  };
-}
+// The initial-state builders live in ./defaults so the shared-factory hydrate utility
+// can reuse them without importing the reducer. Re-exported here for the existing
+// consumers (production context, legacy decoders, golden corpus) that import it.
+export { getInitialState };
 
 
 // REDUCER
@@ -310,60 +205,10 @@ export function reducer(state: FactoryOptions, action: FactoryAction): FactoryOp
       return { ...state, allowedBuildings: newAllowedBuildings };
     }
     case 'LOAD_FROM_SHARED_FACTORY': {
-      try {
-        const decoded = decode(action.config as WireFactory);
-        const newState: FactoryOptions = getInitialState(action.gameData);
-        newState.productionItems = decoded.productionItems.map((i) => ({
-          ...getDefaultProductionItem(),
-          itemKey: i.itemKey,
-          mode: i.mode,
-          value: i.value,
-        }));
-        newState.inputItems = decoded.inputItems.map((i) => ({
-          ...getDefaultInputItem(),
-          itemKey: i.itemKey,
-          value: i.value,
-          weight: i.weight,
-          unlimited: i.unlimited,
-        }));
-        newState.inputResources.forEach((r) => {
-          const resourceOptions = decoded.inputResources.find((i) => r.itemKey === i.itemKey);
-          if (resourceOptions) {
-            r.value = resourceOptions.value;
-            r.weight = resourceOptions.weight;
-            r.unlimited = resourceOptions.unlimited;
-          }
-        });
-        newState.allowHandGatheredItems = decoded.allowHandGatheredItems;
-        newState.weightingOptions = decoded.weightingOptions;
-        // gameModeOptions added in 1.2; keep the 1x default for pre-1.2 shared factories that lack it.
-        if (decoded.gameModeOptions) {
-          newState.gameModeOptions = decoded.gameModeOptions;
-        }
-        decoded.allowedRecipes.forEach((key) => {
-          if (newState.allowedRecipes[key] != null) {
-            newState.allowedRecipes[key] = true;
-          }
-        });
-        // allowedBuildings stores the ENABLED set and defaults to all-on, so a
-        // present list is a full overwrite: each known building is on iff it's in
-        // the decoded set. Absent (pre-feature shares) => keep the all-on default.
-        if (decoded.allowedBuildings) {
-          const enabled = new Set(decoded.allowedBuildings);
-          Object.keys(newState.allowedBuildings).forEach((key) => {
-            newState.allowedBuildings[key] = enabled.has(key);
-          });
-        }
-        newState.nodesPositions = decoded.nodesPositions;
-        // maximizeBalanceMode/transportOptions aren't part of the share wire shape;
-        // read them defensively from the raw payload for any client-side persisted config.
-        newState.maximizeBalanceMode = (action.config as any).maximizeBalanceMode ?? DEFAULT_MAXIMIZE_BALANCE_MODE;
-        newState.transportOptions = (action.config as any).transportOptions ?? getInitialTransportOptions();
-        return newState;
-      } catch (e) {
-        console.error(e);
-        return getInitialState(action.gameData);
-      }
+      // The wire -> FactoryOptions transform lives in hydrateSharedFactory so the
+      // receive-side picker can reuse it; this stays a thin delegation. The helper
+      // owns the try/catch fallback to a fresh initial state.
+      return hydrateSharedFactory(action.config as WireFactory, action.gameData);
     }
     case 'LOAD_FROM_LEGACY_ENCODING': {
       try {

--- a/client/src/contexts/production/types.ts
+++ b/client/src/contexts/production/types.ts
@@ -19,6 +19,11 @@ export type GameModeOptions = {
   powerConsumption: string,
 };
 
+export type AmplificationOptions = {
+  availableSloops: string,
+  availableShards: string,
+};
+
 export type InputItemOptions = {
   key: string,
   itemKey: string,
@@ -54,6 +59,7 @@ export type FactoryOptions = {
   allowHandGatheredItems: boolean,
   weightingOptions: WeightingOptions,
   gameModeOptions: GameModeOptions,
+  amplificationOptions: AmplificationOptions,
   allowedRecipes: RecipeSelectionMap,
   allowedBuildings: BuildingSelectionMap,
   nodesPositions: NodeInfo[],

--- a/client/src/theme.ts
+++ b/client/src/theme.ts
@@ -41,6 +41,16 @@ export const graphColors = {
   recipe: { base: `hsl(197, ${baseSat}, ${baseLight})`, selected: `hsl(197, ${selectSat}, ${selectLight})` },
   nuclear: { base: `hsl(50, ${baseSat}, ${baseLight})`, selected: `hsl(50, ${selectSat}, ${selectLight})` },
 
+  // Boost-indicator borders on recipe nodes, echoing the in-game glow: somersloop
+  // amplification is purple, power-shard overclocking is a deep electric blue, both is
+  // a blend. The recipe node fill is a light sky-blue (hsl 197, 63% light), so the
+  // overclock border is pushed toward true blue and darkened to stay legible on it.
+  amplification: {
+    amplified: 'hsl(285, 95%, 60%)',
+    overclocked: 'hsl(224, 100%, 42%)',
+    both: 'hsl(255, 95%, 58%)',
+  },
+
   // edges
   edge: { line: '#999999', label: '#eeeeee' },
   incoming: { line: `hsl(31, ${baseSat}, ${baseLight})`, label: `hsl(31, ${baseSat}, ${baseLight})` },

--- a/client/src/utilities/factory-io/index.test.ts
+++ b/client/src/utilities/factory-io/index.test.ts
@@ -12,6 +12,7 @@ function sampleConfig(itemKey = 'Desc_IronPlate_C'): FactoryOptions {
     allowHandGatheredItems: false,
     weightingOptions: { resources: '1', power: '1', complexity: '1', buildings: '1' },
     gameModeOptions: { recipePartsCost: '0', powerConsumption: '0' },
+    amplificationOptions: { availableSloops: '0', availableShards: '0' },
     allowedRecipes: { Recipe_IronPlate_C: true },
     allowedBuildings: {},
     nodesPositions: [],

--- a/client/src/utilities/production-solver/amp-realdata.test.ts
+++ b/client/src/utilities/production-solver/amp-realdata.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { ProductionSolver } from './index';
+import gameData_1_2 from '../../data/1.2';
+import { getInitialState } from '../../contexts/production/defaults';
+import { GameData } from '../../contexts/gameData/types';
+import { FactoryOptions } from '../../contexts/production/types';
+
+const gd = gameData_1_2 as unknown as GameData;
+
+function baseOptions(): FactoryOptions {
+  const s = getInitialState(gd);
+  s.productionItems = [{ key: 'p1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '100' }];
+  return s;
+}
+
+describe('amplification against real 1.2 game data', () => {
+  it('produces the same plan and zero boost usage with no budget', async () => {
+    const { report, error } = await new ProductionSolver(baseOptions(), gd).exec();
+    expect(error).toBeNull();
+    expect(report!.amplification.sloopsUsed).toBe(0);
+    expect(report!.amplification.shardsUsed).toBe(0);
+  });
+
+  it('amplifies real recipes and respects the somersloop budget', async () => {
+    const opts = baseOptions();
+    opts.amplificationOptions = { availableSloops: '20', availableShards: '0' };
+    const { productionGraph, report, error } = await new ProductionSolver(opts, gd).exec();
+    expect(error).toBeNull();
+    // At least one amplified variant node should appear (real Desc_* producedIn keys resolve).
+    const ampNodes = Object.keys(productionGraph!.nodes).filter((k) => k.includes('::AMP'));
+    expect(ampNodes.length).toBeGreaterThan(0);
+    expect(report!.amplification.sloopsUsed).toBeGreaterThan(0);
+    // Reported usage is the whole-machine requirement (an integer), not the LP's fractional value.
+    expect(Number.isInteger(report!.amplification.sloopsUsed)).toBe(true);
+  });
+
+  it('overclocks real recipes when only shards are available (buildings-weighted)', async () => {
+    const opts = baseOptions();
+    opts.weightingOptions = { resources: '10', power: '1', complexity: '0', buildings: '1000' };
+    opts.amplificationOptions = { availableSloops: '0', availableShards: '30' };
+    const { productionGraph, report, error } = await new ProductionSolver(opts, gd).exec();
+    expect(error).toBeNull();
+    const ocNodes = Object.keys(productionGraph!.nodes).filter((k) => k.includes('::OC'));
+    expect(ocNodes.length).toBeGreaterThan(0);
+    expect(report!.amplification.shardsUsed).toBeGreaterThan(0);
+    // Power shards go into whole machines (3 per overclocked machine), so usage is an integer.
+    expect(Number.isInteger(report!.amplification.shardsUsed)).toBe(true);
+    expect(report!.amplification.shardsUsed % 3).toBe(0);
+  });
+});

--- a/client/src/utilities/production-solver/amplification.test.ts
+++ b/client/src/utilities/production-solver/amplification.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildVariant,
+  getRecipeVariants,
+  sloopSlotsFor,
+  variantKey,
+  parseVariantKey,
+  OC_POWER_MULT,
+} from './amplification';
+
+describe('amplification variant multipliers', () => {
+  it('base variant is a no-op', () => {
+    expect(buildVariant('', 1)).toEqual({ suffix: '', inputMult: 1, outputMult: 1, powerMult: 1, sloops: 0, shards: 0 });
+  });
+
+  it('full amplification: 2x output, 4x power, no extra input, consumes all sloop slots', () => {
+    const v = buildVariant('AMP', 4);
+    expect(v.inputMult).toBe(1);
+    expect(v.outputMult).toBe(2);
+    expect(v.powerMult).toBe(4);
+    expect(v.sloops).toBe(4);
+    expect(v.shards).toBe(0);
+  });
+
+  it('full overclock: 2.5x throughput both sides, ~3.3577x power, consumes 3 shards', () => {
+    const v = buildVariant('OC', 1);
+    expect(v.inputMult).toBe(2.5);
+    expect(v.outputMult).toBe(2.5);
+    expect(v.powerMult).toBeCloseTo(3.3577, 3);
+    expect(v.sloops).toBe(0);
+    expect(v.shards).toBe(3);
+  });
+
+  it('combined amp+oc: 2.5x input, 5x output, ~13.431x power, consumes sloops and shards', () => {
+    const v = buildVariant('AMPOC', 2);
+    expect(v.inputMult).toBe(2.5);
+    expect(v.outputMult).toBe(5);
+    expect(v.powerMult).toBeCloseTo(13.431, 2);
+    expect(v.sloops).toBe(2);
+    expect(v.shards).toBe(3);
+  });
+
+  it('OC_POWER_MULT equals 2.5 raised to log2(2.5)', () => {
+    expect(OC_POWER_MULT).toBeCloseTo(3.3577, 3);
+  });
+});
+
+describe('slot data', () => {
+  it('maps known buildings to their somersloop slot counts', () => {
+    expect(sloopSlotsFor('Desc_SmelterMk1_C')).toBe(1);
+    expect(sloopSlotsFor('Desc_ConstructorMk1_C')).toBe(1);
+    expect(sloopSlotsFor('Desc_AssemblerMk1_C')).toBe(2);
+    expect(sloopSlotsFor('Desc_ManufacturerMk1_C')).toBe(4);
+    expect(sloopSlotsFor('Desc_HadronCollider_C')).toBe(4);
+  });
+
+  it('returns 0 for buildings without sloop slots', () => {
+    expect(sloopSlotsFor('Desc_Packager_C')).toBe(0);
+    expect(sloopSlotsFor('Desc_GeneratorNuclear_C')).toBe(0);
+    expect(sloopSlotsFor('Desc_UnknownBuilding_C')).toBe(0);
+  });
+});
+
+describe('getRecipeVariants gating', () => {
+  const power = 4; // a positive-power consumer
+
+  it('offers only the base variant when both budgets are 0', () => {
+    const variants = getRecipeVariants('Desc_ConstructorMk1_C', power, 0, 0);
+    expect(variants.map((v) => v.suffix)).toEqual(['']);
+  });
+
+  it('adds AMP when sloops are available and the building has slots', () => {
+    const variants = getRecipeVariants('Desc_ConstructorMk1_C', power, 10, 0);
+    expect(variants.map((v) => v.suffix)).toEqual(['', 'AMP']);
+  });
+
+  it('does not add AMP for a building without sloop slots', () => {
+    const variants = getRecipeVariants('Desc_Packager_C', power, 10, 0);
+    expect(variants.map((v) => v.suffix)).toEqual(['']);
+  });
+
+  it('adds OC when shards are available and the building consumes power', () => {
+    const variants = getRecipeVariants('Desc_ConstructorMk1_C', power, 0, 10);
+    expect(variants.map((v) => v.suffix)).toEqual(['', 'OC']);
+  });
+
+  it('does not add OC for a generator (power < 0)', () => {
+    const variants = getRecipeVariants('Desc_GeneratorNuclear_C', -2500, 0, 10);
+    expect(variants.map((v) => v.suffix)).toEqual(['']);
+  });
+
+  it('offers all four variants when both budgets are available', () => {
+    const variants = getRecipeVariants('Desc_ManufacturerMk1_C', power, 10, 10);
+    expect(variants.map((v) => v.suffix)).toEqual(['', 'AMP', 'OC', 'AMPOC']);
+  });
+});
+
+describe('variant key round-trip', () => {
+  it('keeps the bare recipe key for the base variant', () => {
+    expect(variantKey('Recipe_IronPlate_C', '')).toBe('Recipe_IronPlate_C');
+    expect(parseVariantKey('Recipe_IronPlate_C')).toEqual({ baseRecipeKey: 'Recipe_IronPlate_C', suffix: '' });
+  });
+
+  it('suffixes and parses boost variants', () => {
+    const key = variantKey('Recipe_IronPlate_C', 'AMPOC');
+    expect(key).toBe('Recipe_IronPlate_C::AMPOC');
+    expect(parseVariantKey(key)).toEqual({ baseRecipeKey: 'Recipe_IronPlate_C', suffix: 'AMPOC' });
+  });
+});

--- a/client/src/utilities/production-solver/amplification.ts
+++ b/client/src/utilities/production-solver/amplification.ts
@@ -1,0 +1,138 @@
+// Somersloop (production amplification) and Power Shard (overclocking) modeling.
+//
+// The solver expresses each way of running a machine as a distinct "variant" of a
+// recipe, so a linear program can pick among them. A variant's LP variable value is
+// measured in *physical buildings of that variant*, and these multipliers convert it
+// to throughput/power:
+//   - inputMult / outputMult scale the recipe's per-minute ingredient/product rates
+//   - powerMult scales the building's base power draw
+//   - sloops / shards are consumed per building (checked against the global budgets)
+//
+// Game mechanics (Satisfactory 1.0/1.1/1.2, verified against satisfactory.wiki.gg):
+//   - Overclocking: 3 power-shard slots -> up to 250% clock. Throughput scales
+//     LINEARLY (inputs AND outputs); power scales by (clock/100)^1.321928.
+//     Full = 2.5x throughput, 2.5^1.321928 = 3.3577x power.
+//   - Amplification: somersloops boost OUTPUT ONLY (inputs unchanged). Output
+//     x(1 + filled/total), power x(1 + filled/total)^2. Full = 2x output, 4x power.
+//   - They stack multiplicatively: full both = 2.5x input, 5x output, 13.431x power.
+//
+// Slot counts are fixed in vanilla and are NOT present in the game-data JSON (nor
+// carried through ParseDocs), so they live here as hand-maintained constants keyed
+// by building class. Only full-boost variants are modeled (max sloops / 250% clock);
+// partial overclock/amplification tiers are a deliberate future extension.
+//
+// Out of scope: extractor/miner overclocking (raw extraction is not a recipe in the
+// solver) and generators / the Alien Power Augmenter (sloops there feed power, not
+// production).
+
+/** Somersloop slots per building. Buildings not listed have 0 (Packager, generators). */
+export const SLOOP_SLOTS: Record<string, number> = {
+  Desc_SmelterMk1_C: 1,
+  Desc_ConstructorMk1_C: 1,
+  Desc_AssemblerMk1_C: 2,
+  Desc_FoundryMk1_C: 2,
+  Desc_OilRefinery_C: 2,
+  Desc_Converter_C: 2,
+  Desc_ManufacturerMk1_C: 4,
+  Desc_Blender_C: 4,
+  Desc_HadronCollider_C: 4, // Particle Accelerator
+  Desc_QuantumEncoder_C: 4,
+};
+
+/** Power-shard slots on any overclockable production building. */
+export const SHARD_SLOTS = 3;
+
+// Amplification (full: all somersloop slots filled).
+export const AMP_OUTPUT_MULT = 2;
+export const AMP_POWER_MULT = 4; // (1 + 1)^2
+
+// Overclocking (full: 250% clock via 3 shards).
+export const OC_THROUGHPUT_MULT = 2.5;
+export const OC_POWER_EXPONENT = 1.321928; // log2(2.5)
+export const OC_POWER_MULT = OC_THROUGHPUT_MULT ** OC_POWER_EXPONENT; // ~3.3577
+
+export type VariantSuffix = '' | 'AMP' | 'OC' | 'AMPOC';
+
+export type RecipeVariant = {
+  suffix: VariantSuffix,
+  inputMult: number,
+  outputMult: number,
+  powerMult: number,
+  sloops: number, // per building
+  shards: number, // per building
+};
+
+/** Somersloop slots for a building class (0 if it cannot take sloops). */
+export function sloopSlotsFor(buildingKey: string): number {
+  return SLOOP_SLOTS[buildingKey] ?? 0;
+}
+
+/** The full descriptor for a variant suffix, given the building's somersloop slots. */
+export function buildVariant(suffix: VariantSuffix, sloopSlots: number): RecipeVariant {
+  switch (suffix) {
+    case 'AMP':
+      return { suffix, inputMult: 1, outputMult: AMP_OUTPUT_MULT, powerMult: AMP_POWER_MULT, sloops: sloopSlots, shards: 0 };
+    case 'OC':
+      return { suffix, inputMult: OC_THROUGHPUT_MULT, outputMult: OC_THROUGHPUT_MULT, powerMult: OC_POWER_MULT, sloops: 0, shards: SHARD_SLOTS };
+    case 'AMPOC':
+      return {
+        suffix,
+        inputMult: OC_THROUGHPUT_MULT,
+        outputMult: OC_THROUGHPUT_MULT * AMP_OUTPUT_MULT,
+        powerMult: OC_POWER_MULT * AMP_POWER_MULT,
+        sloops: sloopSlots,
+        shards: SHARD_SLOTS,
+      };
+    case '':
+    default:
+      return { suffix: '', inputMult: 1, outputMult: 1, powerMult: 1, sloops: 0, shards: 0 };
+  }
+}
+
+/**
+ * The variants the solver should offer for a recipe produced in `buildingKey`.
+ * Always includes the base variant. Boost variants are gated on both the building
+ * supporting the boost and the corresponding global budget being non-zero, so with
+ * both budgets at 0 the LP is identical to the un-boosted model.
+ */
+export function getRecipeVariants(
+  buildingKey: string,
+  buildingPower: number,
+  availableSloops: number,
+  availableShards: number,
+): RecipeVariant[] {
+  const sloopSlots = sloopSlotsFor(buildingKey);
+  const canAmp = sloopSlots > 0 && availableSloops > 0;
+  // Overclocking only applies to power consumers; generators (power < 0) are out of scope.
+  const canOc = buildingPower > 0 && availableShards > 0;
+
+  const variants: RecipeVariant[] = [buildVariant('', sloopSlots)];
+  if (canAmp) variants.push(buildVariant('AMP', sloopSlots));
+  if (canOc) variants.push(buildVariant('OC', sloopSlots));
+  if (canAmp && canOc) variants.push(buildVariant('AMPOC', sloopSlots));
+  return variants;
+}
+
+/** Short human-readable suffix for a boosted node's name (empty for the base variant). */
+export function variantLabel(suffix: VariantSuffix | undefined): string {
+  switch (suffix) {
+    case 'AMP': return ' (amplified)';
+    case 'OC': return ' (overclocked 250%)';
+    case 'AMPOC': return ' (amplified + OC 250%)';
+    default: return '';
+  }
+}
+
+const VARIANT_SEP = '::';
+
+/** Build the LP variable / graph-node key for a recipe variant. Base variant keeps the bare recipe key. */
+export function variantKey(recipeKey: string, suffix: VariantSuffix): string {
+  return suffix ? `${recipeKey}${VARIANT_SEP}${suffix}` : recipeKey;
+}
+
+/** Split a variant key back into its base recipe key and suffix. */
+export function parseVariantKey(key: string): { baseRecipeKey: string, suffix: VariantSuffix } {
+  const idx = key.indexOf(VARIANT_SEP);
+  if (idx === -1) return { baseRecipeKey: key, suffix: '' };
+  return { baseRecipeKey: key.slice(0, idx), suffix: key.slice(idx + VARIANT_SEP.length) as VariantSuffix };
+}

--- a/client/src/utilities/production-solver/assembleGraph.ts
+++ b/client/src/utilities/production-solver/assembleGraph.ts
@@ -7,6 +7,7 @@ import {
   ProductionSolution,
   getItemPoints,
 } from './internals';
+import { buildVariant, parseVariantKey, sloopSlotsFor } from './amplification';
 
 // Pure assembly of a production graph from a solver solution. Builds recipe nodes,
 // item nodes (final products, side products, inputs, resources), and the edges that
@@ -24,10 +25,15 @@ export function assembleGraph(
   };
 
   for (const [recipeKey, multiplier] of Object.entries(productionSolution)) {
-    const recipeInfo = gameData.recipes[recipeKey];
+    // recipeKey may be a boost-variant key (e.g. "Recipe_X_C::AMP"); resolve to the base
+    // recipe and the variant multipliers. producedBy/usedBy are keyed by the variant key so
+    // each variant is its own graph node, while node.key stays the base recipe for lookups.
+    const { baseRecipeKey, suffix } = parseVariantKey(recipeKey);
+    const recipeInfo = gameData.recipes[baseRecipeKey];
+    const variant = buildVariant(suffix, sloopSlotsFor(recipeInfo.producedIn));
 
     for (const product of recipeInfo.products) {
-      const amount = multiplier * product.perMinute;
+      const amount = multiplier * product.perMinute * variant.outputMult;
       if (!itemProductionTotals[product.itemClass]) {
         itemProductionTotals[product.itemClass] = {
           producedBy: [],
@@ -38,7 +44,7 @@ export function assembleGraph(
     }
 
     for (const ingredient of recipeInfo.ingredients) {
-      const amount = multiplier * ingredient.perMinute;
+      const amount = multiplier * ingredient.perMinute * variant.inputMult;
       if (!itemProductionTotals[ingredient.itemClass]) {
         itemProductionTotals[ingredient.itemClass] = {
           producedBy: [],
@@ -50,9 +56,11 @@ export function assembleGraph(
 
     graph.nodes[recipeKey] = {
       id: recipeKey,
-      key: recipeKey,
+      key: baseRecipeKey,
       type: NODE_TYPE.RECIPE,
       multiplier,
+      // Only boosted nodes carry a suffix; base nodes stay identical to the un-boosted shape.
+      ...(suffix ? { suffix } : {}),
     };
   }
 

--- a/client/src/utilities/production-solver/buildReport.test.ts
+++ b/client/src/utilities/production-solver/buildReport.test.ts
@@ -55,7 +55,7 @@ const inputs: Inputs = {
   'Desc_OreIron_C': { amount: Infinity, weight: 0.5, type: NODE_TYPE.RESOURCE },
 };
 
-const context: ReportContext = { gameData, inputs };
+const context: ReportContext = { gameData, inputs, availableSloops: 0, availableShards: 0 };
 
 // A complete iron-ore -> ingot -> plate chain produced graph.
 //  - Smelter recipe at multiplier 1 (30 ore -> 30 ingot)
@@ -97,7 +97,7 @@ describe('buildReport', () => {
       ...gameData,
       buildings: { ...gameData.buildings, 'Build_SmelterMk1_C': { ...gameData.buildings['Build_SmelterMk1_C'], power: -50 } },
     };
-    const report = buildReport(g, { gameData: gd, inputs });
+    const report = buildReport(g, { gameData: gd, inputs, availableSloops: 0, availableShards: 0 });
     expect(report.powerUsageEstimate.generators).toBeCloseTo(50);
     // production now only the constructor: 1.5 * 4 = 6
     expect(report.powerUsageEstimate.production).toBeCloseTo(6);
@@ -141,7 +141,7 @@ describe('buildReport', () => {
       ...gameData,
       items: { ...gameData.items, 'Desc_IronPlate_C': { ...gameData.items['Desc_IronPlate_C'], isFicsmas: true } },
     };
-    const report = buildReport(makeGraph(), { gameData: gd, inputs });
+    const report = buildReport(makeGraph(), { gameData: gd, inputs, availableSloops: 0, availableShards: 0 });
     expect(report.pointsProduced).toBe(0);
   });
 
@@ -158,7 +158,7 @@ describe('buildReport', () => {
       resources: { ...gameData.resources, 'Desc_Water_C': { itemClass: 'Desc_Water_C', maxExtraction: null, relativeValue: 1 } },
     };
     const waterInputs: Inputs = { 'Desc_Water_C': { amount: Infinity, weight: 1, type: NODE_TYPE.RESOURCE } };
-    const report = buildReport(graph, { gameData: gd, inputs: waterInputs });
+    const report = buildReport(graph, { gameData: gd, inputs: waterInputs, availableSloops: 0, availableShards: 0 });
     // numExtractors = ceil(300/120) = 3; rods = 3 * 10 = 30
     expect(report.buildingsUsed['Desc_WaterPump_C'].count).toBe(3);
     expect(report.buildingsUsed['Desc_WaterPump_C'].materialCost['Desc_IronRod_C']).toBe(30);
@@ -204,7 +204,7 @@ describe('buildReport', () => {
         'B': { slug: 'b', name: 'B', isAlternate: false, ingredients: [], products: [], producedIn: 'Build_SmelterMk1_C', isFicsmas: false },
       },
     };
-    const report = buildReport(graph, { gameData: gd, inputs });
+    const report = buildReport(graph, { gameData: gd, inputs, availableSloops: 0, availableShards: 0 });
     expect(report.loopWarning).toBe(true);
   });
 });

--- a/client/src/utilities/production-solver/buildReport.ts
+++ b/client/src/utilities/production-solver/buildReport.ts
@@ -1,13 +1,14 @@
 import { ItemRate } from '../../contexts/gameData/types';
 import { NODE_TYPE, ProducedItemInformation, ProductionGraph, Report } from './models';
 import { ReportContext, getItemPoints } from './internals';
+import { buildVariant, sloopSlotsFor } from './amplification';
 
 // Pure computation of the production report (power breakdown, build area, foundations,
 // buildings used, material costs, raw resources, items-per-step recap, loop warning)
 // from an assembled production graph. Behavior is identical to the former
 // ProductionSolver.generateProductionReport method.
 export function buildReport(productionGraph: ProductionGraph, context: ReportContext): Report {
-  const { gameData, inputs } = context;
+  const { gameData, inputs, availableSloops, availableShards } = context;
   const report: Report = {
     pointsProduced: 0,
     powerUsageEstimate: {
@@ -23,7 +24,13 @@ export function buildReport(productionGraph: ProductionGraph, context: ReportCon
     totalMaterialCost: {},
     totalRawResources: {},
     totalItemsRecap: [],
-    loopWarning: false
+    loopWarning: false,
+    amplification: {
+      sloopsUsed: 0,
+      sloopsAvailable: availableSloops,
+      shardsUsed: 0,
+      shardsAvailable: availableShards,
+    },
   };
 
   report.totalItemsRecap = generateItemsPerStep(productionGraph, gameData);
@@ -34,10 +41,19 @@ export function buildReport(productionGraph: ProductionGraph, context: ReportCon
       report.totalRawResources[gameData.items[node.key].name] = node.multiplier;
     }
     if (node.type === NODE_TYPE.RECIPE) {
-      const recipeInfo = gameData.recipes[key];
+      // node.key is the base recipe (the map key may be a boost-variant key); the variant
+      // scales power and tallies the somersloops/power shards this node consumes.
+      const recipeInfo = gameData.recipes[node.key];
       const buildingKey = recipeInfo.producedIn;
       const buildingInfo = gameData.buildings[buildingKey];
-      const power = node.multiplier * buildingInfo.power;
+      const variant = buildVariant(node.suffix ?? '', sloopSlotsFor(buildingKey));
+      // Somersloops and power shards are placed in whole machines, so the real requirement
+      // is per-machine slots x the (rounded-up) machine count — never a fraction. This matches
+      // how buildingsUsed.count and material costs round up below.
+      const machineCount = Math.ceil(node.multiplier);
+      report.amplification.sloopsUsed += machineCount * variant.sloops;
+      report.amplification.shardsUsed += machineCount * variant.shards;
+      const power = node.multiplier * buildingInfo.power * variant.powerMult;
       if (power < 0) {
         report.powerUsageEstimate.generators += -power;
       } else {
@@ -147,7 +163,9 @@ function generateItemsPerStep(productionGraph: ProductionGraph, gameData: Report
 
   while (keys.length > 0){
     for (key of keys){
-      const recipe = gameData.recipes[key];
+      // `key` is the node map key, which may be a boost-variant key; the underlying recipe
+      // (same ingredients/products) is found via the node's base recipe key.
+      const recipe = gameData.recipes[nodes[key].key];
       const applicableIngredientsAmount = recipe.ingredients.filter(ingredientKeyFilter).length;
       if (applicableIngredientsAmount === recipe.ingredients.length){
         for (var product of recipe.products){

--- a/client/src/utilities/production-solver/flow-model.ts
+++ b/client/src/utilities/production-solver/flow-model.ts
@@ -1,5 +1,6 @@
 import { GameData } from '../../contexts/gameData/types';
 import { GraphNode, NODE_TYPE, ProductionGraph } from './models';
+import { variantLabel } from './amplification';
 import { describeTransport, formatTransport, TransportCapacities } from './transport';
 
 // An accessible, DOM-friendly view-model of the production graph (issue #92, ADR 0002).
@@ -98,7 +99,7 @@ export function buildFlowModel(
       rows.set(node.id, {
         id: node.id,
         recipeKey: node.key,
-        recipeName: recipe?.name ?? node.key,
+        recipeName: (recipe?.name ?? node.key) + variantLabel(node.suffix),
         buildingKey,
         buildingName: gameData.buildings[buildingKey]?.name ?? buildingKey,
         buildingCount: node.multiplier,

--- a/client/src/utilities/production-solver/goldens/baselines/alt-recipes-enabled.json
+++ b/client/src/utilities/production-solver/goldens/baselines/alt-recipes-enabled.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -615,6 +619,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 85,

--- a/client/src/utilities/production-solver/goldens/baselines/building-disabled-fallback.json
+++ b/client/src/utilities/production-solver/goldens/baselines/building-disabled-fallback.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_FoundryMk1_C": {
           "count": 1,

--- a/client/src/utilities/production-solver/goldens/baselines/complex-ai-expansion-server.json
+++ b/client/src/utilities/production-solver/goldens/baselines/complex-ai-expansion-server.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -1251,6 +1255,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_AssemblerMk1_C": {
           "count": 18,

--- a/client/src/utilities/production-solver/goldens/baselines/eight-targets-iron-capped.json
+++ b/client/src/utilities/production-solver/goldens/baselines/eight-targets-iron-capped.json
@@ -935,6 +935,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_AssemblerMk1_C": {
           "count": 15,

--- a/client/src/utilities/production-solver/goldens/baselines/error-infeasible-resource-starved.json
+++ b/client/src/utilities/production-solver/goldens/baselines/error-infeasible-resource-starved.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,

--- a/client/src/utilities/production-solver/goldens/baselines/error-no-outputs.json
+++ b/client/src/utilities/production-solver/goldens/baselines/error-no-outputs.json
@@ -109,6 +109,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,

--- a/client/src/utilities/production-solver/goldens/baselines/error-target-disabled-recipe.json
+++ b/client/src/utilities/production-solver/goldens/baselines/error-target-disabled-recipe.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,

--- a/client/src/utilities/production-solver/goldens/baselines/error-transport-belt-too-low.json
+++ b/client/src/utilities/production-solver/goldens/baselines/error-transport-belt-too-low.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,

--- a/client/src/utilities/production-solver/goldens/baselines/free-input-item.json
+++ b/client/src/utilities/production-solver/goldens/baselines/free-input-item.json
@@ -124,6 +124,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -503,6 +507,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/fuel-plan-blender-off.json
+++ b/client/src/utilities/production-solver/goldens/baselines/fuel-plan-blender-off.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_OilRefinery_C": {
           "count": 195,

--- a/client/src/utilities/production-solver/goldens/baselines/gamemode-both-multipliers.json
+++ b/client/src/utilities/production-solver/goldens/baselines/gamemode-both-multipliers.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/gamemode-power-half.json
+++ b/client/src/utilities/production-solver/goldens/baselines/gamemode-power-half.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/gamemode-recipeparts-2x.json
+++ b/client/src/utilities/production-solver/goldens/baselines/gamemode-recipeparts-2x.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/hand-gathered-on.json
+++ b/client/src/utilities/production-solver/goldens/baselines/hand-gathered-on.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/inputs-added-modular-frame.json
+++ b/client/src/utilities/production-solver/goldens/baselines/inputs-added-modular-frame.json
@@ -131,6 +131,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -498,6 +502,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_AssemblerMk1_C": {
           "count": 6,

--- a/client/src/utilities/production-solver/goldens/baselines/limited-resource-finite.json
+++ b/client/src/utilities/production-solver/goldens/baselines/limited-resource-finite.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -549,6 +553,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 85,

--- a/client/src/utilities/production-solver/goldens/baselines/maximize-ironplate-single.json
+++ b/client/src/utilities/production-solver/goldens/baselines/maximize-ironplate-single.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -561,6 +565,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3359,

--- a/client/src/utilities/production-solver/goldens/baselines/maximize-wire-single.json
+++ b/client/src/utilities/production-solver/goldens/baselines/maximize-wire-single.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -591,6 +595,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3711,

--- a/client/src/utilities/production-solver/goldens/baselines/multi-maximize-distinct-priority.json
+++ b/client/src/utilities/production-solver/goldens/baselines/multi-maximize-distinct-priority.json
@@ -122,6 +122,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -567,6 +571,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3359,

--- a/client/src/utilities/production-solver/goldens/baselines/multi-maximize-equal.json
+++ b/client/src/utilities/production-solver/goldens/baselines/multi-maximize-equal.json
@@ -122,6 +122,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -591,6 +595,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4668,

--- a/client/src/utilities/production-solver/goldens/baselines/multi-maximize-proportional.json
+++ b/client/src/utilities/production-solver/goldens/baselines/multi-maximize-proportional.json
@@ -122,6 +122,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -591,6 +595,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4996,

--- a/client/src/utilities/production-solver/goldens/baselines/multi-maximize-three-equal.json
+++ b/client/src/utilities/production-solver/goldens/baselines/multi-maximize-three-equal.json
@@ -128,6 +128,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -639,6 +643,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 5978,

--- a/client/src/utilities/production-solver/goldens/baselines/packagedoil-fuel-both-rate.json
+++ b/client/src/utilities/production-solver/goldens/baselines/packagedoil-fuel-both-rate.json
@@ -531,6 +531,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/packagedoil-fuel-complexity-max.json
+++ b/client/src/utilities/production-solver/goldens/baselines/packagedoil-fuel-complexity-max.json
@@ -531,6 +531,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/packagedoil-rate-fuel-maximize.json
+++ b/client/src/utilities/production-solver/goldens/baselines/packagedoil-rate-fuel-maximize.json
@@ -579,6 +579,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/plastic-rubber-recycle-loop.json
+++ b/client/src/utilities/production-solver/goldens/baselines/plastic-rubber-recycle-loop.json
@@ -122,6 +122,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -543,6 +547,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_OilRefinery_C": {
           "count": 5,

--- a/client/src/utilities/production-solver/goldens/baselines/points-target-rate.json
+++ b/client/src/utilities/production-solver/goldens/baselines/points-target-rate.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -1443,6 +1447,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_AssemblerMk1_C": {
           "count": 16,

--- a/client/src/utilities/production-solver/goldens/baselines/rate-cable-chain.json
+++ b/client/src/utilities/production-solver/goldens/baselines/rate-cable-chain.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -495,6 +499,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/rate-concrete-60.json
+++ b/client/src/utilities/production-solver/goldens/baselines/rate-concrete-60.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/rate-ironplate-60.json
+++ b/client/src/utilities/production-solver/goldens/baselines/rate-ironplate-60.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/rate-liquidfuel-60.json
+++ b/client/src/utilities/production-solver/goldens/baselines/rate-liquidfuel-60.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_OilRefinery_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/rate-multi-item.json
+++ b/client/src/utilities/production-solver/goldens/baselines/rate-multi-item.json
@@ -128,6 +128,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -561,6 +565,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 7,

--- a/client/src/utilities/production-solver/goldens/baselines/rate-plastic-30.json
+++ b/client/src/utilities/production-solver/goldens/baselines/rate-plastic-30.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_OilRefinery_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/recipe-target-ironingot-2.json
+++ b/client/src/utilities/production-solver/goldens/baselines/recipe-target-ironingot-2.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/recipe-target-ironplate-3.json
+++ b/client/src/utilities/production-solver/goldens/baselines/recipe-target-ironplate-3.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/transport-belt-120-fits.json
+++ b/client/src/utilities/production-solver/goldens/baselines/transport-belt-120-fits.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/transport-pipe-300-fits.json
+++ b/client/src/utilities/production-solver/goldens/baselines/transport-pipe-300-fits.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_OilRefinery_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/used-recipe-disabled-coated-plate.json
+++ b/client/src/utilities/production-solver/goldens/baselines/used-recipe-disabled-coated-plate.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -519,6 +523,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_AssemblerMk1_C": {
           "count": 1,

--- a/client/src/utilities/production-solver/goldens/baselines/weight-buildings-single-nonzero.json
+++ b/client/src/utilities/production-solver/goldens/baselines/weight-buildings-single-nonzero.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/weight-complexity-nonzero-small.json
+++ b/client/src/utilities/production-solver/goldens/baselines/weight-complexity-nonzero-small.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/weight-complexity-zero-baseline.json
+++ b/client/src/utilities/production-solver/goldens/baselines/weight-complexity-zero-baseline.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/weight-power-priority.json
+++ b/client/src/utilities/production-solver/goldens/baselines/weight-power-priority.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/weight-resources-complexity-swap.json
+++ b/client/src/utilities/production-solver/goldens/baselines/weight-resources-complexity-swap.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmparts2-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmparts2-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmparts2-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmparts2-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmparts2-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmparts2-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -531,6 +535,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 694,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmpowhalf-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmpowhalf-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmpowhalf-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmpowhalf-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 8,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmpowhalf-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmpowhalf-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -561,6 +565,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3359,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmstd-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmstd-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmstd-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmstd-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 8,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmstd-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-lp-gmstd-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -561,6 +565,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3359,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmparts2-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmparts2-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmparts2-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmparts2-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmparts2-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmparts2-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -531,6 +535,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 694,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmpowhalf-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmpowhalf-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmpowhalf-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmpowhalf-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 8,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmpowhalf-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmpowhalf-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -561,6 +565,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3359,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmstd-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmstd-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmstd-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmstd-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 8,

--- a/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmstd-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-max-milp-gmstd-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -561,6 +565,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3359,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmparts2-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmparts2-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmparts2-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmparts2-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 4,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmparts2-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmparts2-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmpowhalf-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmpowhalf-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmpowhalf-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmpowhalf-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmpowhalf-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmpowhalf-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmstd-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmstd-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmstd-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmstd-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmstd-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-lp-gmstd-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmparts2-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmparts2-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmparts2-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmparts2-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmparts2-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmparts2-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmpowhalf-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmpowhalf-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmpowhalf-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmpowhalf-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmpowhalf-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmpowhalf-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmstd-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmstd-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmstd-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmstd-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmstd-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-rate-milp-gmstd-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -483,6 +487,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_ConstructorMk1_C": {
           "count": 3,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmparts2-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmparts2-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmparts2-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmparts2-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmparts2-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmparts2-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmpowhalf-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmpowhalf-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmpowhalf-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmpowhalf-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmpowhalf-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmpowhalf-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmstd-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmstd-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmstd-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmstd-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmstd-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-lp-gmstd-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmparts2-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmparts2-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmparts2-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmparts2-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmparts2-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmparts2-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "2",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmpowhalf-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmpowhalf-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmpowhalf-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmpowhalf-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmpowhalf-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmpowhalf-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "0.5"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmstd-txbelt120.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmstd-txbelt120.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmstd-txbelt240.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmstd-txbelt240.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmstd-txnone.json
+++ b/client/src/utilities/production-solver/goldens/baselines/x-recipe-milp-gmstd-txnone.json
@@ -116,6 +116,10 @@
       "recipePartsCost": "1",
       "powerConsumption": "1"
     },
+    "amplificationOptions": {
+      "availableSloops": "0",
+      "availableShards": "0"
+    },
     "allowedRecipes": {
       "Recipe_AILimiter_C": true,
       "Recipe_AlienDNACapsule_C": true,
@@ -471,6 +475,12 @@
       }
     },
     "report": {
+      "amplification": {
+        "shardsAvailable": 0,
+        "shardsUsed": 0,
+        "sloopsAvailable": 0,
+        "sloopsUsed": 0
+      },
       "buildingsUsed": {
         "Desc_SmelterMk1_C": {
           "count": 2,

--- a/client/src/utilities/production-solver/index.test.ts
+++ b/client/src/utilities/production-solver/index.test.ts
@@ -134,6 +134,10 @@ function createValidOptions(overrides?: Partial<FactoryOptions>): FactoryOptions
       recipePartsCost: '1',
       powerConsumption: '1',
     },
+    amplificationOptions: {
+      availableSloops: '0',
+      availableShards: '0',
+    },
     allowedRecipes: {
       'Recipe_IronIngot_C': true,
       'Recipe_IronPlate_C': true,
@@ -431,6 +435,7 @@ function byproductOptions(): FactoryOptions {
     allowHandGatheredItems: false,
     weightingOptions: { resources: '1', power: '1', complexity: '0', buildings: '0' },
     gameModeOptions: { recipePartsCost: '1', powerConsumption: '1' },
+    amplificationOptions: { availableSloops: '0', availableShards: '0' },
     allowedRecipes: { 'Recipe_Package_C': true, 'Recipe_Fuel_C': true },
     allowedBuildings: { 'Build_Refinery_C': true },
     nodesPositions: [],
@@ -624,5 +629,95 @@ describe('ProductionSolver belt/pipe capacity (issue #130)', () => {
     expect(error).not.toBeNull();
     expect(error!.message).toBe('BELT/PIPE CAPACITY TOO LOW');
     expect(error!.helpText).toMatch(/belt 60\/min/);
+  });
+});
+
+describe('ProductionSolver amplification (somersloops / power shards)', () => {
+  // A single amplifiable recipe (Constructor has 1 somersloop slot). Iron ingot is a bounded
+  // raw input so the resource weight rewards amplification (2x output for the same input).
+  const ampGameData: GameData = {
+    buildings: {
+      'Desc_ConstructorMk1_C': { slug: 'constructor', name: 'Constructor', power: 4, area: 100, buildCost: [], isFicsmas: false },
+      // Iron ingot is modeled as a raw resource here; buildReport attributes its extraction to a miner.
+      'Desc_MinerMk3_C': { slug: 'miner_mk3', name: 'Miner Mk.3', power: 110, area: 100, buildCost: [], isFicsmas: false },
+    },
+    recipes: {
+      'Recipe_IronPlate_C': {
+        slug: 'iron_plate',
+        name: 'Iron Plate',
+        isAlternate: false,
+        ingredients: [{ itemClass: 'Desc_IronIngot_C', perMinute: 30 }],
+        products: [{ itemClass: 'Desc_IronPlate_C', perMinute: 20 }],
+        producedIn: 'Desc_ConstructorMk1_C',
+        isFicsmas: false,
+      },
+    },
+    resources: {
+      'Desc_IronIngot_C': { itemClass: 'Desc_IronIngot_C', maxExtraction: 100000, relativeValue: 1 },
+    },
+    items: {
+      'Desc_IronIngot_C': { slug: 'iron_ingot', name: 'Iron Ingot', sinkPoints: 2, isFluid: false, usedInRecipes: ['Recipe_IronPlate_C'], producedFromRecipes: [], isFicsmas: false },
+      'Desc_IronPlate_C': { slug: 'iron_plate', name: 'Iron Plate', sinkPoints: 6, isFluid: false, usedInRecipes: [], producedFromRecipes: ['Recipe_IronPlate_C'], isFicsmas: false },
+    },
+    handGatheredItems: {},
+  };
+
+  function ampOptions(overrides?: Partial<FactoryOptions>): FactoryOptions {
+    return {
+      key: 'amp',
+      productionItems: [{ key: 'p1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '20' }],
+      inputItems: [],
+      inputResources: [{ key: 'Desc_IronIngot_C', itemKey: 'Desc_IronIngot_C', value: '1000', weight: '1', unlimited: false }],
+      allowHandGatheredItems: false,
+      weightingOptions: { resources: '1000', power: '1', complexity: '0', buildings: '0' },
+      gameModeOptions: { recipePartsCost: '1', powerConsumption: '1' },
+      amplificationOptions: { availableSloops: '0', availableShards: '0' },
+      allowedRecipes: { 'Recipe_IronPlate_C': true },
+      allowedBuildings: { 'Desc_ConstructorMk1_C': true },
+      nodesPositions: [],
+      maximizeBalanceMode: 'proportional',
+      transportOptions: { beltCapacity: null, pipeCapacity: null },
+      ...overrides,
+    };
+  }
+
+  it('runs the base recipe and reports no boost usage when no sloops are available', async () => {
+    const { productionGraph, report, error } = await new ProductionSolver(ampOptions(), ampGameData).exec();
+    expect(error).toBeNull();
+    // Base variant only: the bare recipe key exists, no ::AMP node.
+    expect(productionGraph!.nodes['Recipe_IronPlate_C']).toBeDefined();
+    expect(productionGraph!.nodes['Recipe_IronPlate_C::AMP']).toBeUndefined();
+    // 20 plates/min needs 1 base constructor consuming 30 ingots/min.
+    expect(report!.amplification.sloopsUsed).toBe(0);
+    expect(productionGraph!.nodes['Desc_IronIngot_C'].multiplier).toBeCloseTo(30, 4);
+  });
+
+  it('amplifies to halve input use when sloops are available', async () => {
+    const options = ampOptions({ amplificationOptions: { availableSloops: '106', availableShards: '0' } });
+    const { productionGraph, report, error } = await new ProductionSolver(options, ampGameData).exec();
+    expect(error).toBeNull();
+    // Solver switches to the amplified variant: 0.5 amplified constructors make 20 plates
+    // from just 15 ingots (2x output, same input), using 0.5 somersloops.
+    const ampNode = productionGraph!.nodes['Recipe_IronPlate_C::AMP'];
+    expect(ampNode).toBeDefined();
+    expect(ampNode.suffix).toBe('AMP');
+    expect(ampNode.multiplier).toBeCloseTo(0.5, 4);
+    expect(productionGraph!.nodes['Desc_IronIngot_C'].multiplier).toBeCloseTo(15, 4);
+    // Somersloops go into whole machines: 0.5 amplified constructors round up to 1 physical
+    // machine, whose single slot needs 1 whole somersloop (not the fractional 0.5).
+    expect(report!.amplification.sloopsUsed).toBe(1);
+    expect(Number.isInteger(report!.amplification.sloopsUsed)).toBe(true);
+    expect(report!.amplification.sloopsAvailable).toBe(106);
+  });
+
+  it('reports somersloop usage as whole machines, rounding each machine up', async () => {
+    // The LP allocates fractional amplified machines, but a real build needs whole machines
+    // with every slot filled — so usage is always an integer (regression for issue: report
+    // showed 4.833 sloops when the real requirement was 6).
+    const options = ampOptions({ amplificationOptions: { availableSloops: '106', availableShards: '0' } });
+    const { report, error } = await new ProductionSolver(options, ampGameData).exec();
+    expect(error).toBeNull();
+    expect(report!.amplification.sloopsUsed).toBeGreaterThan(0);
+    expect(Number.isInteger(report!.amplification.sloopsUsed)).toBe(true);
   });
 });

--- a/client/src/utilities/production-solver/index.ts
+++ b/client/src/utilities/production-solver/index.ts
@@ -21,6 +21,14 @@ import {
 } from './internals';
 import { assembleGraph } from './assembleGraph';
 import { buildReport } from './buildReport';
+import {
+  RecipeVariant,
+  getRecipeVariants,
+  buildVariant,
+  sloopSlotsFor,
+  variantKey,
+  parseVariantKey,
+} from './amplification';
 
 export {
   NODE_TYPE,
@@ -98,6 +106,12 @@ export class ProductionSolver {
   private maximizeBalanceMode: MaximizeBalanceMode;
   private beltCapacity: number | null;
   private pipeCapacity: number | null;
+  // Somersloop / power-shard budgets, and the boost variants each allowed recipe may run.
+  // With both budgets 0 every recipe maps to a single base variant, so the LP is identical
+  // to the un-boosted model.
+  private availableSloops: number;
+  private availableShards: number;
+  private variantsByRecipe: Map<string, RecipeVariant[]>;
 
   public constructor(options: FactoryOptions, gameData: GameData) {
     // Apply 1.2 Game Mode cost multipliers (default 1 = no scaling, e.g. for 1.1 or default mode).
@@ -115,6 +129,11 @@ export class ProductionSolver {
     const rawPipe = options.transportOptions?.pipeCapacity;
     const parsedPipe = rawPipe != null ? Number(rawPipe) : NaN;
     this.pipeCapacity = !Number.isNaN(parsedPipe) && parsedPipe > 0 ? parsedPipe : null;
+
+    this.availableSloops = options.amplificationOptions ? Number(options.amplificationOptions.availableSloops) : 0;
+    this.availableShards = options.amplificationOptions ? Number(options.amplificationOptions.availableShards) : 0;
+    this.validateNumber(this.availableSloops);
+    this.validateNumber(this.availableShards);
 
     const allowedRecipes = options.allowedRecipes;
     // allowedBuildings may be absent on state restored from very old session storage;
@@ -305,6 +324,26 @@ export class ProductionSolver {
     if (Object.keys(this.rateTargets).length === 0 && this.maximizeTargets.length === 0) {
       throw new GraphError('NO OUTPUTS SET', 'Open the control panel to get started.');
     }
+
+    // Precompute the boost variants offered per allowed recipe. Recipes pinned as a
+    // recipe-mode production target keep a fixed building count, so they stay base-only —
+    // boosting them would contradict the user's explicit "run N of this recipe" intent and
+    // muddy the recipe-target graph edge that routes their output.
+    const recipeTargetKeys = new Set(Object.keys(recipeTargets));
+    this.variantsByRecipe = new Map();
+    for (const [recipeKey, allowed] of Object.entries(this.effectiveAllowedRecipes)) {
+      if (!allowed) continue;
+      const recipeInfo = this.gameData.recipes[recipeKey];
+      const buildingInfo = this.gameData.buildings[recipeInfo.producedIn];
+      const variants = recipeTargetKeys.has(recipeKey)
+        ? [buildVariant('', 0)]
+        : getRecipeVariants(recipeInfo.producedIn, buildingInfo.power, this.availableSloops, this.availableShards);
+      this.variantsByRecipe.set(recipeKey, variants);
+    }
+  }
+
+  private variantsFor(recipeKey: string): RecipeVariant[] {
+    return this.variantsByRecipe.get(recipeKey) ?? [buildVariant('', 0)];
   }
 
   private validateNumber(num: number) {
@@ -431,7 +470,12 @@ export class ProductionSolver {
       if (Object.keys(productionGraph.nodes).length === 0) {
         throw new GraphError('SOLUTION IS EMPTY', 'For some reason the solution for your parameters is an empty factory. Double check that your factory settings make sense.');
       }
-      const report = buildReport(productionGraph, { gameData: this.gameData, inputs: this.inputs });
+      const report = buildReport(productionGraph, {
+        gameData: this.gameData,
+        inputs: this.inputs,
+        availableSloops: this.availableSloops,
+        availableShards: this.availableShards,
+      });
 
       return {
         productionGraph,
@@ -457,14 +501,16 @@ export class ProductionSolver {
   // feed a final product back into the factory to be re-consumed.
   private surplusByproducts(solution: ProductionSolution): Inputs {
     const net: { [key: string]: number } = {};
-    for (const [recipeKey, multiplier] of Object.entries(solution)) {
-      const recipeInfo = this.gameData.recipes[recipeKey];
+    for (const [key, multiplier] of Object.entries(solution)) {
+      const { baseRecipeKey, suffix } = parseVariantKey(key);
+      const recipeInfo = this.gameData.recipes[baseRecipeKey];
       if (!recipeInfo) continue;
+      const variant = buildVariant(suffix, sloopSlotsFor(recipeInfo.producedIn));
       for (const product of recipeInfo.products) {
-        net[product.itemClass] = (net[product.itemClass] ?? 0) + multiplier * product.perMinute;
+        net[product.itemClass] = (net[product.itemClass] ?? 0) + multiplier * product.perMinute * variant.outputMult;
       }
       for (const ingredient of recipeInfo.ingredients) {
-        net[ingredient.itemClass] = (net[ingredient.itemClass] ?? 0) - multiplier * ingredient.perMinute;
+        net[ingredient.itemClass] = (net[ingredient.itemClass] ?? 0) - multiplier * ingredient.perMinute * variant.inputMult;
       }
     }
     const surplus: Inputs = {};
@@ -510,67 +556,78 @@ export class ProductionSolver {
     for (const [recipeKey, recipeInfo] of Object.entries(this.gameData.recipes)) {
       if (!this.effectiveAllowedRecipes[recipeKey]) continue;
       const buildingInfo = this.gameData.buildings[recipeInfo.producedIn];
-      const powerScore = buildingInfo.power > 0 ? buildingInfo.power * this.globalWeights.power : 0;
-      const buildingsScore = this.globalWeights.buildings;
-      let resourceScore = 0;
 
-      for (const ingredient of recipeInfo.ingredients) {
-        const inputInfo = this.inputs[ingredient.itemClass];
-        if (inputInfo) {
-          resourceScore += inputInfo.weight * ingredient.perMinute * this.globalWeights.resources;
-        }
-      }
+      // Each recipe expands into one LP variable per boost variant (base + amplified /
+      // overclocked / both). A variant's value is measured in physical buildings of that
+      // variant; the variant multipliers scale throughput and power accordingly.
+      for (const variant of this.variantsFor(recipeKey)) {
+        const vKey = variantKey(recipeKey, variant.suffix);
 
+        // Overclocking (variant.powerMult) raises consumer power super-linearly; amplification
+        // (also folded into powerMult) squares it. Generators (power < 0) never get boost variants.
+        const powerScore = buildingInfo.power > 0 ? buildingInfo.power * variant.powerMult * this.globalWeights.power : 0;
+        const buildingsScore = this.globalWeights.buildings;
+        let resourceScore = 0;
 
-      const recipeObjVar: Var = {
-        name: recipeKey,
-        coef: powerScore + resourceScore + buildingsScore,
-      };
-      model.objective.vars.push(recipeObjVar);
-      objectiveVarMap.set(recipeKey, recipeObjVar);
-
-      if (this.beltCapacity !== null || this.pipeCapacity !== null) {
-        for (const product of recipeInfo.products) {
-          if (!this.allowedItems[product.itemClass] || product.perMinute <= 0) continue;
-          const isFluid = this.gameData.items[product.itemClass]?.isFluid ?? false;
-          const capacity = isFluid ? this.pipeCapacity : this.beltCapacity;
-          if (capacity !== null) {
-            // Tighten the cap by output already allocated to this recipe in prior passes, so the
-            // cumulative total across all summed passes stays within a single belt/pipe (issue #130).
-            const priorMultiplier = priorSolution?.[recipeKey] ?? 0;
-            const ub = Math.max(0, capacity - priorMultiplier * product.perMinute);
-            model.subjectTo.push({
-              name: `${recipeKey}_${product.itemClass}_capacity`,
-              vars: [{ name: recipeKey, coef: product.perMinute }],
-              bnds: { type: glpk.GLP_UP, ub, lb: NaN },
-            });
-          }
-        }
-      }
-
-      if (isRateTargetPass) {
-        if (this.rateTargets[recipeKey]) {
-          model.subjectTo.push({
-            name: `${recipeKey} recipe constraint`,
-            vars: [{ name: recipeKey, coef: 1 }],
-            bnds: { type: glpk.GLP_LO, ub: 0, lb: this.rateTargets[recipeKey].value },
-          });
-        }
-      }
-
-      if (doPoints) {
-        let pointCoef = 0;
-        for (const product of recipeInfo.products) {
-          if (!this.inputs[product.itemClass] || this.inputs[product.itemClass].type === NODE_TYPE.INPUT_ITEM) {
-            pointCoef -= product.perMinute * getItemPoints(this.gameData, product.itemClass) / 1000;
-          }
-        }
         for (const ingredient of recipeInfo.ingredients) {
-          if (!this.inputs[ingredient.itemClass] || this.inputs[ingredient.itemClass].type === NODE_TYPE.INPUT_ITEM) {
-            pointCoef += ingredient.perMinute * getItemPoints(this.gameData, ingredient.itemClass) / 1000;
+          const inputInfo = this.inputs[ingredient.itemClass];
+          if (inputInfo) {
+            // Amplification leaves inputs unchanged (inputMult 1); overclocking scales them.
+            resourceScore += inputInfo.weight * ingredient.perMinute * variant.inputMult * this.globalWeights.resources;
           }
         }
-        pointsVars.push({ name: recipeKey, coef: pointCoef });
+
+        const recipeObjVar: Var = {
+          name: vKey,
+          coef: powerScore + resourceScore + buildingsScore,
+        };
+        model.objective.vars.push(recipeObjVar);
+        objectiveVarMap.set(vKey, recipeObjVar);
+
+        if (this.beltCapacity !== null || this.pipeCapacity !== null) {
+          for (const product of recipeInfo.products) {
+            if (!this.allowedItems[product.itemClass] || product.perMinute <= 0) continue;
+            const isFluid = this.gameData.items[product.itemClass]?.isFluid ?? false;
+            const capacity = isFluid ? this.pipeCapacity : this.beltCapacity;
+            if (capacity !== null) {
+              const perMin = product.perMinute * variant.outputMult;
+              // Tighten the cap by output already allocated to this variant in prior passes, so the
+              // cumulative total across all summed passes stays within a single belt/pipe (issue #130).
+              const priorMultiplier = priorSolution?.[vKey] ?? 0;
+              const ub = Math.max(0, capacity - priorMultiplier * perMin);
+              model.subjectTo.push({
+                name: `${vKey}_${product.itemClass}_capacity`,
+                vars: [{ name: vKey, coef: perMin }],
+                bnds: { type: glpk.GLP_UP, ub, lb: NaN },
+              });
+            }
+          }
+        }
+
+        if (doPoints) {
+          let pointCoef = 0;
+          for (const product of recipeInfo.products) {
+            if (!this.inputs[product.itemClass] || this.inputs[product.itemClass].type === NODE_TYPE.INPUT_ITEM) {
+              pointCoef -= product.perMinute * variant.outputMult * getItemPoints(this.gameData, product.itemClass) / 1000;
+            }
+          }
+          for (const ingredient of recipeInfo.ingredients) {
+            if (!this.inputs[ingredient.itemClass] || this.inputs[ingredient.itemClass].type === NODE_TYPE.INPUT_ITEM) {
+              pointCoef += ingredient.perMinute * variant.inputMult * getItemPoints(this.gameData, ingredient.itemClass) / 1000;
+            }
+          }
+          pointsVars.push({ name: vKey, coef: pointCoef });
+        }
+      }
+
+      // Recipe-mode targets pin a building count. These recipes are base-only (see
+      // variantsByRecipe), so the sum below is a single variable in practice.
+      if (isRateTargetPass && this.rateTargets[recipeKey]) {
+        model.subjectTo.push({
+          name: `${recipeKey} recipe constraint`,
+          vars: this.variantsFor(recipeKey).map((variant) => ({ name: variantKey(recipeKey, variant.suffix), coef: 1 })),
+          bnds: { type: glpk.GLP_LO, ub: 0, lb: this.rateTargets[recipeKey].value },
+        });
       }
     }
 
@@ -616,31 +673,41 @@ export class ProductionSolver {
       const binKey = `${itemKey}_BIN`;
       const binVars: Var[] = [];
 
+      // Consumption: each variant consumes inputs scaled by inputMult (amplification = 1,
+      // overclock = 2.5). One LP variable per variant, keyed by its suffixed name.
       for (const recipeKey of itemInfo.usedInRecipes) {
         if (!this.effectiveAllowedRecipes[recipeKey]) continue;
         const recipeInfo = this.gameData.recipes[recipeKey];
         const target = recipeInfo.ingredients.find((i) => i.itemClass === itemKey)!;
-        const v: Var = { name: recipeKey, coef: target.perMinute };
-        vars.push(v);
-        varsMap.set(recipeKey, v);
+        for (const variant of this.variantsFor(recipeKey)) {
+          const vKey = variantKey(recipeKey, variant.suffix);
+          const v: Var = { name: vKey, coef: target.perMinute * variant.inputMult };
+          vars.push(v);
+          varsMap.set(vKey, v);
 
-        if (!this.gameData.handGatheredItems[itemKey]) {
-          binVars.push({ name: recipeKey, coef: -1 });
+          if (!this.gameData.handGatheredItems[itemKey]) {
+            binVars.push({ name: vKey, coef: -1 });
+          }
         }
       }
 
+      // Production: each variant produces outputs scaled by outputMult (amplification = 2,
+      // overclock = 2.5, both = 5).
       for (const recipeKey of itemInfo.producedFromRecipes) {
         if (!this.effectiveAllowedRecipes[recipeKey]) continue;
         const recipeInfo = this.gameData.recipes[recipeKey];
         const target = recipeInfo.products.find((p) => p.itemClass === itemKey)!;
-
-        const existingVar = varsMap.get(recipeKey);
-        if (existingVar) {
-          existingVar.coef -= target.perMinute;
-        } else {
-          const v: Var = { name: recipeKey, coef: -target.perMinute };
-          vars.push(v);
-          varsMap.set(recipeKey, v);
+        for (const variant of this.variantsFor(recipeKey)) {
+          const vKey = variantKey(recipeKey, variant.suffix);
+          const produced = target.perMinute * variant.outputMult;
+          const existingVar = varsMap.get(vKey);
+          if (existingVar) {
+            existingVar.coef -= produced;
+          } else {
+            const v: Var = { name: vKey, coef: -produced };
+            vars.push(v);
+            varsMap.set(vKey, v);
+          }
         }
       }
 
@@ -706,6 +773,42 @@ export class ProductionSolver {
           name: `${itemKey} intermediates constraint`,
           vars,
           bnds: { type: glpk.GLP_UP, ub: 0, lb: NaN },
+        });
+      }
+    }
+
+    // Global somersloop / power-shard budgets: the total slots consumed across every boost
+    // variant may not exceed what the user has available. This is a continuous relaxation —
+    // fractional buildings consume fractional slots — so the reported usage should be rounded
+    // up when built in-game. Only added when the corresponding budget is set (and thus boost
+    // variants exist), so the un-boosted model gains no constraints.
+    if (this.availableSloops > 0) {
+      const sloopVars: Var[] = [];
+      for (const [recipeKey, variants] of this.variantsByRecipe) {
+        for (const variant of variants) {
+          if (variant.sloops > 0) sloopVars.push({ name: variantKey(recipeKey, variant.suffix), coef: variant.sloops });
+        }
+      }
+      if (sloopVars.length > 0) {
+        model.subjectTo.push({
+          name: 'somersloop budget',
+          vars: sloopVars,
+          bnds: { type: glpk.GLP_UP, ub: this.availableSloops, lb: NaN },
+        });
+      }
+    }
+    if (this.availableShards > 0) {
+      const shardVars: Var[] = [];
+      for (const [recipeKey, variants] of this.variantsByRecipe) {
+        for (const variant of variants) {
+          if (variant.shards > 0) shardVars.push({ name: variantKey(recipeKey, variant.suffix), coef: variant.shards });
+        }
+      }
+      if (shardVars.length > 0) {
+        model.subjectTo.push({
+          name: 'power shard budget',
+          vars: shardVars,
+          bnds: { type: glpk.GLP_UP, ub: this.availableShards, lb: NaN },
         });
       }
     }
@@ -780,7 +883,9 @@ export class ProductionSolver {
     const result: ProductionSolution = {};
     Object.entries(solution.result.vars).forEach(([key, val]) => {
       if (val > cullThreshold) {
-        if (this.gameData.recipes[key]) {
+        // Keep the variant key intact (assembleGraph/buildReport re-derive the boost from it),
+        // but validate against the underlying base recipe so binary/budget vars are dropped.
+        if (this.gameData.recipes[parseVariantKey(key).baseRecipeKey]) {
           result[key] = val;
         }
       }

--- a/client/src/utilities/production-solver/internals.ts
+++ b/client/src/utilities/production-solver/internals.ts
@@ -58,4 +58,7 @@ export type GraphContext = {
 export type ReportContext = {
   gameData: GameData,
   inputs: Inputs,
+  // Somersloop / power-shard budgets the user made available (0 when unused).
+  availableSloops: number,
+  availableShards: number,
 };

--- a/client/src/utilities/production-solver/models.ts
+++ b/client/src/utilities/production-solver/models.ts
@@ -1,4 +1,5 @@
 import { GraphError } from '../error/GraphError';
+import { VariantSuffix } from './amplification';
 
 export const NODE_TYPE = {
   FINAL_PRODUCT: 'FINAL_PRODUCT',
@@ -45,6 +46,14 @@ export type Report = {
   },
   totalItemsRecap: ProducedItemInformation[],
   loopWarning: boolean,
+  // Somersloop / power-shard consumption and budgets. usage is a continuous relaxation
+  // (fractional buildings use fractional slots) so round up when building in-game.
+  amplification: {
+    sloopsUsed: number,
+    sloopsAvailable: number,
+    shardsUsed: number,
+    shardsAvailable: number,
+  },
 }
 
 export type GraphNode = {
@@ -52,6 +61,8 @@ export type GraphNode = {
   key: string,
   type: string,
   multiplier: number,
+  // Boost variant for RECIPE nodes: '' base, 'AMP' amplified, 'OC' overclocked, 'AMPOC' both.
+  suffix?: VariantSuffix,
 };
 
 export type GraphEdge = {

--- a/client/src/utilities/shared-factory/codec.test.ts
+++ b/client/src/utilities/shared-factory/codec.test.ts
@@ -20,6 +20,7 @@ function sampleConfig(): FactoryOptions {
     allowHandGatheredItems: true,
     weightingOptions: { resources: '1000', power: '1', complexity: '0', buildings: '0' },
     gameModeOptions: { recipePartsCost: '1', powerConsumption: '1' },
+    amplificationOptions: { availableSloops: '10', availableShards: '15' },
     allowedRecipes: {
       Recipe_IronIngot_C: true,
       Recipe_IronPlate_C: true,
@@ -65,6 +66,7 @@ describe('encode', () => {
     expect(wire.productionItems[0]).toEqual({ itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: 20 });
     expect(typeof wire.weightingOptions.resources).toBe('number');
     expect(wire.gameModeOptions).toEqual({ recipePartsCost: 1, powerConsumption: 1 });
+    expect(wire.amplificationOptions).toEqual({ availableSloops: 10, availableShards: 15 });
     // only enabled recipes survive the flatten
     expect(wire.allowedRecipes).toEqual(['Recipe_IronIngot_C', 'Recipe_IronPlate_C']);
     // allowedBuildings flattens the same way: only the enabled set is stored
@@ -85,6 +87,25 @@ describe('decode', () => {
     delete wire.gameModeOptions;
     const decoded = decode(wire as WireFactory);
     expect(decoded.gameModeOptions).toBeNull();
+  });
+
+  it('encodes a config missing amplificationOptions as no-boost (old library factories)', () => {
+    const config = sampleConfig();
+    delete (config as Partial<FactoryOptions>).amplificationOptions;
+    const wire = encode(config, '1.2');
+    expect(wire.amplificationOptions).toEqual({ availableSloops: 0, availableShards: 0 });
+  });
+
+  it('coerces amplificationOptions numbers back to strings', () => {
+    const decoded = decode(encode(sampleConfig(), '1.2'));
+    expect(decoded.amplificationOptions).toEqual({ availableSloops: '10', availableShards: '15' });
+  });
+
+  it('yields null amplificationOptions when the wire payload omits them (older/server-stripped share)', () => {
+    const wire = encode(sampleConfig(), '1.2') as Partial<WireFactory>;
+    delete wire.amplificationOptions;
+    const decoded = decode(wire as WireFactory);
+    expect(decoded.amplificationOptions).toBeNull();
   });
 
   it('yields null allowedBuildings when the wire payload omits them (pre-feature share)', () => {
@@ -115,6 +136,7 @@ describe('round-trip decode(encode(x))', () => {
     expect(decoded.allowHandGatheredItems).toBe(true);
     expect(decoded.weightingOptions).toEqual(config.weightingOptions);
     expect(decoded.gameModeOptions).toEqual(config.gameModeOptions);
+    expect(decoded.amplificationOptions).toEqual(config.amplificationOptions);
     // allowedRecipes is map -> filtered list on encode; decode yields the enabled keys
     expect(decoded.allowedRecipes).toEqual(['Recipe_IronIngot_C', 'Recipe_IronPlate_C']);
     expect(decoded.allowedBuildings).toEqual(['Build_SmelterMk1_C', 'Build_ConstructorMk1_C']);

--- a/client/src/utilities/shared-factory/codec.ts
+++ b/client/src/utilities/shared-factory/codec.ts
@@ -4,6 +4,7 @@ import {
   InputItemOptions,
   WeightingOptions,
   GameModeOptions,
+  AmplificationOptions,
   NodeInfo,
 } from '../../contexts/production/types';
 
@@ -84,6 +85,11 @@ export type WireGameModeOptions = {
   powerConsumption: number,
 };
 
+export type WireAmplificationOptions = {
+  availableSloops: number,
+  availableShards: number,
+};
+
 export type WireFactory = {
   gameVersion: string,
   productionItems: WireProductionItem[],
@@ -92,6 +98,10 @@ export type WireFactory = {
   allowHandGatheredItems: boolean,
   weightingOptions: WireWeightingOptions,
   gameModeOptions: WireGameModeOptions,
+  /** Somersloop/power-shard budgets. Added after 1.2; absent on older shares (= 0/0).
+   *  NOTE: not yet declared on the server FactoryConfigSchema, so it is dropped on
+   *  persisted `?factory=` shares; it round-trips only for client-side configs. */
+  amplificationOptions?: WireAmplificationOptions,
   allowedRecipes: string[],
   /** Enabled building keys. Added after 1.2; absent on older shares (= all enabled). */
   allowedBuildings?: string[],
@@ -107,6 +117,8 @@ export type DecodedFactory = {
   weightingOptions: WeightingOptions,
   /** Present only when the wire payload included game-mode options (added in 1.2). */
   gameModeOptions: GameModeOptions | null,
+  /** Present only when the wire payload included amplification options; null on older shares (= 0/0). */
+  amplificationOptions: AmplificationOptions | null,
   /** Recipe keys that should be marked allowed. */
   allowedRecipes: string[],
   /** Enabled building keys, or null when the share predates building selection (= all enabled). */
@@ -160,6 +172,12 @@ export function encode(config: FactoryOptions, gameVersion: string): WireFactory
       recipePartsCost: Number(config.gameModeOptions.recipePartsCost),
       powerConsumption: Number(config.gameModeOptions.powerConsumption),
     },
+    // Optional-chained: library factories saved before this field existed (and older
+    // persisted configs) lack amplificationOptions; encode them as no-boost rather than throw.
+    amplificationOptions: {
+      availableSloops: Number(config.amplificationOptions?.availableSloops ?? 0),
+      availableShards: Number(config.amplificationOptions?.availableShards ?? 0),
+    },
     allowedRecipes: Object.keys(config.allowedRecipes).filter((key) => config.allowedRecipes[key]),
     allowedBuildings: Object.keys(config.allowedBuildings).filter((key) => config.allowedBuildings[key]),
     nodesPositions: config.nodesPositions,
@@ -199,6 +217,14 @@ export function decode(wire: WireFactory): DecodedFactory {
       ? {
           recipePartsCost: String(wire.gameModeOptions.recipePartsCost),
           powerConsumption: String(wire.gameModeOptions.powerConsumption),
+        }
+      : null,
+    // amplificationOptions added after 1.2; older shares (and server-persisted shares
+    // that drop it) lack it => null = no boost budget.
+    amplificationOptions: wire.amplificationOptions
+      ? {
+          availableSloops: String(wire.amplificationOptions.availableSloops),
+          availableShards: String(wire.amplificationOptions.availableShards),
         }
       : null,
     allowedRecipes: wire.allowedRecipes,

--- a/client/src/utilities/shared-factory/hydrate.test.ts
+++ b/client/src/utilities/shared-factory/hydrate.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { hydrateSharedFactory } from './hydrate';
+import { encode } from './codec';
+import { FactoryOptions } from '../../contexts/production/types';
+import { GameData } from '../../contexts/gameData/types';
+
+// Minimal game data fixture (mirrors reducer.test.ts) so hydrate can build a fresh
+// initial state and map the decoded payload onto it.
+const mockGameData: GameData = {
+  buildings: {
+    Build_ConstructorMk1_C: { slug: 'constructor', name: 'Constructor', power: 4, area: 100, buildCost: [], isFicsmas: false },
+    Build_SmelterMk1_C: { slug: 'smelter', name: 'Smelter', power: 4, area: 54, buildCost: [], isFicsmas: false },
+  },
+  recipes: {
+    Recipe_IronIngot_C: { slug: 'iron_ingot', name: 'Iron Ingot', isAlternate: false, ingredients: [{ itemClass: 'Desc_OreIron_C', perMinute: 30 }], products: [{ itemClass: 'Desc_IronIngot_C', perMinute: 30 }], producedIn: 'Build_SmelterMk1_C', isFicsmas: false },
+    Recipe_IronPlate_C: { slug: 'iron_plate', name: 'Iron Plate', isAlternate: false, ingredients: [{ itemClass: 'Desc_IronIngot_C', perMinute: 30 }], products: [{ itemClass: 'Desc_IronPlate_C', perMinute: 20 }], producedIn: 'Build_ConstructorMk1_C', isFicsmas: false },
+    Recipe_AlternateIronPlate_C: { slug: 'alt_iron_plate', name: 'Alternate Iron Plate', isAlternate: true, ingredients: [{ itemClass: 'Desc_IronIngot_C', perMinute: 20 }], products: [{ itemClass: 'Desc_IronPlate_C', perMinute: 25 }], producedIn: 'Build_ConstructorMk1_C', isFicsmas: false },
+  },
+  resources: {
+    Desc_OreIron_C: { itemClass: 'Desc_OreIron_C', maxExtraction: 70380, relativeValue: 1 },
+    Desc_OreCopper_C: { itemClass: 'Desc_OreCopper_C', maxExtraction: 28860, relativeValue: 2 },
+    Desc_Water_C: { itemClass: 'Desc_Water_C', maxExtraction: null, relativeValue: 0 },
+  },
+  items: {
+    Desc_OreIron_C: { slug: 'iron_ore', name: 'Iron Ore', sinkPoints: 1, isFluid: false, usedInRecipes: [], producedFromRecipes: [], isFicsmas: false },
+    Desc_IronIngot_C: { slug: 'iron_ingot', name: 'Iron Ingot', sinkPoints: 2, isFluid: false, usedInRecipes: [], producedFromRecipes: [], isFicsmas: false },
+    Desc_IronPlate_C: { slug: 'iron_plate', name: 'Iron Plate', sinkPoints: 6, isFluid: false, usedInRecipes: [], producedFromRecipes: [], isFicsmas: false },
+  },
+  handGatheredItems: {},
+};
+
+function sampleConfig(): FactoryOptions {
+  return {
+    key: 'test-key',
+    productionItems: [
+      { key: 'p1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '20' },
+      { key: 'p2', itemKey: 'Desc_IronIngot_C', mode: 'maximize', value: '5' },
+    ],
+    inputItems: [
+      { key: 'i1', itemKey: 'Desc_IronIngot_C', value: '100', weight: '0', unlimited: false },
+    ],
+    inputResources: [
+      { key: 'r1', itemKey: 'Desc_OreIron_C', value: '5000', weight: '1', unlimited: false },
+      { key: 'r2', itemKey: 'Desc_OreCopper_C', value: '2000', weight: '2', unlimited: false },
+      { key: 'r3', itemKey: 'Desc_Water_C', value: '0', weight: '0', unlimited: true },
+    ],
+    allowHandGatheredItems: true,
+    weightingOptions: { resources: '500', power: '10', complexity: '5', buildings: '3' },
+    gameModeOptions: { recipePartsCost: '1', powerConsumption: '1' },
+    allowedRecipes: {
+      Recipe_IronIngot_C: true,
+      Recipe_IronPlate_C: true,
+      Recipe_AlternateIronPlate_C: false,
+    },
+    allowedBuildings: {
+      Build_SmelterMk1_C: true,
+      Build_ConstructorMk1_C: false,
+    },
+    nodesPositions: [{ key: 'node1', x: 10, y: 20 }],
+    maximizeBalanceMode: 'TRUE_MAXIMIZE' as any,
+    transportOptions: { beltCapacity: null, pipeCapacity: null },
+  };
+}
+
+describe('hydrateSharedFactory', () => {
+  it('round-trips encode -> wire -> hydrate for the meaningful fields', () => {
+    const config = sampleConfig();
+    const wire = encode(config, '1.2');
+    const result = hydrateSharedFactory(wire, mockGameData);
+
+    expect(result.productionItems).toHaveLength(2);
+    expect(result.productionItems[0]).toMatchObject({ itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '20' });
+    expect(result.productionItems[1]).toMatchObject({ itemKey: 'Desc_IronIngot_C', mode: 'maximize', value: '5' });
+
+    expect(result.inputItems).toHaveLength(1);
+    expect(result.inputItems[0]).toMatchObject({ itemKey: 'Desc_IronIngot_C', value: '100', weight: '0', unlimited: false });
+
+    const iron = result.inputResources.find((r) => r.itemKey === 'Desc_OreIron_C')!;
+    expect(iron.value).toBe('5000');
+    expect(iron.weight).toBe('1');
+
+    expect(result.allowHandGatheredItems).toBe(true);
+    expect(result.weightingOptions).toEqual(config.weightingOptions);
+    expect(result.gameModeOptions).toEqual(config.gameModeOptions);
+
+    expect(result.allowedRecipes.Recipe_IronIngot_C).toBe(true);
+    expect(result.allowedRecipes.Recipe_IronPlate_C).toBe(true);
+    // alternate stays off (encode drops it; hydrate only flips listed keys on)
+    expect(result.allowedRecipes.Recipe_AlternateIronPlate_C).toBe(false);
+
+    // allowedBuildings is a full overwrite from the enabled set
+    expect(result.allowedBuildings.Build_SmelterMk1_C).toBe(true);
+    expect(result.allowedBuildings.Build_ConstructorMk1_C).toBe(false);
+
+    expect(result.nodesPositions).toEqual(config.nodesPositions);
+  });
+
+  it('leaves all buildings enabled when the wire omits allowedBuildings (pre-feature share)', () => {
+    const wire = encode(sampleConfig(), '1.2') as any;
+    delete wire.allowedBuildings;
+    const result = hydrateSharedFactory(wire, mockGameData);
+    expect(result.allowedBuildings.Build_SmelterMk1_C).toBe(true);
+    expect(result.allowedBuildings.Build_ConstructorMk1_C).toBe(true);
+  });
+
+  it('falls back to a fresh initial state on a malformed payload', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = hydrateSharedFactory(null as any, mockGameData);
+    expect(result.productionItems).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/client/src/utilities/shared-factory/hydrate.test.ts
+++ b/client/src/utilities/shared-factory/hydrate.test.ts
@@ -47,6 +47,7 @@ function sampleConfig(): FactoryOptions {
     allowHandGatheredItems: true,
     weightingOptions: { resources: '500', power: '10', complexity: '5', buildings: '3' },
     gameModeOptions: { recipePartsCost: '1', powerConsumption: '1' },
+    amplificationOptions: { availableSloops: '2', availableShards: '4' },
     allowedRecipes: {
       Recipe_IronIngot_C: true,
       Recipe_IronPlate_C: true,
@@ -82,6 +83,7 @@ describe('hydrateSharedFactory', () => {
     expect(result.allowHandGatheredItems).toBe(true);
     expect(result.weightingOptions).toEqual(config.weightingOptions);
     expect(result.gameModeOptions).toEqual(config.gameModeOptions);
+    expect(result.amplificationOptions).toEqual(config.amplificationOptions);
 
     expect(result.allowedRecipes.Recipe_IronIngot_C).toBe(true);
     expect(result.allowedRecipes.Recipe_IronPlate_C).toBe(true);

--- a/client/src/utilities/shared-factory/hydrate.ts
+++ b/client/src/utilities/shared-factory/hydrate.ts
@@ -1,0 +1,73 @@
+import { FactoryOptions } from '../../contexts/production/types';
+import { GameData } from '../../contexts/gameData/types';
+import { DEFAULT_MAXIMIZE_BALANCE_MODE } from '../../contexts/production/consts';
+import {
+  getInitialState,
+  getDefaultProductionItem,
+  getDefaultInputItem,
+  getInitialTransportOptions,
+} from '../../contexts/production/defaults';
+import { decode, WireFactory } from './codec';
+
+// The wire -> FactoryOptions transform for an incoming shared factory. This was
+// inline in the reducer's LOAD_FROM_SHARED_FACTORY case; it now lives here so the
+// receive-side (single URL share AND multi-share picker) can hydrate a payload
+// without going through the active-factory reducer. The reducer delegates to this,
+// so behavior — including the try/catch that falls back to a fresh initial state —
+// is identical. Round-trip stability is asserted by hydrate.test.ts.
+export function hydrateSharedFactory(wire: WireFactory, gameData: GameData): FactoryOptions {
+  try {
+    const decoded = decode(wire);
+    const newState: FactoryOptions = getInitialState(gameData);
+    newState.productionItems = decoded.productionItems.map((i) => ({
+      ...getDefaultProductionItem(),
+      itemKey: i.itemKey,
+      mode: i.mode,
+      value: i.value,
+    }));
+    newState.inputItems = decoded.inputItems.map((i) => ({
+      ...getDefaultInputItem(),
+      itemKey: i.itemKey,
+      value: i.value,
+      weight: i.weight,
+      unlimited: i.unlimited,
+    }));
+    newState.inputResources.forEach((r) => {
+      const resourceOptions = decoded.inputResources.find((i) => r.itemKey === i.itemKey);
+      if (resourceOptions) {
+        r.value = resourceOptions.value;
+        r.weight = resourceOptions.weight;
+        r.unlimited = resourceOptions.unlimited;
+      }
+    });
+    newState.allowHandGatheredItems = decoded.allowHandGatheredItems;
+    newState.weightingOptions = decoded.weightingOptions;
+    // gameModeOptions added in 1.2; keep the 1x default for pre-1.2 shared factories that lack it.
+    if (decoded.gameModeOptions) {
+      newState.gameModeOptions = decoded.gameModeOptions;
+    }
+    decoded.allowedRecipes.forEach((key) => {
+      if (newState.allowedRecipes[key] != null) {
+        newState.allowedRecipes[key] = true;
+      }
+    });
+    // allowedBuildings stores the ENABLED set and defaults to all-on, so a
+    // present list is a full overwrite: each known building is on iff it's in
+    // the decoded set. Absent (pre-feature shares) => keep the all-on default.
+    if (decoded.allowedBuildings) {
+      const enabled = new Set(decoded.allowedBuildings);
+      Object.keys(newState.allowedBuildings).forEach((key) => {
+        newState.allowedBuildings[key] = enabled.has(key);
+      });
+    }
+    newState.nodesPositions = decoded.nodesPositions;
+    // maximizeBalanceMode/transportOptions aren't part of the share wire shape;
+    // read them defensively from the raw payload for any client-side persisted config.
+    newState.maximizeBalanceMode = (wire as any).maximizeBalanceMode ?? DEFAULT_MAXIMIZE_BALANCE_MODE;
+    newState.transportOptions = (wire as any).transportOptions ?? getInitialTransportOptions();
+    return newState;
+  } catch (e) {
+    console.error(e);
+    return getInitialState(gameData);
+  }
+}

--- a/client/src/utilities/shared-factory/hydrate.ts
+++ b/client/src/utilities/shared-factory/hydrate.ts
@@ -46,6 +46,10 @@ export function hydrateSharedFactory(wire: WireFactory, gameData: GameData): Fac
     if (decoded.gameModeOptions) {
       newState.gameModeOptions = decoded.gameModeOptions;
     }
+    // amplificationOptions added after 1.2; keep the 0/0 default when absent.
+    if (decoded.amplificationOptions) {
+      newState.amplificationOptions = decoded.amplificationOptions;
+    }
     decoded.allowedRecipes.forEach((key) => {
       if (newState.allowedRecipes[key] != null) {
         newState.allowedRecipes[key] = true;

--- a/client/src/utilities/shared-factory/share-url.test.ts
+++ b/client/src/utilities/shared-factory/share-url.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { buildShareUrl, parseShareKeys, MAX_SHARE_FACTORIES } from './share-url';
+
+const origin = () => `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+
+describe('buildShareUrl', () => {
+  it('builds a single-key link with no comma (unchanged single-share link)', () => {
+    expect(buildShareUrl(['abc123'])).toBe(`${origin()}?factory=abc123`);
+  });
+
+  it('comma-joins multiple keys, unencoded', () => {
+    expect(buildShareUrl(['a', 'b', 'c'])).toBe(`${origin()}?factory=a,b,c`);
+  });
+
+  it('does not truncate at the cap — the cap is enforced by callers', () => {
+    const keys = Array.from({ length: MAX_SHARE_FACTORIES + 10 }, (_, i) => `k${i}`);
+    const url = buildShareUrl(keys);
+    expect(url.endsWith(`?factory=${keys.join(',')}`)).toBe(true);
+  });
+});
+
+describe('parseShareKeys', () => {
+  it('returns [] for null/empty', () => {
+    expect(parseShareKeys(null)).toEqual([]);
+    expect(parseShareKeys('')).toEqual([]);
+  });
+
+  it('returns a single key for a comma-less param', () => {
+    expect(parseShareKeys('abc123')).toEqual(['abc123']);
+  });
+
+  it('splits on comma', () => {
+    expect(parseShareKeys('a,b,c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('trims whitespace and drops empty segments', () => {
+    expect(parseShareKeys(' a , b ,,c, ')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('round-trips through buildShareUrl for many keys', () => {
+    const keys = Array.from({ length: 60 }, (_, i) => `k${i}`);
+    const param = buildShareUrl(keys).split('?factory=')[1];
+    expect(parseShareKeys(param)).toEqual(keys);
+  });
+});
+
+describe('MAX_SHARE_FACTORIES', () => {
+  it('is 50', () => {
+    expect(MAX_SHARE_FACTORIES).toBe(50);
+  });
+});

--- a/client/src/utilities/shared-factory/share-url.ts
+++ b/client/src/utilities/shared-factory/share-url.ts
@@ -1,0 +1,31 @@
+import { SHARE_QUERY_PARAM } from '../../contexts/gameData/consts';
+
+// The most factories a single share link carries. Enforced on BOTH ends: the send
+// side (ShareMultipleModal) caps selection, and the receive side (gameData) caps how
+// many keys it fetches — extras past the cap surface as unresolved rows.
+export const MAX_SHARE_FACTORIES = 50;
+
+// Disabled-row reason shown when a factory can't be included because the selection
+// (send) or the incoming set (receive) is already at the cap. Derived from the cap so
+// the two stay in sync.
+export const OVER_CAP_REASON = `Over the ${MAX_SHARE_FACTORIES}-factory limit`;
+
+// Build the shareable URL for one or more factory keys. Keys are comma-joined
+// UNENCODED (share keys are 16 lowercase hex chars, so they need no escaping and a
+// raw comma keeps the link short). A single key yields `?factory=<key>` with no
+// comma, so the existing single-share link is byte-for-byte unchanged.
+export function buildShareUrl(keys: string[]): string {
+  const value = keys.join(',');
+  return `${window.location.protocol}//${window.location.host}${window.location.pathname}?${SHARE_QUERY_PARAM}=${value}`;
+}
+
+// Parse the `?factory=` value into a list of keys. Splits on comma, trims each, and
+// drops empties (so a trailing comma or stray whitespace never yields a blank key).
+// Returns [] for a null/empty param. The single-key link (no comma) yields one key.
+export function parseShareKeys(param: string | null): string[] {
+  if (!param) return [];
+  return param
+    .split(',')
+    .map((k) => k.trim())
+    .filter((k) => k.length > 0);
+}

--- a/client/tests/a11y.spec.ts
+++ b/client/tests/a11y.spec.ts
@@ -142,7 +142,8 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
     await page.getByRole('button', { name: 'Close Control Panel' }).click();
 
     // Clicking Share posts the factory and opens the "Link copied!" popover.
-    await page.getByRole('button', { name: 'Share' }).click();
+    // (exact: the multi-share split control also renders a "More share options" button.)
+    await page.getByRole('button', { name: 'Share', exact: true }).click();
     await expect(page.getByText('Link copied!')).toBeVisible();
 
     const results = await buildScan(page).analyze();
@@ -201,6 +202,31 @@ test.describe('Accessibility (WCAG 2.0 A/AA) scans', () => {
 
     // Switch to the Report tab
     await page.getByRole('tab', { name: 'Report' }).click();
+
+    const results = await buildScan(page).analyze();
+
+    expect(results.violations).toEqual([]);
+  });
+
+  test('Report tab with an amplification budget has no WCAG A/AA violations', async ({ page }) => {
+    await page.goto('/');
+
+    await page.getByRole('button', { name: 'Open Control Panel' }).click();
+    await page.getByRole('button', { name: '+ Add Product' }).click();
+    await page.getByPlaceholder('Select an item').click();
+    await page.getByRole('option', { name: 'Iron Plate', exact: true }).click();
+
+    // Set budgets so the Report tab renders the Amplification stat cards (only shown
+    // when a somersloop/power-shard budget is available).
+    await page.getByRole('spinbutton', { name: 'Somersloops' }).fill('20');
+    await page.getByRole('spinbutton', { name: 'Power Shards' }).fill('30');
+    await page.waitForTimeout(1000);
+
+    await page.getByRole('button', { name: 'Close Control Panel' }).click();
+    await page.getByRole('tab', { name: 'Report' }).click();
+
+    // Confirm the new cards actually rendered before scanning them.
+    await expect(page.getByRole('heading', { name: 'Amplification' })).toBeVisible();
 
     const results = await buildScan(page).analyze();
 

--- a/client/tests/factory-library.spec.ts
+++ b/client/tests/factory-library.spec.ts
@@ -222,7 +222,7 @@ test.describe('Multi-factory library', () => {
     await gotoApp(page);
 
     // Empty factory → Share disabled (firing it would 400).
-    const shareBtn = page.getByRole('button', { name: 'Share' });
+    const shareBtn = page.getByRole('button', { name: 'Share', exact: true });
     await expect(shareBtn).toBeDisabled();
 
     // Add a product → Share becomes enabled.

--- a/client/tests/main.spec.ts
+++ b/client/tests/main.spec.ts
@@ -282,7 +282,7 @@ test.describe('Factory Planner Application', () => {
     // The Share control now lives in the body FactorySwitcher; close the drawer so
     // it isn't overlapped. With a product selected it must be enabled.
     await page.getByRole('button', { name: 'Close Control Panel' }).click();
-    const shareBtn = page.getByRole('button', { name: 'Share' });
+    const shareBtn = page.getByRole('button', { name: 'Share', exact: true });
     await expect(shareBtn).toBeVisible();
     await expect(shareBtn).toBeEnabled();
   });
@@ -315,7 +315,7 @@ test.describe('Factory Planner Application', () => {
 
     // Share moved to the body FactorySwitcher; close the drawer so it isn't overlapped.
     await page.getByRole('button', { name: 'Close Control Panel' }).click();
-    await page.getByRole('button', { name: 'Share' }).click();
+    await page.getByRole('button', { name: 'Share', exact: true }).click();
 
     await expect.poll(() => sharedBody).not.toBeNull();
     expect(sharedBody.factoryConfig.gameModeOptions).toEqual({
@@ -358,5 +358,33 @@ test.describe('Factory Planner Application', () => {
     // The dropdowns should reflect the saved multipliers, not the defaults.
     await expect(page.getByRole('combobox', { name: 'Recipe Cost Multiplier' })).toHaveValue('0.5x');
     await expect(page.getByRole('combobox', { name: 'Power Multiplier' })).toHaveValue('2x');
+  });
+
+  test('applies a somersloop budget and reports the boost usage', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Open Control Panel' }).click();
+
+    // A production goal is required for the solver to run.
+    await page.getByRole('button', { name: '+ Add Product' }).click();
+    await page.getByPlaceholder('Select an item').click();
+    await page.getByRole('option', { name: 'Iron Plate', exact: true }).click();
+
+    // Give the solver a somersloop budget (section gated to 1.2, the default version).
+    // With the default resource-dominant weighting, amplifying halves the ore a step
+    // consumes, so the solver should spend sloops.
+    const sloopsInput = page.getByRole('spinbutton', { name: 'Somersloops' });
+    await sloopsInput.fill('20');
+    await page.waitForTimeout(700); // let the debounced auto-solve run
+
+    // Read the plan on the Report tab.
+    await page.getByRole('button', { name: 'Close Control Panel' }).click();
+    await page.getByRole('tab', { name: 'Report' }).click();
+
+    // The Amplification section and its cards appear only when a budget is set.
+    await expect(page.getByRole('heading', { name: 'Amplification' })).toBeVisible();
+    const sloopCard = page.getByText('Somersloops Used', { exact: true }).locator('..');
+    await expect(sloopCard).toContainText('/ 20');
+    // Usage must be > 0 — the solver actually amplified (not just rendered the card).
+    await expect(sloopCard).not.toContainText('0 / 20');
   });
 });

--- a/client/tests/share-cold-start.spec.ts
+++ b/client/tests/share-cold-start.spec.ts
@@ -30,7 +30,7 @@ async function addProductAndReachShare(page: Page) {
   await page.getByRole('option', { name: 'Iron Plate', exact: true }).click();
   // Share lives in the body FactorySwitcher — close the drawer so it isn't overlapped.
   await page.getByRole('button', { name: 'Close Control Panel' }).click();
-  await expect(page.getByRole('button', { name: 'Share' })).toBeEnabled();
+  await expect(page.getByRole('button', { name: 'Share', exact: true })).toBeEnabled();
 }
 
 test.describe('Share on a cold-started server (#182)', () => {
@@ -62,7 +62,7 @@ test.describe('Share on a cold-started server (#182)', () => {
     await routeColdStartShare(page, 3000);
     await addProductAndReachShare(page);
 
-    await page.getByRole('button', { name: 'Share' }).click();
+    await page.getByRole('button', { name: 'Share', exact: true }).click();
 
     // While the cold POST is in flight the popover must read "Generating…", never "copied".
     await expect(page.getByText('Generating…')).toBeVisible();
@@ -93,7 +93,7 @@ test.describe('Share on a cold-started server (#182)', () => {
     await routeColdStartShare(page, 1500);
     await addProductAndReachShare(page);
 
-    await page.getByRole('button', { name: 'Share' }).click();
+    await page.getByRole('button', { name: 'Share', exact: true }).click();
 
     // The failure copy appears and the link is offered in a read-only field, never a
     // false "Link copied!".

--- a/client/tests/share-multiple.spec.ts
+++ b/client/tests/share-multiple.spec.ts
@@ -1,0 +1,533 @@
+import { test, expect, Page } from '@playwright/test';
+import AxeBuilder from '@axe-core/playwright';
+
+// E2E for the "share multiple factories" feature: one link carries several library
+// factories (`?factory=k1,k2,…`) and the recipient picks which to import. The whole
+// feature is client-side; the existing POST /share-factory and GET
+// /shared-factories/{key} endpoints are reused and mocked here exactly like the
+// single-share specs (anchored routes so Vite's own module requests aren't swallowed).
+
+const FACTORY_TAB = '[role="tab"][title*="edited"]';
+const LOADING = 'Loading game data...';
+
+// ---- App bootstrap ---------------------------------------------------------
+
+async function gotoApp(page: Page, url = '/') {
+  await page.goto(url);
+  await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible({ timeout: 30_000 });
+}
+
+async function openControlPanel(page: Page) {
+  await page.getByRole('button', { name: 'Open Control Panel' }).click();
+  await page.getByRole('tab', { name: 'Production', exact: true }).click();
+}
+
+// ---- Library seeding -------------------------------------------------------
+
+// A complete FactoryOptions with one selected product, so canShareFactory() is true
+// and encode() (run client-side before the POST) has every field it reads.
+function shareableConfig(itemKey = 'Desc_IronPlate_C', value = '10') {
+  return {
+    key: 'seedcfg',
+    productionItems: [{ key: 'p1', itemKey, mode: 'per-minute', value }],
+    inputItems: [],
+    inputResources: [],
+    allowHandGatheredItems: false,
+    weightingOptions: { resources: '1000', power: '1', complexity: '0', buildings: '0' },
+    gameModeOptions: { recipePartsCost: '1', powerConsumption: '1' },
+    allowedRecipes: {},
+    allowedBuildings: {},
+    nodesPositions: [],
+    maximizeBalanceMode: 'proportional',
+    transportOptions: { beltCapacity: null, pipeCapacity: null },
+  };
+}
+
+// A config with a placeholder (no item selected) row → not shareable.
+function emptyProductsConfig() {
+  const c = shareableConfig();
+  c.productionItems = [{ key: 'p1', itemKey: '', mode: 'per-minute', value: '0' }];
+  return c;
+}
+
+type Seed = { id: string; nickname?: string; config?: any; gameVersion?: string; createdAt?: number };
+
+// Write a `factory-library` map + active pointer directly, mirroring the shape in
+// contexts/library/storage.ts (a LibraryMap keyed by id). Order in the UI is
+// createdAt asc, so callers pass increasing createdAt.
+async function seedLibrary(page: Page, seeds: Seed[], activeId: string) {
+  const now = Date.now();
+  const library: Record<string, any> = {};
+  seeds.forEach((s, i) => {
+    library[s.id] = {
+      id: s.id,
+      nickname: s.nickname,
+      gameVersion: s.gameVersion ?? '1.2',
+      config: s.config,
+      createdAt: s.createdAt ?? now + i,
+      updatedAt: s.createdAt ?? now + i,
+    };
+  });
+  await page.addInitScript(
+    ([lib, active]) => {
+      window.localStorage.setItem('factory-library', JSON.stringify(lib));
+      window.sessionStorage.setItem('active-factory-id', active as string);
+    },
+    [library, activeId] as const,
+  );
+}
+
+// ---- Network mocks ---------------------------------------------------------
+
+// Stub POST /share-factory with a fresh unique key per call; returns the array the
+// route fills so a test can count calls and know the issued keys.
+function mockSharePost(page: Page): string[] {
+  const postedKeys: string[] = [];
+  page.route(/\/share-factory$/, async (route) => {
+    const key = `sharekey${String(postedKeys.length).padStart(8, '0')}`;
+    postedKeys.push(key);
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: { key } }),
+    });
+  });
+  return postedKeys;
+}
+
+// As above, but the first call 500s (partial-failure exercise). Returns the keys
+// that were actually issued (the successes).
+function mockSharePostWithOneFailure(page: Page): string[] {
+  const postedKeys: string[] = [];
+  let seen = 0;
+  page.route(/\/share-factory$/, async (route) => {
+    const i = seen++;
+    if (i === 0) {
+      await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'boom' }) });
+      return;
+    }
+    const key = `sharekey${String(postedKeys.length).padStart(8, '0')}`;
+    postedKeys.push(key);
+    await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ data: { key } }) });
+  });
+  return postedKeys;
+}
+
+type WireSpec = { version?: string; itemKey?: string; value?: number };
+
+function wireFactory({ version = 'V1_2', itemKey = 'Desc_IronPlate_C', value = 10 }: WireSpec = {}) {
+  return {
+    gameVersion: version,
+    productionItems: [{ itemKey, mode: 'per-minute', value }],
+    inputItems: [],
+    inputResources: [],
+    allowHandGatheredItems: false,
+    weightingOptions: { resources: 1000, power: 1, complexity: 0, buildings: 0 },
+    gameModeOptions: { recipePartsCost: 1, powerConsumption: 1 },
+    allowedRecipes: [],
+    nodesPositions: [],
+  };
+}
+
+// Mock GET /shared-factories/{key}. `resolve(key)` returns a WireSpec for a live
+// key, or null for a dead one (404). Anchored to `//host/…/shared-factories/{key}`
+// so it never swallows Vite's own useGetSharedFactory.ts module request.
+function mockSharedGet(page: Page, resolve: (key: string) => WireSpec | null) {
+  return page.route(/\/\/[^/]+\/(?:api\/)?shared-factories\/([^/?#]+)/, async (route) => {
+    const m = route.request().url().match(/shared-factories\/([^/?#]+)/);
+    const key = m ? m[1] : '';
+    const spec = resolve(key);
+    if (!spec) {
+      await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ error: 'not found' }) });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ data: { factory_config: wireFactory(spec) } }),
+    });
+  });
+}
+
+// ---- UI helpers ------------------------------------------------------------
+
+// Open the Share split-button dropdown → "Share multiple…" and return the modal.
+async function openShareMultiple(page: Page) {
+  await page.getByRole('button', { name: 'More share options' }).click();
+  await page.getByRole('menuitem', { name: 'Share multiple…' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Share factories' });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+// axe scan scoped to a single dialog (WCAG 2.0 A/AA), mirroring a11y.spec.ts. The
+// `color-contrast` rule is dropped here: the row list (FactorySelectList, extracted
+// verbatim from LibraryManagerModal) renders its meta/reason as Mantine's `dimmed`
+// token (#868e96), which sits at ~3.15:1 on the light modal surface — a pre-existing
+// app-wide token issue, not something these dialogs introduce. Every other structural
+// WCAG rule (roles, names, labels, aria) still runs, which is what this asserts.
+async function scanDialog(page: Page) {
+  return new AxeBuilder({ page })
+    .withTags(['wcag2a', 'wcag2aa'])
+    .include('[role="dialog"]')
+    .disableRules(['color-contrast'])
+    .analyze();
+}
+
+test.describe('Share multiple — send', () => {
+  test.beforeEach(async ({ page }) => {
+    // Drawer closed so the FactorySwitcher (which hosts the Share split button) is reachable.
+    await page.addInitScript(() => sessionStorage.setItem('drawer-open', '"false"'));
+  });
+
+  test('lists all library factories and disables un-shareable slots', async ({ page }) => {
+    await seedLibrary(
+      page,
+      [
+        { id: 'a', nickname: 'Alpha Base', config: shareableConfig() },
+        { id: 'b', nickname: 'Beta Base', config: shareableConfig('Desc_IronRod_C', '20') },
+        { id: 'c', nickname: 'Never Edited' }, // config undefined
+        { id: 'd', nickname: 'No Products', config: emptyProductsConfig() },
+      ],
+      'c',
+    );
+    await gotoApp(page);
+    const dialog = await openShareMultiple(page);
+
+    // Every library factory is a row.
+    await expect(dialog.getByRole('checkbox', { name: /Alpha Base/ })).toBeEnabled();
+    await expect(dialog.getByRole('checkbox', { name: /Beta Base/ })).toBeEnabled();
+
+    // A never-edited (empty) slot and a no-products slot are both disabled with the reason.
+    await expect(dialog.getByRole('checkbox', { name: /Never Edited/ })).toBeDisabled();
+    await expect(dialog.getByRole('checkbox', { name: /No Products/ })).toBeDisabled();
+    await expect(dialog.getByText('No products to share').first()).toBeVisible();
+  });
+
+  test('shares 2 selected factories → 2 POSTs and a 2-key link', async ({ page, context, browserName }) => {
+    if (browserName === 'chromium') await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const postedKeys = mockSharePost(page);
+
+    await seedLibrary(
+      page,
+      [
+        { id: 'a', nickname: 'Alpha Base', config: shareableConfig() },
+        { id: 'b', nickname: 'Beta Base', config: shareableConfig('Desc_IronRod_C', '20') },
+      ],
+      'a',
+    );
+    await gotoApp(page);
+    const dialog = await openShareMultiple(page);
+
+    await dialog.getByRole('checkbox', { name: /Alpha Base/ }).check();
+    await dialog.getByRole('checkbox', { name: /Beta Base/ }).check();
+    await dialog.getByRole('button', { name: 'Share 2 selected' }).click();
+
+    await expect(dialog.getByText('Link copied!')).toBeVisible({ timeout: 15_000 });
+    expect(postedKeys).toHaveLength(2);
+
+    if (browserName === 'chromium') {
+      const link = await page.evaluate(() => navigator.clipboard.readText());
+      expect(link).toContain('?factory=');
+      const value = new URL(link).searchParams.get('factory') ?? '';
+      expect(value.split(',')).toHaveLength(2);
+      for (const k of postedKeys) expect(value).toContain(k);
+    }
+  });
+
+  test('Select all over a mixed library shares only the shareable ones', async ({ page, context, browserName }) => {
+    if (browserName === 'chromium') await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const postedKeys = mockSharePost(page);
+    await seedLibrary(
+      page,
+      [
+        { id: 'a', nickname: 'Alpha Base', config: shareableConfig() },
+        { id: 'b', nickname: 'Never Edited' },
+        { id: 'c', nickname: 'Gamma Base', config: shareableConfig('Desc_IronRod_C', '20') },
+        { id: 'd', nickname: 'No Products', config: emptyProductsConfig() },
+      ],
+      'a',
+    );
+    await gotoApp(page);
+    const dialog = await openShareMultiple(page);
+
+    await dialog.getByRole('button', { name: 'Select all' }).click();
+    // Only the two shareable rows become checked.
+    await expect(dialog.getByRole('checkbox', { checked: true })).toHaveCount(2);
+    await dialog.getByRole('button', { name: 'Share 2 selected' }).click();
+
+    await expect(dialog.getByText('Link copied!')).toBeVisible({ timeout: 15_000 });
+    expect(postedKeys).toHaveLength(2);
+  });
+
+  test('partial POST failure reports the shortfall and drops the failed key', async ({ page, context, browserName }) => {
+    if (browserName === 'chromium') await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const postedKeys = mockSharePostWithOneFailure(page);
+
+    await seedLibrary(
+      page,
+      [
+        { id: 'a', nickname: 'Alpha Base', config: shareableConfig() },
+        { id: 'b', nickname: 'Beta Base', config: shareableConfig('Desc_IronRod_C', '20') },
+      ],
+      'a',
+    );
+    await gotoApp(page);
+    const dialog = await openShareMultiple(page);
+
+    await dialog.getByRole('checkbox', { name: /Alpha Base/ }).check();
+    await dialog.getByRole('checkbox', { name: /Beta Base/ }).check();
+    await dialog.getByRole('button', { name: 'Share 2 selected' }).click();
+
+    await expect(dialog.getByText('Shared 1 of 2 — copied')).toBeVisible({ timeout: 15_000 });
+    expect(postedKeys).toHaveLength(1); // exactly one survivor
+
+    if (browserName === 'chromium') {
+      const link = await page.evaluate(() => navigator.clipboard.readText());
+      const value = new URL(link).searchParams.get('factory') ?? '';
+      expect(value).not.toContain(','); // one key, no comma
+      expect(value).toBe(postedKeys[0]);
+    }
+  });
+
+  test('single selection builds a back-compat link with no comma', async ({ page, context, browserName }) => {
+    if (browserName === 'chromium') await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const postedKeys = mockSharePost(page);
+
+    await seedLibrary(page, [{ id: 'a', nickname: 'Alpha Base', config: shareableConfig() }], 'a');
+    await gotoApp(page);
+    const dialog = await openShareMultiple(page);
+
+    await dialog.getByRole('checkbox', { name: /Alpha Base/ }).check();
+    await dialog.getByRole('button', { name: 'Share 1 selected' }).click();
+
+    await expect(dialog.getByText('Link copied!')).toBeVisible({ timeout: 15_000 });
+    expect(postedKeys).toHaveLength(1);
+
+    if (browserName === 'chromium') {
+      const link = await page.evaluate(() => navigator.clipboard.readText());
+      const value = new URL(link).searchParams.get('factory') ?? '';
+      expect(value).not.toContain(',');
+      expect(value).toBe(postedKeys[0]);
+    }
+  });
+
+  test('caps selection at 50 on send: 51st disabled, notice shown, link has 50 keys', async ({ page, context, browserName }) => {
+    if (browserName === 'chromium') await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const postedKeys = mockSharePost(page);
+
+    // 51 shareable factories, ordered by createdAt (Factory-00 .. Factory-50).
+    const seeds: Seed[] = [];
+    for (let i = 0; i <= 50; i++) {
+      const id = `f${String(i).padStart(2, '0')}`;
+      seeds.push({ id, nickname: `Factory-${String(i).padStart(2, '0')}`, config: shareableConfig(), createdAt: 1_000 + i });
+    }
+    await seedLibrary(page, seeds, 'f00');
+    await gotoApp(page);
+    const dialog = await openShareMultiple(page);
+
+    await dialog.getByRole('button', { name: 'Select all' }).click();
+
+    // At most 50 selected; the 51st row is over the cap and disabled; notice visible.
+    await expect(dialog.getByRole('checkbox', { checked: true })).toHaveCount(50);
+    await expect(dialog.getByRole('checkbox', { name: /Factory-50/ })).toBeDisabled();
+    await expect(dialog.getByText('Over the 50-factory limit').first()).toBeVisible();
+    await expect(dialog.getByText('You can share up to 50 factories in one link.')).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Share 50 selected' }).click();
+    await expect(dialog.getByText('Link copied!')).toBeVisible({ timeout: 30_000 });
+    expect(postedKeys).toHaveLength(50);
+
+    if (browserName === 'chromium') {
+      const link = await page.evaluate(() => navigator.clipboard.readText());
+      const value = new URL(link).searchParams.get('factory') ?? '';
+      expect(value.split(',')).toHaveLength(50);
+    }
+  });
+});
+
+test.describe('Share multiple — receive', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => sessionStorage.setItem('drawer-open', '"false"'));
+  });
+
+  test('imports both keys of a 2-key link, strips URL, persists across reload', async ({ page }) => {
+    mockSharedGet(page, (key) =>
+      key === 'k1' ? { itemKey: 'Desc_IronPlate_C', value: 10 } : key === 'k2' ? { itemKey: 'Desc_IronRod_C', value: 20 } : null,
+    );
+
+    await gotoApp(page, '/?factory=k1,k2');
+
+    const dialog = page.getByRole('dialog', { name: 'Import shared factories' });
+    await expect(dialog).toBeVisible({ timeout: 30_000 });
+    // Both resolved rows default-checked.
+    await expect(dialog.getByRole('checkbox', { checked: true })).toHaveCount(2);
+    await dialog.getByRole('button', { name: 'Import 2 selected' }).click();
+
+    // URL is stripped (it is stripped up front on a multi-share boot).
+    await expect(page).toHaveURL(/^[^?]*$/);
+
+    const tabs = page.locator(FACTORY_TAB);
+    await expect(tabs.filter({ hasText: 'Iron Plate' })).toHaveCount(1);
+    await expect(tabs.filter({ hasText: 'Iron Rod' })).toHaveCount(1);
+
+    await page.reload();
+    await expect(page.getByRole('combobox', { name: 'Game version' })).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(FACTORY_TAB).filter({ hasText: 'Iron Plate' })).toHaveCount(1);
+    await expect(page.locator(FACTORY_TAB).filter({ hasText: 'Iron Rod' })).toHaveCount(1);
+  });
+
+  test('imports only the checked subset', async ({ page }) => {
+    mockSharedGet(page, (key) =>
+      key === 'k1' ? { itemKey: 'Desc_IronPlate_C', value: 10 } : key === 'k2' ? { itemKey: 'Desc_IronRod_C', value: 20 } : null,
+    );
+
+    await gotoApp(page, '/?factory=k1,k2');
+    const dialog = page.getByRole('dialog', { name: 'Import shared factories' });
+    await expect(dialog).toBeVisible({ timeout: 30_000 });
+
+    // Uncheck the Iron Rod row → only Iron Plate imports.
+    await dialog.getByRole('checkbox', { name: /Iron Rod/ }).uncheck();
+    await dialog.getByRole('button', { name: 'Import 1 selected' }).click();
+
+    const tabs = page.locator(FACTORY_TAB);
+    await expect(tabs.filter({ hasText: 'Iron Plate' })).toHaveCount(1);
+    await expect(tabs.filter({ hasText: 'Iron Rod' })).toHaveCount(0);
+  });
+
+  test('a dead key is greyed and unselectable; the live one still imports', async ({ page }) => {
+    mockSharedGet(page, (key) => (key === 'k1' ? { itemKey: 'Desc_IronPlate_C', value: 10 } : null)); // k2 → 404
+
+    await gotoApp(page, '/?factory=k1,k2');
+    const dialog = page.getByRole('dialog', { name: 'Import shared factories' });
+    await expect(dialog).toBeVisible({ timeout: 30_000 });
+
+    // The dead key row is disabled with the reason.
+    const dead = dialog.getByRole('checkbox', { name: /Expired or invalid/ });
+    await expect(dead).toBeDisabled();
+
+    await dialog.getByRole('button', { name: 'Import 1 selected' }).click();
+    await expect(page.locator(FACTORY_TAB).filter({ hasText: 'Iron Plate' })).toHaveCount(1);
+  });
+
+  test('all keys dead → cohesive share-error, no picker, nothing imported', async ({ page }) => {
+    mockSharedGet(page, () => null); // both 404
+
+    await gotoApp(page, '/?factory=dead1,dead2');
+
+    // No import picker; the cohesive share-error surfaces instead (matches share-error.spec).
+    await expect(page.getByRole('dialog', { name: 'Import shared factories' })).toHaveCount(0);
+    const err = page.getByRole('dialog', { name: /Shared factory not found/i });
+    await expect(err).toBeVisible({ timeout: 30_000 });
+    await expect(err.getByText(/valid for/i)).toContainText('7 days');
+
+    // The old dead-end takeover must be gone, and nothing was imported.
+    await expect(page.getByText(/error occurred connecting to the server/i)).toHaveCount(0);
+    await err.getByRole('button', { name: 'Continue' }).click();
+    await expect(page.locator(FACTORY_TAB).filter({ hasText: /Iron/ })).toHaveCount(0);
+  });
+
+  test('a single-key link silently imports without the picker (regression guard)', async ({ page }) => {
+    mockSharedGet(page, () => ({ itemKey: 'Desc_IronPlate_C', value: 10 }));
+
+    await gotoApp(page, '/?factory=onlyonekey');
+
+    // The imported factory lands directly as a slot — no picker dialog.
+    await expect(page.locator(FACTORY_TAB).filter({ hasText: 'Iron Plate' })).toHaveCount(1);
+    await expect(page.getByRole('dialog', { name: 'Import shared factories' })).toHaveCount(0);
+    await expect(page).toHaveURL(/^[^?]*$/);
+  });
+
+  test('imports a mix of game versions with correct labels', async ({ page }) => {
+    mockSharedGet(page, (key) =>
+      key === 'k1'
+        ? { version: 'V1_1', itemKey: 'Desc_IronPlate_C', value: 10 }
+        : key === 'k2'
+        ? { version: 'V1_2', itemKey: 'Desc_IronRod_C', value: 20 }
+        : null,
+    );
+
+    await gotoApp(page, '/?factory=k1,k2');
+    const dialog = page.getByRole('dialog', { name: 'Import shared factories' });
+    await expect(dialog).toBeVisible({ timeout: 30_000 });
+
+    // Per-version rows carry their version meta.
+    await expect(dialog.getByText('v1.1')).toBeVisible();
+    await expect(dialog.getByText('v1.2')).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Import 2 selected' }).click();
+
+    const tabs = page.locator(FACTORY_TAB);
+    await expect(tabs.filter({ hasText: 'Iron Plate' })).toHaveCount(1, { timeout: 30_000 });
+    await expect(tabs.filter({ hasText: 'Iron Rod' })).toHaveCount(1);
+  });
+
+  test('cancel imports nothing; URL already stripped; planner usable', async ({ page }) => {
+    mockSharedGet(page, (key) =>
+      key === 'k1' ? { itemKey: 'Desc_IronPlate_C', value: 10 } : key === 'k2' ? { itemKey: 'Desc_IronRod_C', value: 20 } : null,
+    );
+
+    await gotoApp(page, '/?factory=k1,k2');
+    const dialog = page.getByRole('dialog', { name: 'Import shared factories' });
+    await expect(dialog).toBeVisible({ timeout: 30_000 });
+
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(dialog).toHaveCount(0);
+
+    // Nothing imported, URL already stripped, and the planner still works.
+    await expect(page.locator(FACTORY_TAB).filter({ hasText: /Iron/ })).toHaveCount(0);
+    await expect(page).toHaveURL(/^[^?]*$/);
+    await openControlPanel(page);
+    await expect(page.getByRole('button', { name: '+ Add Product' })).toBeVisible();
+  });
+
+  test('caps at 50 on receive: overflow surfaced, at most 50 importable', async ({ page }) => {
+    // 51 live keys k0..k50; the 51st is past the cap and never fetched (overflow).
+    mockSharedGet(page, () => ({ itemKey: 'Desc_IronPlate_C', value: 10 }));
+    const keys = Array.from({ length: 51 }, (_, i) => `k${i}`).join(',');
+
+    await gotoApp(page, `/?factory=${keys}`);
+    const dialog = page.getByRole('dialog', { name: 'Import shared factories' });
+    await expect(dialog).toBeVisible({ timeout: 30_000 });
+
+    // At most 50 are checkable/checked; the overflow row is disabled (not a dead-end).
+    await expect(dialog.getByRole('checkbox', { checked: true })).toHaveCount(50);
+    await expect(dialog.getByRole('button', { name: 'Import 50 selected' })).toBeVisible();
+    await expect(dialog.getByRole('checkbox', { disabled: true })).toHaveCount(1);
+  });
+});
+
+test.describe('Share multiple — accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => sessionStorage.setItem('drawer-open', '"false"'));
+    // Freeze transitions so axe never samples an element mid-fade (see a11y.spec.ts).
+    await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'light' });
+    await page.addInitScript(() => {
+      const style = document.createElement('style');
+      style.textContent = '*,*::before,*::after{transition:none!important;animation:none!important;}';
+      document.documentElement.appendChild(style);
+    });
+  });
+
+  test('the Share-factories modal has an accessible name and no WCAG A/AA violations', async ({ page }) => {
+    await seedLibrary(page, [{ id: 'a', nickname: 'Alpha Base', config: shareableConfig() }], 'a');
+    await gotoApp(page);
+    const dialog = await openShareMultiple(page); // accessible name asserted inside
+    await expect(dialog).toBeVisible();
+
+    const results = await scanDialog(page);
+    expect(results.violations).toEqual([]);
+  });
+
+  test('the Import-shared-factories modal has an accessible name and no WCAG A/AA violations', async ({ page }) => {
+    mockSharedGet(page, (key) =>
+      key === 'k1' ? { itemKey: 'Desc_IronPlate_C', value: 10 } : key === 'k2' ? { itemKey: 'Desc_IronRod_C', value: 20 } : null,
+    );
+    await gotoApp(page, '/?factory=k1,k2');
+    const dialog = page.getByRole('dialog', { name: 'Import shared factories' });
+    await expect(dialog).toBeVisible({ timeout: 30_000 });
+
+    const results = await scanDialog(page);
+    expect(results.violations).toEqual([]);
+  });
+});

--- a/client/tests/share-multiple.spec.ts
+++ b/client/tests/share-multiple.spec.ts
@@ -494,6 +494,10 @@ test.describe('Share multiple — receive', () => {
     await expect(dialog.getByRole('checkbox', { checked: true })).toHaveCount(50);
     await expect(dialog.getByRole('button', { name: 'Import 50 selected' })).toBeVisible();
     await expect(dialog.getByRole('checkbox', { disabled: true })).toHaveCount(1);
+    // The overflow row reads as over-the-limit, NOT "Expired or invalid": these keys
+    // were never fetched, they're simply past the 50-per-link cap.
+    await expect(dialog.getByText('Over the 50-factory limit')).toBeVisible();
+    await expect(dialog.getByText('Expired or invalid')).toHaveCount(0);
   });
 });
 


### PR DESCRIPTION
## Summary
Adds a global **somersloop / power-shard budget** the in-browser LP solver allocates to amplify (2× output, no extra input) and overclock (2.5× throughput) recipes, folded into the existing weighted objective.

- Each recipe expands into up to 4 LP variants (base / AMP / OC / AMPOC), **gated so a zero budget leaves the LP byte-identical** to before (goldens regenerated additively).
- Report shows **whole-machine** somersloop/shard requirements; graph nodes get **purple (amplified) / deep-blue (overclocked) / violet (both)** border indicators.
- Slot counts live as client constants; **client-only persistence** for now (server `FactoryConfigSchema` unchanged).
- Fixes `encode()` to tolerate library configs saved before this field; fixes pre-existing ambiguous `Share` e2e selectors broken by the multi-share split button.

## Tests
Unit (amplification math, solver behavior, codec round-trip), real-data solver integration, plus Playwright functional + a11y coverage.

## Note
This branch is based on `feat/share-multiple-factories`, so it also carries those 2 commits (share-multiple) into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)