### PR TITLE
feat(api): persist amplification & allowed-buildings through share backend

### DIFF
--- a/YetAnotherFactoryPlanner.IntegrationTests/ShareFactoryEndpointTests.cs
+++ b/YetAnotherFactoryPlanner.IntegrationTests/ShareFactoryEndpointTests.cs
@@ -110,6 +110,65 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 	}
 
 	/// <summary>
+	/// Regression guard for the amplification-persistence fix — somersloop/power-shard budgets are part
+	/// of the factory's identity. Two configs identical except for <c>amplificationOptions</c> must hash
+	/// to DIFFERENT keys; otherwise FindOrSaveAsync dedupes the second save away and a shared 10-sloop
+	/// factory could resolve to an otherwise-identical 0-sloop link.
+	/// </summary>
+	[Fact]
+	public async Task PostShareFactory_ConfigsDifferingOnlyByAmplification_ReturnDifferentKeys()
+	{
+		// Arrange
+		using var client = fixture.App.CreateHttpClient("api");
+
+		var noBoost = BuildMinimalFactoryRequest("Desc_IronPlate_C", amount: 10, gameVersion: "1.2");
+		var boosted = BuildMinimalFactoryRequest("Desc_IronPlate_C", amount: 10, gameVersion: "1.2",
+			availableSloops: 10, availableShards: 5);
+
+		// Act
+		var noBoostResponse = await client.PostAsJsonAsync("/api/share-factory", noBoost, JsonOptions, TestContext.Current.CancellationToken);
+		var boostedResponse = await client.PostAsJsonAsync("/api/share-factory", boosted, JsonOptions, TestContext.Current.CancellationToken);
+
+		// Assert
+		Assert.Equal(HttpStatusCode.Created, noBoostResponse.StatusCode);
+		Assert.Equal(HttpStatusCode.Created, boostedResponse.StatusCode);
+
+		var noBoostKey = await ExtractKeyAsync(noBoostResponse);
+		var boostedKey = await ExtractKeyAsync(boostedResponse);
+
+		Assert.NotEqual(noBoostKey, boostedKey);
+	}
+
+	/// <summary>
+	/// End-to-end guard for the amplification-persistence fix — the saved <c>amplificationOptions</c>
+	/// must survive the Cosmos round-trip: after sharing a factory with non-zero sloops/shards, fetching
+	/// it back returns the same budgets (so the <c>?factory=</c> link restores as configured). This is
+	/// the automated form of the handoff's manual "open the shared link and confirm budgets restore".
+	/// </summary>
+	[Fact]
+	public async Task PostShareFactory_PersistsAmplificationOptions_RoundTrips()
+	{
+		// Arrange
+		using var client = fixture.App.CreateHttpClient("api");
+		var requestBody = BuildMinimalFactoryRequest("Desc_IronPlate_C", amount: 10, gameVersion: "1.2",
+			availableSloops: 12, availableShards: 7);
+
+		// Act — save, then fetch back
+		var postResponse = await client.PostAsJsonAsync("/api/share-factory", requestBody, JsonOptions, TestContext.Current.CancellationToken);
+		Assert.Equal(HttpStatusCode.Created, postResponse.StatusCode);
+		var key = await ExtractKeyAsync(postResponse);
+
+		var getResponse = await client.GetAsync($"/api/shared-factories/{key}", TestContext.Current.CancellationToken);
+		Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+		// Assert — the budgets persisted exactly as sent
+		var json = await getResponse.Content.ReadFromJsonAsync<JsonElement>(JsonOptions, TestContext.Current.CancellationToken);
+		var amplificationOptions = json.GetProperty("data").GetProperty("factory_config").GetProperty("amplificationOptions");
+		Assert.Equal(12, amplificationOptions.GetProperty("availableSloops").GetInt32());
+		Assert.Equal(7, amplificationOptions.GetProperty("availableShards").GetInt32());
+	}
+
+	/// <summary>
 	/// Smoke test — a single POST with a valid factory config is saved and returns a key.
 	/// This verifies the happy path remains intact.
 	/// </summary>
@@ -161,6 +220,8 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 		decimal amount,
 		decimal recipePartsCost = 1,
 		decimal powerConsumption = 1,
+		int availableSloops = 0,
+		int availableShards = 0,
 		string gameVersion = "1.1") => new
 	{
 		factoryConfig = new
@@ -176,6 +237,7 @@ public sealed class ShareFactoryEndpointTests(AppHostFixture fixture)
 			},
 			weightingOptions = new { resources = 1000, power = 1, complexity = 0, buildings = 0 },
 			gameModeOptions = new { recipePartsCost, powerConsumption },
+			amplificationOptions = new { availableSloops, availableShards },
 			nodesPositions = Array.Empty<object>(),
 		},
 	};

--- a/api.Core/Models/AmplificationOptions.cs
+++ b/api.Core/Models/AmplificationOptions.cs
@@ -1,0 +1,4 @@
+namespace api.Models;
+
+// Somersloop / power-shard budgets available to the solver. Whole counts; 0/0 means no amplification.
+public record AmplificationOptions(int AvailableSloops, int AvailableShards);

--- a/api.Core/Models/FactoryConfigSchema.cs
+++ b/api.Core/Models/FactoryConfigSchema.cs
@@ -11,5 +11,9 @@ public class FactoryConfigSchema
     public List<NodePosition> NodesPositions { get; set; } = [];
     public WeightingOptions WeightingOptions { get; set; } = new(1000, 1, 0, 0);
     public GameModeOptions GameModeOptions { get; set; } = new(1, 1);
+    // Somersloop/power-shard budgets. Defaulted so pre-feature clients and old Cosmos docs deserialize to 0/0.
+    public AmplificationOptions AmplificationOptions { get; set; } = new(0, 0);
+    // Enabled building keys. Empty = all buildings allowed (pre-feature shares omit it).
+    public List<string> AllowedBuildings { get; set; } = [];
     public bool AllowHandGatheredItems { get; set; }
 }

--- a/api.Core/Services/ShareFactoryId.cs
+++ b/api.Core/Services/ShareFactoryId.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using api.Models;
 
 namespace api.Services;
@@ -17,9 +18,25 @@ namespace api.Services;
 /// </summary>
 public static class ShareFactoryId
 {
+    // Amplification and building-selection are appended to the canonical ONLY when set (see below).
+    // WhenWritingNull then omits the default cases so that pre-feature configs serialize to the exact
+    // historical bytes and keep their original id — no existing share link or dedup entry is orphaned.
+    // No pre-existing canonical field is ever null, so this option is a no-op for them.
+    private static readonly JsonSerializerOptions CanonicalOptions =
+        new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+
     /// <summary>Produces the deterministic canonical JSON used as the hash input.</summary>
-    public static string Canonicalize(FactoryConfigSchema config) =>
-        JsonSerializer.Serialize(new
+    public static string Canonicalize(FactoryConfigSchema config)
+    {
+        // These fields were added after the original wire contract. They affect the factory's identity
+        // (a different boost budget or building restriction is a genuinely different factory), so they
+        // must be hashed — otherwise distinct factories would collide on the same id and be deduped.
+        // They are included only when non-default so the ids of every pre-feature config stay stable.
+        var amp = config.AmplificationOptions;
+        var hasAmp = amp is not null && (amp.AvailableSloops != 0 || amp.AvailableShards != 0);
+        var hasBuildings = config.AllowedBuildings.Count > 0;
+
+        return JsonSerializer.Serialize(new
         {
             gameVersion = config.GameVersion,
             productionItems = config.ProductionItems.OrderBy(x => x.ItemKey).ThenBy(x => x.Mode).ThenBy(x => x.Value),
@@ -29,7 +46,10 @@ public static class ShareFactoryId
             weightingOptions = config.WeightingOptions,
             gameModeOptions = config.GameModeOptions,
             allowHandGatheredItems = config.AllowHandGatheredItems,
-        });
+            amplificationOptions = hasAmp ? amp : null,
+            allowedBuildings = hasBuildings ? config.AllowedBuildings.OrderBy(x => x) : null,
+        }, CanonicalOptions);
+    }
 
     /// <summary>Computes the 16-hex-char share id for a config.</summary>
     public static string Compute(FactoryConfigSchema config)

--- a/api.Core/Validation/FactoryConfigSchemaValidator.cs
+++ b/api.Core/Validation/FactoryConfigSchemaValidator.cs
@@ -26,10 +26,15 @@ public class FactoryConfigSchemaValidator : AbstractValidator<FactoryConfigSchem
         RuleForEach(x => x.InputResources).SetValidator(new InputValidator());
         RuleFor(x => x.WeightingOptions).NotNull().SetValidator(new WeightingOptionsValidator());
         RuleFor(x => x.GameModeOptions).NotNull().SetValidator(new GameModeOptionsValidator());
+        RuleFor(x => x.AmplificationOptions).NotNull().SetValidator(new AmplificationOptionsValidator());
         // AllowedRecipes may be empty (means all recipes are allowed)
         RuleFor(x => x.AllowedRecipes)
             .Must(x => x.Count <= 500).WithMessage("AllowedRecipes must not exceed 500 items.");
         RuleForEach(x => x.AllowedRecipes).NotEmpty().MaximumLength(200);
+        // AllowedBuildings may be empty (means all buildings are allowed)
+        RuleFor(x => x.AllowedBuildings)
+            .Must(x => x.Count <= 500).WithMessage("AllowedBuildings must not exceed 500 items.");
+        RuleForEach(x => x.AllowedBuildings).NotEmpty().MaximumLength(200);
         RuleFor(x => x.NodesPositions)
             .Must(x => x.Count <= 1000).WithMessage("NodesPositions must not exceed 1000 items.");
         RuleForEach(x => x.NodesPositions).SetValidator(new NodePositionValidator());
@@ -76,6 +81,16 @@ public class FactoryConfigSchemaValidator : AbstractValidator<FactoryConfigSchem
         {
             RuleFor(x => x.RecipePartsCost).GreaterThan(0);
             RuleFor(x => x.PowerConsumption).GreaterThan(0);
+        }
+    }
+
+    private sealed class AmplificationOptionsValidator : AbstractValidator<AmplificationOptions>
+    {
+        public AmplificationOptionsValidator()
+        {
+            // Whole, non-negative counts; the upper bound is a sanity ceiling well above any real budget.
+            RuleFor(x => x.AvailableSloops).InclusiveBetween(0, 100000);
+            RuleFor(x => x.AvailableShards).InclusiveBetween(0, 100000);
         }
     }
 

--- a/api.Tests/Serialization/WireContractTests.cs
+++ b/api.Tests/Serialization/WireContractTests.cs
@@ -26,6 +26,8 @@ public class WireContractTests
         NodesPositions = [new NodePosition("node-1", 10, 20)],
         WeightingOptions = new WeightingOptions(1000, 1, 0, 0),
         GameModeOptions = new GameModeOptions(1, 1),
+        AmplificationOptions = new AmplificationOptions(10, 5),
+        AllowedBuildings = ["Build_SmelterMk1_C", "Build_ConstructorMk1_C"],
         AllowHandGatheredItems = true,
     };
 
@@ -46,10 +48,45 @@ public class WireContractTests
                  {
                      "productionItems", "inputItems", "inputResources", "allowedRecipes",
                      "nodesPositions", "weightingOptions", "gameModeOptions", "allowHandGatheredItems",
+                     "amplificationOptions", "allowedBuildings",
                  })
         {
             Assert.True(root.TryGetProperty(field, out _), $"Missing camelCase field '{field}'.");
         }
+
+        // Nested amplification keys must be camelCase too — the client reads availableSloops/availableShards.
+        var amp = root.GetProperty("amplificationOptions");
+        Assert.Equal(10, amp.GetProperty("availableSloops").GetInt32());
+        Assert.Equal(5, amp.GetProperty("availableShards").GetInt32());
+    }
+
+    [Fact]
+    public void FactoryConfig_RoundTrips_AmplificationAndAllowedBuildings()
+    {
+        // Guards the camelCase mapping end-to-end: what the worker persists to Cosmos must deserialize
+        // back into the same C# members (a mapping regression here silently drops the fields on shares).
+        var json = JsonSerializer.Serialize(SampleConfig(), Web);
+        var restored = JsonSerializer.Deserialize<FactoryConfigSchema>(json, Web);
+
+        Assert.NotNull(restored);
+        Assert.Equal(10, restored!.AmplificationOptions.AvailableSloops);
+        Assert.Equal(5, restored.AmplificationOptions.AvailableShards);
+        Assert.Equal(["Build_SmelterMk1_C", "Build_ConstructorMk1_C"], restored.AllowedBuildings);
+    }
+
+    [Fact]
+    public void FactoryConfig_MissingAmplification_DeserializesToDefaultZero()
+    {
+        // Old Cosmos docs written before these fields existed must deserialize cleanly to 0/0 (and an
+        // empty building list), not null — the defaulted properties guarantee this back-compat.
+        const string legacy = """{"gameVersion":"V1_2","productionItems":[{"itemKey":"Desc_IronPlate_C","mode":"per-minute","value":20}]}""";
+
+        var restored = JsonSerializer.Deserialize<FactoryConfigSchema>(legacy, Web);
+
+        Assert.NotNull(restored);
+        Assert.Equal(0, restored!.AmplificationOptions.AvailableSloops);
+        Assert.Equal(0, restored.AmplificationOptions.AvailableShards);
+        Assert.Empty(restored.AllowedBuildings);
     }
 
     [Fact]

--- a/api.Tests/Services/ShareFactoryIdTests.cs
+++ b/api.Tests/Services/ShareFactoryIdTests.cs
@@ -61,4 +61,62 @@ public class ShareFactoryIdTests
         Assert.Equal(16, id.Length);
         Assert.Matches("^[0-9a-f]{16}$", id);
     }
+
+    // Default amplification (0/0) and no building restriction must NOT change the canonical bytes,
+    // so a config that predates these fields keeps its historical id. The pinned test above already
+    // asserts the exact value; this one pins the equivalence explicitly.
+    [Fact]
+    public void Compute_DefaultAmplificationAndBuildings_MatchesPreFeatureId()
+    {
+        var withDefaults = KnownConfig();
+        withDefaults.AmplificationOptions = new AmplificationOptions(0, 0);
+        withDefaults.AllowedBuildings = [];
+
+        Assert.Equal("6a012cfd4bee911e", ShareFactoryId.Compute(withDefaults));
+    }
+
+    [Fact]
+    public void Compute_NonZeroAmplification_DiffersFromDefault()
+    {
+        var boosted = KnownConfig();
+        boosted.AmplificationOptions = new AmplificationOptions(10, 5);
+
+        Assert.NotEqual(ShareFactoryId.Compute(KnownConfig()), ShareFactoryId.Compute(boosted));
+    }
+
+    // Collision guard: configs differing only by boost budget are genuinely different factories and
+    // must not dedupe onto the same id.
+    [Fact]
+    public void Compute_DifferentSloopCounts_ProduceDifferentIds()
+    {
+        var a = KnownConfig();
+        a.AmplificationOptions = new AmplificationOptions(4, 0);
+        var b = KnownConfig();
+        b.AmplificationOptions = new AmplificationOptions(8, 0);
+
+        Assert.NotEqual(ShareFactoryId.Compute(a), ShareFactoryId.Compute(b));
+    }
+
+    [Fact]
+    public void Compute_DifferentAllowedBuildings_ProduceDifferentIds()
+    {
+        var a = KnownConfig();
+        a.AllowedBuildings = ["Build_SmelterMk1_C"];
+        var b = KnownConfig();
+        b.AllowedBuildings = ["Build_SmelterMk1_C", "Build_ConstructorMk1_C"];
+
+        Assert.NotEqual(ShareFactoryId.Compute(a), ShareFactoryId.Compute(b));
+    }
+
+    // AllowedBuildings ordering must be normalized away, matching AllowedRecipes.
+    [Fact]
+    public void Compute_AllowedBuildings_IsOrderInsensitive()
+    {
+        var a = KnownConfig();
+        a.AllowedBuildings = ["Build_SmelterMk1_C", "Build_ConstructorMk1_C"];
+        var b = KnownConfig();
+        b.AllowedBuildings = ["Build_ConstructorMk1_C", "Build_SmelterMk1_C"];
+
+        Assert.Equal(ShareFactoryId.Compute(a), ShareFactoryId.Compute(b));
+    }
 }

--- a/api.Tests/Validation/FactoryConfigSchemaValidatorTests.cs
+++ b/api.Tests/Validation/FactoryConfigSchemaValidatorTests.cs
@@ -254,6 +254,86 @@ public class FactoryConfigSchemaValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.WeightingOptions);
     }
 
+    // AmplificationOptions validation
+    [Fact]
+    public void ValidConfig_DefaultAmplification_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.AmplificationOptions = new AmplificationOptions(0, 0);
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor(x => x.AmplificationOptions);
+    }
+
+    [Fact]
+    public void ValidConfig_PositiveAmplification_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.AmplificationOptions = new AmplificationOptions(10, 5);
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor(x => x.AmplificationOptions);
+    }
+
+    [Fact]
+    public void ValidConfig_NullAmplification_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.AmplificationOptions = null!;
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.AmplificationOptions);
+    }
+
+    [Theory]
+    [InlineData(-1, 0, "AmplificationOptions.AvailableSloops")]
+    [InlineData(0, -1, "AmplificationOptions.AvailableShards")]
+    [InlineData(100001, 0, "AmplificationOptions.AvailableSloops")]
+    [InlineData(0, 100001, "AmplificationOptions.AvailableShards")]
+    public void ValidConfig_OutOfRangeAmplification_ShouldFail(int sloops, int shards, string property)
+    {
+        var config = CreateValidConfig();
+        config.AmplificationOptions = new AmplificationOptions(sloops, shards);
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(property);
+    }
+
+    // AllowedBuildings validation
+    [Fact]
+    public void ValidConfig_EmptyAllowedBuildings_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.AllowedBuildings = [];
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor(x => x.AllowedBuildings);
+    }
+
+    [Fact]
+    public void ValidConfig_ValidAllowedBuildings_ShouldPass()
+    {
+        var config = CreateValidConfig();
+        config.AllowedBuildings = ["Build_SmelterMk1_C", "Build_ConstructorMk1_C"];
+        var result = _validator.TestValidate(config);
+        result.ShouldNotHaveValidationErrorFor(x => x.AllowedBuildings);
+    }
+
+    [Fact]
+    public void ValidConfig_AllowedBuildings_WithEmptyString_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.AllowedBuildings = [""];
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor("AllowedBuildings[0]");
+    }
+
+    [Fact]
+    public void ValidConfig_AllowedBuildingsExceedingLimit_ShouldFail()
+    {
+        var config = CreateValidConfig();
+        config.AllowedBuildings = Enumerable.Range(0, 501)
+            .Select(i => $"Build_{i}")
+            .ToList();
+        var result = _validator.TestValidate(config);
+        result.ShouldHaveValidationErrorFor(x => x.AllowedBuildings);
+    }
+
     // Multiple production items
     [Fact]
     public void ValidConfig_MultipleValidProductionItems_ShouldPass()


### PR DESCRIPTION
## Context

The somersloop/power-shard solver feature (PR #192) shipped with persistence intentionally **client-only** for launch. The client already encodes `amplificationOptions` (boost budgets) and `allowedBuildings` into the shared-factory wire payload, but the share API persists to Cosmos as the strongly-typed `FactoryConfigSchema`, and `System.Text.Json` silently drops JSON properties with no matching C# member. Both fields survived local-library autosave but were **stripped on every `?factory=` share link** and never returned on GET. (`allowedBuildings` had the identical latent gap.)

## Change (server-only)

- **`FactoryConfigSchema`** now declares `AmplificationOptions` (defaulted `(0,0)`) and `AllowedBuildings` (defaulted `[]`) — non-null defaults so old Cosmos docs and pre-feature clients deserialize cleanly.
- **Validation** — `AmplificationOptions` counts `0–100000`; `AllowedBuildings` mirrors the existing `AllowedRecipes` rules (≤500 items, non-empty, max length).
- **`ShareFactoryId.Canonicalize`** folds both fields into the content hash **only when non-default** (via `WhenWritingNull`). This is the critical coupling: persisting a field without hashing it would let two factories differing only by boost budget / building restriction collide onto one share key and be deduped. Gating on non-default keeps every pre-feature config's id byte-stable (pinned id `6a012cfd4bee911e` unchanged → no orphaned links), while feature-using factories get distinct ids.

No client change — the codec/hydrate paths already consume these fields.

## Tests

- `api.Tests`: **55 passing** — validator range/limit/null, camelCase serialize↔deserialize round-trip, legacy-doc → `0/0`, hash continuity + collision guards.
- `IntegrationTests`: **7 passing** — 2 new tests exercise the real Cosmos emulator POST→GET round-trip (budgets restore) and the collision guard.
- Client vitest (unit + a11y): **411 passing**; Playwright e2e: **156/156** (CI-equivalent retries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)