### PR TITLE
fix(client): keep somersloop/power-shard plans within budget (whole machines)

### DIFF
--- a/client/src/utilities/production-solver/amp-realdata.test.ts
+++ b/client/src/utilities/production-solver/amp-realdata.test.ts
@@ -34,6 +34,22 @@ describe('amplification against real 1.2 game data', () => {
     expect(Number.isInteger(report!.amplification.sloopsUsed)).toBe(true);
   });
 
+  it('never exceeds a tight sloop/shard budget on a deep real chain', async () => {
+    // A many-recipe target with a tiny sloop budget and a generous shard budget: the old
+    // continuous relaxation smeared fractional boosts across ~24 recipes, each rounding up in
+    // the report to a whole machine (1 sloop -> 2 used, 100 shards -> 141 used). Whole-machine
+    // integer boosts must keep usage within budget.
+    const opts = baseOptions();
+    opts.productionItems = [{ key: 'p1', itemKey: 'Desc_Computer_C', mode: 'per-minute', value: '10' }];
+    opts.amplificationOptions = { availableSloops: '1', availableShards: '100' };
+    const { report, error } = await new ProductionSolver(opts, gd).exec();
+    expect(error).toBeNull();
+    expect(report!.amplification.sloopsUsed).toBeLessThanOrEqual(report!.amplification.sloopsAvailable);
+    expect(report!.amplification.shardsUsed).toBeLessThanOrEqual(report!.amplification.shardsAvailable);
+    expect(Number.isInteger(report!.amplification.sloopsUsed)).toBe(true);
+    expect(Number.isInteger(report!.amplification.shardsUsed)).toBe(true);
+  });
+
   it('overclocks real recipes when only shards are available (buildings-weighted)', async () => {
     const opts = baseOptions();
     opts.weightingOptions = { resources: '10', power: '1', complexity: '0', buildings: '1000' };

--- a/client/src/utilities/production-solver/index.test.ts
+++ b/client/src/utilities/production-solver/index.test.ts
@@ -693,31 +693,40 @@ describe('ProductionSolver amplification (somersloops / power shards)', () => {
   });
 
   it('amplifies to halve input use when sloops are available', async () => {
-    const options = ampOptions({ amplificationOptions: { availableSloops: '106', availableShards: '0' } });
+    // One whole amplified constructor makes 40 plates from 30 ingots (2x output, same input);
+    // matching that with base constructors would take two machines and 60 ingots. Boost variants
+    // are whole machines, so the win only exists when a full amplified machine is warranted.
+    const options = ampOptions({
+      productionItems: [{ key: 'p1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '40' }],
+      amplificationOptions: { availableSloops: '106', availableShards: '0' },
+    });
     const { productionGraph, report, error } = await new ProductionSolver(options, ampGameData).exec();
     expect(error).toBeNull();
-    // Solver switches to the amplified variant: 0.5 amplified constructors make 20 plates
-    // from just 15 ingots (2x output, same input), using 0.5 somersloops.
     const ampNode = productionGraph!.nodes['Recipe_IronPlate_C::AMP'];
     expect(ampNode).toBeDefined();
     expect(ampNode.suffix).toBe('AMP');
-    expect(ampNode.multiplier).toBeCloseTo(0.5, 4);
-    expect(productionGraph!.nodes['Desc_IronIngot_C'].multiplier).toBeCloseTo(15, 4);
-    // Somersloops go into whole machines: 0.5 amplified constructors round up to 1 physical
-    // machine, whose single slot needs 1 whole somersloop (not the fractional 0.5).
+    // A single, whole amplified machine — not a fraction.
+    expect(ampNode.multiplier).toBeCloseTo(1, 4);
+    expect(productionGraph!.nodes['Desc_IronIngot_C'].multiplier).toBeCloseTo(30, 4);
+    // Its one somersloop slot needs exactly one somersloop.
     expect(report!.amplification.sloopsUsed).toBe(1);
     expect(Number.isInteger(report!.amplification.sloopsUsed)).toBe(true);
     expect(report!.amplification.sloopsAvailable).toBe(106);
   });
 
-  it('reports somersloop usage as whole machines, rounding each machine up', async () => {
-    // The LP allocates fractional amplified machines, but a real build needs whole machines
-    // with every slot filled — so usage is always an integer (regression for issue: report
-    // showed 4.833 sloops when the real requirement was 6).
-    const options = ampOptions({ amplificationOptions: { availableSloops: '106', availableShards: '0' } });
-    const { report, error } = await new ProductionSolver(options, ampGameData).exec();
+  it('reports whole-machine somersloop usage that never exceeds the budget', async () => {
+    // Five whole amplified constructors make 200 plates from 150 ingots (vs 300 for ten base
+    // machines), consuming exactly five somersloops — integer usage, within budget. Previously
+    // the LP smeared fractional amplified machines and the report rounded each up past the budget.
+    const options = ampOptions({
+      productionItems: [{ key: 'p1', itemKey: 'Desc_IronPlate_C', mode: 'per-minute', value: '200' }],
+      amplificationOptions: { availableSloops: '106', availableShards: '0' },
+    });
+    const { productionGraph, report, error } = await new ProductionSolver(options, ampGameData).exec();
     expect(error).toBeNull();
-    expect(report!.amplification.sloopsUsed).toBeGreaterThan(0);
+    expect(productionGraph!.nodes['Recipe_IronPlate_C::AMP'].multiplier).toBeCloseTo(5, 4);
+    expect(report!.amplification.sloopsUsed).toBe(5);
     expect(Number.isInteger(report!.amplification.sloopsUsed)).toBe(true);
+    expect(report!.amplification.sloopsUsed).toBeLessThanOrEqual(report!.amplification.sloopsAvailable);
   });
 });

--- a/client/src/utilities/production-solver/index.ts
+++ b/client/src/utilities/production-solver/index.ts
@@ -525,6 +525,22 @@ export class ProductionSolver {
     return surplus;
   }
 
+  // Somersloops / power shards consumed by a (cumulative) solution's boost-variant nodes.
+  // Used to subtract prior passes' usage from the budget available to the next pass, since the
+  // slot budget is a physical pool shared across all summed passes. Base variants consume none.
+  private boostUsage(solution: ProductionSolution, kind: 'sloops' | 'shards'): number {
+    let total = 0;
+    for (const [key, multiplier] of Object.entries(solution)) {
+      const { baseRecipeKey, suffix } = parseVariantKey(key);
+      if (!suffix) continue;
+      const recipeInfo = this.gameData.recipes[baseRecipeKey];
+      if (!recipeInfo) continue;
+      const variant = buildVariant(suffix, sloopSlotsFor(recipeInfo.producedIn));
+      total += multiplier * variant[kind];
+    }
+    return total;
+  }
+
   private graphContext() {
     return {
       gameData: this.gameData,
@@ -547,6 +563,7 @@ export class ProductionSolver {
       },
       subjectTo: [],
       binaries: [],
+      generals: [],
     };
 
     const doPoints = (isRateTargetPass && this.rateTargets[POINTS_ITEM_KEY]) || targetKeys.includes(POINTS_ITEM_KEY);
@@ -777,40 +794,52 @@ export class ProductionSolver {
       }
     }
 
-    // Global somersloop / power-shard budgets: the total slots consumed across every boost
-    // variant may not exceed what the user has available. This is a continuous relaxation —
-    // fractional buildings consume fractional slots — so the reported usage should be rounded
-    // up when built in-game. Only added when the corresponding budget is set (and thus boost
-    // variants exist), so the un-boosted model gains no constraints.
-    if (this.availableSloops > 0) {
-      const sloopVars: Var[] = [];
-      for (const [recipeKey, variants] of this.variantsByRecipe) {
-        for (const variant of variants) {
-          if (variant.sloops > 0) sloopVars.push({ name: variantKey(recipeKey, variant.suffix), coef: variant.sloops });
-        }
-      }
-      if (sloopVars.length > 0) {
-        model.subjectTo.push({
-          name: 'somersloop budget',
-          vars: sloopVars,
-          bnds: { type: glpk.GLP_UP, ub: this.availableSloops, lb: NaN },
-        });
+    // Global somersloop / power-shard budgets. Somersloops and power shards are placed in
+    // WHOLE machines, so a boost variant's building count is an integer decision variable
+    // (GLPK generals) — not a continuous relaxation. Without this the LP smears the budget as
+    // fractional sub-machine overclocks across many recipes, each of which the report then
+    // rounds up to a whole machine, busting the budget (e.g. 1 sloop -> 2 used, 100 shards ->
+    // 141 used). Integer building counts make each boost land in a specific, buildable machine
+    // and keep total slot usage <= the budget exactly.
+    //
+    // The budget is a physical pool shared across every solver pass, so the amount already
+    // consumed by prior (summed) passes is subtracted before bounding this pass. Only added
+    // when a budget is set (and thus boost variants exist), so the un-boosted model gains no
+    // integer variables or constraints.
+    const priorSloopsUsed = priorSolution ? this.boostUsage(priorSolution, 'sloops') : 0;
+    const priorShardsUsed = priorSolution ? this.boostUsage(priorSolution, 'shards') : 0;
+    const remainingSloops = Math.max(0, this.availableSloops - priorSloopsUsed);
+    const remainingShards = Math.max(0, this.availableShards - priorShardsUsed);
+    const sloopVars: Var[] = [];
+    const shardVars: Var[] = [];
+    for (const [recipeKey, variants] of this.variantsByRecipe) {
+      for (const variant of variants) {
+        if (variant.sloops === 0 && variant.shards === 0) continue;
+        const vKey = variantKey(recipeKey, variant.suffix);
+        // Whole-machine boost: integer building count, capped by what each budget alone allows.
+        let ub = Infinity;
+        if (variant.sloops > 0) ub = Math.min(ub, Math.floor(remainingSloops / variant.sloops));
+        if (variant.shards > 0) ub = Math.min(ub, Math.floor(remainingShards / variant.shards));
+        model.generals!.push(vKey);
+        model.bounds = model.bounds ?? [];
+        model.bounds.push({ name: vKey, type: glpk.GLP_DB, lb: 0, ub: Math.max(0, ub) });
+        if (variant.sloops > 0) sloopVars.push({ name: vKey, coef: variant.sloops });
+        if (variant.shards > 0) shardVars.push({ name: vKey, coef: variant.shards });
       }
     }
-    if (this.availableShards > 0) {
-      const shardVars: Var[] = [];
-      for (const [recipeKey, variants] of this.variantsByRecipe) {
-        for (const variant of variants) {
-          if (variant.shards > 0) shardVars.push({ name: variantKey(recipeKey, variant.suffix), coef: variant.shards });
-        }
-      }
-      if (shardVars.length > 0) {
-        model.subjectTo.push({
-          name: 'power shard budget',
-          vars: shardVars,
-          bnds: { type: glpk.GLP_UP, ub: this.availableShards, lb: NaN },
-        });
-      }
+    if (this.availableSloops > 0 && sloopVars.length > 0) {
+      model.subjectTo.push({
+        name: 'somersloop budget',
+        vars: sloopVars,
+        bnds: { type: glpk.GLP_UP, ub: remainingSloops, lb: NaN },
+      });
+    }
+    if (this.availableShards > 0 && shardVars.length > 0) {
+      model.subjectTo.push({
+        name: 'power shard budget',
+        vars: shardVars,
+        bnds: { type: glpk.GLP_UP, ub: remainingShards, lb: NaN },
+      });
     }
 
     if (maxima && targetKeys.length > 1) {
@@ -882,12 +911,17 @@ export class ProductionSolver {
     const cullThreshold = Math.max(MIN_RECIPE_MULTIPLIER, this.scale * RECIPE_NOISE_SCALE_FACTOR);
     const result: ProductionSolution = {};
     Object.entries(solution.result.vars).forEach(([key, val]) => {
-      if (val > cullThreshold) {
-        // Keep the variant key intact (assembleGraph/buildReport re-derive the boost from it),
-        // but validate against the underlying base recipe so binary/budget vars are dropped.
-        if (this.gameData.recipes[parseVariantKey(key).baseRecipeKey]) {
-          result[key] = val;
-        }
+      // Validate against the underlying base recipe so binary/budget vars are dropped; keep the
+      // variant key intact (assembleGraph/buildReport re-derive the boost from it).
+      const { baseRecipeKey, suffix } = parseVariantKey(key);
+      if (!this.gameData.recipes[baseRecipeKey]) return;
+      if (suffix) {
+        // Boost variants are integer (whole machines); snap off MIP floating-point noise so the
+        // report's whole-machine slot tally is exact and can't drift over budget.
+        const rounded = Math.round(val);
+        if (rounded >= 1) result[key] = rounded;
+      } else if (val > cullThreshold) {
+        result[key] = val;
       }
     });
     return result;

--- a/client/src/utilities/production-solver/models.ts
+++ b/client/src/utilities/production-solver/models.ts
@@ -46,8 +46,8 @@ export type Report = {
   },
   totalItemsRecap: ProducedItemInformation[],
   loopWarning: boolean,
-  // Somersloop / power-shard consumption and budgets. usage is a continuous relaxation
-  // (fractional buildings use fractional slots) so round up when building in-game.
+  // Somersloop / power-shard consumption and budgets. Boost variants are solved as whole
+  // machines (integer building counts), so usage is exact and never exceeds the budget.
   amplification: {
     sloopsUsed: number,
     sloopsAvailable: number,

--- a/client/tests/main.spec.ts
+++ b/client/tests/main.spec.ts
@@ -368,6 +368,10 @@ test.describe('Factory Planner Application', () => {
     await page.getByRole('button', { name: '+ Add Product' }).click();
     await page.getByPlaceholder('Select an item').click();
     await page.getByRole('option', { name: 'Iron Plate', exact: true }).click();
+    // Somersloops amplify WHOLE machines, so a target must be large enough that a fully
+    // amplified machine reduces resource use — the default 10/min is under a single machine
+    // and correctly warrants no sloops. 100/min spans several machines worth of production.
+    await page.getByPlaceholder('Amount').fill('100');
 
     // Give the solver a somersloop budget (section gated to 1.2, the default version).
     // With the default resource-dominant weighting, amplifying halves the ore a step


### PR DESCRIPTION
## Problem

The somersloop/power-shard amplification budget was modelled as a **continuous LP relaxation**, so the solver:

1. **Exceeded the budget.** For `availableSloops:1, availableShards:100` the report showed `sloopsUsed:2, shardsUsed:141` — an in-game-infeasible plan.
2. **Smeared the boost into dust.** The budget was spread as fractional sub-machine overclocks across ~24 recipes (e.g. `PureIronIngot::OC` at 0.006 machines), so none of it was an actionable "put your somersloop in *this* machine" result.

## Fix — whole-machine integer boosts (MILP)

Somersloops and power shards go into **whole** machines, so a boost variant's building count is now an **integer decision variable** (GLPK `generals`) with a per-variant upper bound of `floor(remainingBudget / slots)`, alongside the existing `≤ budget` constraints. Each boost now lands in a specific, buildable machine and total slot usage stays `≤` budget exactly.

- The budget is a physical pool shared across solver passes, so `boostUsage(priorSolution)` subtracts what prior (summed) passes already consumed before bounding the next pass.
- Culled boost values snap to the nearest integer so MIP floating-point noise can't `ceil` past the budget in the report.
- **All gated on a budget being set** — an un-amplified factory gains zero integer variables or constraints, so its model is byte-identical to before.

## Impact

- User's exact factory: `sloopsUsed 2→1`, `shardsUsed 141→69` — within budget, every boost on a whole machine.
- **Perf:** solve time ~37ms → ~60ms on a real deep factory — negligible for the every-keystroke auto-solve; tight per-variable bounds keep branch-and-bound small.
- **Persistence-neutral:** only computed `report.amplification` changes; the stored `amplificationOptions` shape, wire contract, and share-id are untouched.

## Tests

- Rewrote two tests that had encoded the fractional-machine behavior (`0.5` amplified constructors) to assert whole-machine semantics.
- Added a budget-feasibility regression on real 1.2 game data (deep chain, tight sloop + generous shard budget).
- Full solver suite green (230 tests), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)